### PR TITLE
Settings redesign, home page side bar, leaderboard sorter, game searcher

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,7 +61,7 @@ const App: React.FC = () => {
         leagueFilter={dashboard.markets.leagueFilter}
         searchQuery={dashboard.markets.searchQuery}
         sportTabs={dashboard.markets.sportTabs}
-        availableLeagues={dashboard.markets.availableLeagues}
+        sportFilteredMarkets={dashboard.markets.sportFilteredMarkets}
         markets={dashboard.markets.markets}
         loading={dashboard.markets.loading}
         error={dashboard.markets.error}

--- a/App.tsx
+++ b/App.tsx
@@ -65,6 +65,8 @@ const App: React.FC = () => {
         markets={dashboard.markets.markets}
         loading={dashboard.markets.loading}
         error={dashboard.markets.error}
+        globalSearchLoading={dashboard.markets.globalSearchLoading}
+        globalSearchError={dashboard.markets.globalSearchError}
         leaderboardEntries={dashboard.leaderboardEntries}
         friends={dashboard.friends}
         activity={dashboard.activity}

--- a/App.tsx
+++ b/App.tsx
@@ -75,6 +75,7 @@ const App: React.FC = () => {
         onLogout={dashboard.auth.logout}
         onSetView={dashboard.setView}
         onSportFilter={dashboard.markets.handleSportFilter}
+        onSelectLeagueInSport={dashboard.markets.selectLeagueInSport}
         onLeagueFilter={dashboard.markets.setLeagueFilter}
         onSearchChange={dashboard.markets.setSearchQuery}
         onRetryMarkets={dashboard.markets.loadMarkets}

--- a/App.tsx
+++ b/App.tsx
@@ -65,8 +65,7 @@ const App: React.FC = () => {
         markets={dashboard.markets.markets}
         loading={dashboard.markets.loading}
         error={dashboard.markets.error}
-        globalSearchLoading={dashboard.markets.globalSearchLoading}
-        globalSearchError={dashboard.markets.globalSearchError}
+        searchCacheMarketCount={dashboard.markets.searchCacheMarketCount}
         leaderboardEntries={dashboard.leaderboardEntries}
         friends={dashboard.friends}
         activity={dashboard.activity}

--- a/components/Boostcard.tsx
+++ b/components/Boostcard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Sparkles, ChevronDown, ChevronUp, TrendingUp, RefreshCcw } from 'lucide-react';
+import { Sparkles, Ticket, TrendingUp, RefreshCcw } from 'lucide-react';
 import { getUserBoosts, UserBoosts, BoostType } from '@/services/dbOps.ts';
 
 interface BoostsCardProps {
@@ -170,10 +170,7 @@ export const BoostsCard: React.FC<BoostsCardProps> = ({ uid, activeBoost, onSele
                         <span className="text-[10px] font-semibold text-amber-400/70 normal-case">· 1 active</span>
                     )}
                 </span>
-                {expanded
-                    ? <ChevronUp size={14} className="text-slate-500" />
-                    : <ChevronDown size={14} className="text-slate-500" />
-                }
+                <Ticket size={14} className="text-slate-500 shrink-0" aria-hidden />
             </button>
 
             {expanded && (

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,14 +1,84 @@
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { LeaderboardEntry } from '../models';
-import { Trophy, TrendingUp, Medal } from 'lucide-react';
+import { Trophy, TrendingUp, Medal, ArrowUp, ArrowDown } from 'lucide-react';
 
 interface LeaderboardProps {
   entries: LeaderboardEntry[];
 }
 
+type SortKey = 'rank' | 'user' | 'netWorth' | 'winRate' | 'trend';
+type SortDir = 'asc' | 'desc';
+
+function trendScore(e: LeaderboardEntry): number {
+  return e.netWorth * (e.winRate / 100);
+}
+
 export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
+  const [sortKey, setSortKey] = useState<SortKey>('rank');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'user' ? 'asc' : 'desc');
+    }
+  };
+
+  const sortedEntries = useMemo(() => {
+    if (entries.length === 0) return entries;
+    const dir = sortDir === 'asc' ? 1 : -1;
+    const cmp = (a: LeaderboardEntry, b: LeaderboardEntry): number => {
+      switch (sortKey) {
+        case 'rank':
+          return (a.rank - b.rank) * dir;
+        case 'user':
+          return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) * dir;
+        case 'netWorth':
+          return (a.netWorth - b.netWorth) * dir;
+        case 'winRate':
+          return (a.winRate - b.winRate) * dir;
+        case 'trend':
+          return (trendScore(a) - trendScore(b)) * dir;
+        default:
+          return 0;
+      }
+    };
+    return [...entries].sort(cmp);
+  }, [entries, sortKey, sortDir]);
+
+  const isCanonicalRankOrder = sortKey === 'rank' && sortDir === 'asc';
+
+  const SortHeader: React.FC<{
+    label: string;
+    colKey: SortKey;
+    align?: 'left' | 'right';
+  }> = ({ label, colKey, align = 'left' }) => {
+    const active = sortKey === colKey;
+    return (
+      <th className={`px-6 py-4 ${align === 'right' ? 'text-right' : 'text-left'}`}>
+        <button
+          type="button"
+          onClick={() => toggleSort(colKey)}
+          className={`inline-flex items-center gap-1.5 font-bold uppercase tracking-widest transition-colors hover:text-slate-300 ${
+            active ? 'text-blue-400' : 'text-slate-500'
+          }`}
+        >
+          {label}
+          {active &&
+            (sortDir === 'asc' ? (
+              <ArrowUp className="shrink-0" size={12} aria-hidden />
+            ) : (
+              <ArrowDown className="shrink-0" size={12} aria-hidden />
+            ))}
+        </button>
+      </th>
+    );
+  };
+
   return (
     <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div className="flex items-center justify-between mb-8">
@@ -26,12 +96,12 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
       <div className="glass-card rounded-2xl overflow-hidden border-slate-800">
         <table className="w-full text-left">
           <thead>
-            <tr className="bg-slate-900/50 text-[10px] font-bold text-slate-500 uppercase tracking-widest border-b border-slate-800">
-              <th className="px-6 py-4">Rank</th>
-              <th className="px-6 py-4">User</th>
-              <th className="px-6 py-4">Net Worth</th>
-              <th className="px-6 py-4">Win Rate</th>
-              <th className="px-6 py-4 text-right">Trend</th>
+            <tr className="bg-slate-900/50 text-[10px] border-b border-slate-800">
+              <SortHeader label="Rank" colKey="rank" />
+              <SortHeader label="User" colKey="user" />
+              <SortHeader label="Net Worth" colKey="netWorth" />
+              <SortHeader label="Win Rate" colKey="winRate" />
+              <SortHeader label="Trend" colKey="trend" align="right" />
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/50">
@@ -48,18 +118,20 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
                 </td>
               </tr>
             ) : (
-            entries.map((entry) => (
+            sortedEntries.map((entry, idx) => {
+              const displayRank = isCanonicalRankOrder ? entry.rank : idx + 1;
+              return (
               <tr 
                 key={entry.id} 
                 className={`hover:bg-blue-500/5 transition-colors ${entry.isCurrentUser ? 'bg-blue-600/10' : ''}`}
               >
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-2">
-                    {entry.rank === 1 && <Medal className="text-yellow-400" size={16} />}
-                    {entry.rank === 2 && <Medal className="text-slate-300" size={16} />}
-                    {entry.rank === 3 && <Medal className="text-amber-600" size={16} />}
-                    <span className={`font-bold ${entry.rank <= 3 ? 'text-lg' : 'text-slate-400'}`}>
-                      #{entry.rank}
+                    {displayRank === 1 && <Medal className="text-yellow-400" size={16} />}
+                    {displayRank === 2 && <Medal className="text-slate-300" size={16} />}
+                    {displayRank === 3 && <Medal className="text-amber-600" size={16} />}
+                    <span className={`font-bold ${displayRank <= 3 ? 'text-lg' : 'text-slate-400'}`}>
+                      #{displayRank}
                     </span>
                   </div>
                 </td>
@@ -94,7 +166,8 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
                   <TrendingUp className="inline text-green-400" size={16} />
                 </td>
               </tr>
-            ))
+            );
+            })
             )}
           </tbody>
         </table>

--- a/models/constants.ts
+++ b/models/constants.ts
@@ -8,6 +8,9 @@ export const BONUS_STORAGE_KEY = 'bethub_last_bonus_claim';
 
 export const SPORT_TABS = ['ALL', 'Football', 'Basketball', 'Baseball', 'Hockey', 'Soccer'] as const;
 
+/** Show “View All Games” only when the board already lists this many rows (avoids clutter for normal boards). */
+export const VIEW_ALL_GAMES_VISIBLE_THRESHOLD = 60;
+
 export const FIREBASE_CONFIG = {
   apiKey: "AIzaSyCcgJVGV0L95RkcRZ-jqzFAepr3N73wewQ",
   authDomain: "seniorproject-ce9fe.firebaseapp.com",

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -3,6 +3,27 @@ import type { Market } from '../models';
 import { fetchMarketsForSportTab } from '../services/oddsApiService';
 import { SPORT_TABS } from '../models/constants';
 
+const GLOBAL_SEARCH_DEBOUNCE_MS = 400;
+
+/** Text used for substring search (teams often appear only on spread/h2h option labels). */
+function marketSearchHaystack(m: Market): string {
+  const parts = [
+    m.title,
+    m.subtitle,
+    m.category,
+    m.sport_key ?? '',
+    ...m.options.map((o) => o.label),
+  ];
+  return parts.join(' ').toLowerCase().replace(/@/g, ' ');
+}
+
+function queryMatchesHaystack(haystack: string, rawQuery: string): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+  const tokens = q.split(/\s+/).filter(Boolean);
+  return tokens.every((t) => haystack.includes(t));
+}
+
 function defaultSportTab(): string {
   const tab = SPORT_TABS.find((t) => t !== 'ALL');
   return tab ?? 'Football';
@@ -22,7 +43,12 @@ export function useMarketsViewModel() {
   const [sportFilter, setSportFilter] = useState<string>(initialSport);
   const [leagueFilter, setLeagueFilter] = useState<string>('ALL');
   const [searchQuery, setSearchQuery] = useState('');
+  const [globalSearchMarkets, setGlobalSearchMarkets] = useState<Market[]>([]);
+  const [globalSearchLoading, setGlobalSearchLoading] = useState(false);
+  const [globalSearchError, setGlobalSearchError] = useState<string | null>(null);
   const fetchGeneration = useRef(0);
+  const globalSearchFetchGen = useRef(0);
+  const globalSearchPoolReadyRef = useRef(false);
   const didInitialFetch = useRef(false);
 
   const loadMarkets = useCallback(async (sportTab?: string) => {
@@ -71,20 +97,74 @@ export function useMarketsViewModel() {
     void loadMarkets(initialSport);
   }, [initialSport, loadMarkets]);
 
+  /** When searching from a single-sport tab, load the upcoming “all sports” feed once; reuse until search cleared or user picks ALL. */
+  useEffect(() => {
+    const q = searchQuery.trim();
+    if (!q || sportFilter === 'ALL') {
+      globalSearchFetchGen.current += 1;
+      globalSearchPoolReadyRef.current = false;
+      setGlobalSearchLoading(false);
+      setGlobalSearchError(null);
+      setGlobalSearchMarkets([]);
+      return;
+    }
+
+    if (globalSearchPoolReadyRef.current) {
+      setGlobalSearchLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const gen = ++globalSearchFetchGen.current;
+    setGlobalSearchLoading(true);
+    setGlobalSearchError(null);
+
+    const t = window.setTimeout(async () => {
+      if (cancelled) return;
+      try {
+        const data = await fetchMarketsForSportTab('ALL', 'us');
+        if (cancelled || gen !== globalSearchFetchGen.current) return;
+        setGlobalSearchMarkets(data);
+        setGlobalSearchError(null);
+        globalSearchPoolReadyRef.current = true;
+      } catch (e) {
+        if (cancelled || gen !== globalSearchFetchGen.current) return;
+        setGlobalSearchError(e instanceof Error ? e.message : 'Failed to load odds');
+        globalSearchPoolReadyRef.current = false;
+      } finally {
+        if (!cancelled && gen === globalSearchFetchGen.current) {
+          setGlobalSearchLoading(false);
+        }
+      }
+    }, GLOBAL_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(t);
+    };
+  }, [searchQuery, sportFilter]);
+
+  const searchTrimmed = searchQuery.trim();
+  /** Single-sport tab + active search uses the global upcoming pool; ALL tab or no search uses the tab’s `markets`. */
+  const searchPool =
+    searchTrimmed && sportFilter !== 'ALL' ? globalSearchMarkets : markets;
+
   // Filter by sport tab + search, then by league (league options depend on sport)
-  const sportFilteredMarkets = markets.filter((m) => {
+  const sportFilteredMarkets = searchPool.filter((m) => {
     if (!sportFilter) return false;
-    const matchesSport = sportFilter === 'ALL' || m.category === sportFilter;
-    const matchesSearch =
-      m.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      m.category.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      m.subtitle.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesSport && matchesSearch;
+    const inSportScope =
+      searchTrimmed && sportFilter !== 'ALL'
+        ? true
+        : sportFilter === 'ALL' || m.category === sportFilter;
+    const matchesSearch = queryMatchesHaystack(marketSearchHaystack(m), searchQuery);
+    return inSportScope && matchesSearch;
   });
 
   const availableLeagues = Array.from(new Set(sportFilteredMarkets.map((m) => m.subtitle))).sort();
+  // While searching, do not hide games behind a league chip (e.g. NCAAF-only vs NFL team names).
+  const effectiveLeagueFilter = searchTrimmed ? 'ALL' : leagueFilter;
   const leagueFiltered = sportFilteredMarkets.filter(
-    (m) => leagueFilter === 'ALL' || m.subtitle === leagueFilter
+    (m) => effectiveLeagueFilter === 'ALL' || m.subtitle === effectiveLeagueFilter
   );
 
   /** Drop events too far out to limit noise and match “soonest first” browsing. */
@@ -109,6 +189,8 @@ export function useMarketsViewModel() {
     hasSelectedSport: Boolean(sportFilter),
     loading,
     error,
+    globalSearchLoading: Boolean(searchTrimmed && sportFilter !== 'ALL' && globalSearchLoading),
+    globalSearchError: searchTrimmed && sportFilter !== 'ALL' ? globalSearchError : null,
     sportFilter,
     leagueFilter,
     searchQuery,

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -1,20 +1,29 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Market } from '../models';
 import { fetchMarketsForSportTab } from '../services/oddsApiService';
 import { SPORT_TABS } from '../models/constants';
 
+function defaultSportTab(): string {
+  const tab = SPORT_TABS.find((t) => t !== 'ALL');
+  return tab ?? 'Football';
+}
+
 /**
  * Odds/markets from The Odds API. Filters: sport tab, league, search.
- * API runs only after the user selects a sport tab (no fetch on mount).
+ * Defaults to the first sport tab and loads odds on mount; league filter defaults to ALL.
+ * Sport filter `ALL` = all sports (single upcoming odds request). With league ALL, boards list
+ * games soonest-first and hide kickoffs beyond 30 days (LIVE always kept).
  */
 export function useMarketsViewModel() {
+  const initialSport = defaultSportTab();
   const [markets, setMarkets] = useState<Market[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sportFilter, setSportFilter] = useState<string>('');
+  const [sportFilter, setSportFilter] = useState<string>(initialSport);
   const [leagueFilter, setLeagueFilter] = useState<string>('ALL');
   const [searchQuery, setSearchQuery] = useState('');
   const fetchGeneration = useRef(0);
+  const didInitialFetch = useRef(false);
 
   const loadMarkets = useCallback(async (sportTab?: string) => {
     const tab = sportTab ?? sportFilter;
@@ -46,6 +55,22 @@ export function useMarketsViewModel() {
     [loadMarkets]
   );
 
+  /** Sidebar / popular: jump to one sport + league without the sport handler resetting league to ALL. */
+  const selectLeagueInSport = useCallback(
+    (sport: string, league: string) => {
+      setSportFilter(sport);
+      setLeagueFilter(league);
+      void loadMarkets(sport);
+    },
+    [loadMarkets]
+  );
+
+  useEffect(() => {
+    if (didInitialFetch.current) return;
+    didInitialFetch.current = true;
+    void loadMarkets(initialSport);
+  }, [initialSport, loadMarkets]);
+
   // Filter by sport tab + search, then by league (league options depend on sport)
   const sportFilteredMarkets = markets.filter((m) => {
     if (!sportFilter) return false;
@@ -58,12 +83,28 @@ export function useMarketsViewModel() {
   });
 
   const availableLeagues = Array.from(new Set(sportFilteredMarkets.map((m) => m.subtitle))).sort();
-  const filteredMarkets = sportFilteredMarkets.filter(
+  const leagueFiltered = sportFilteredMarkets.filter(
     (m) => leagueFilter === 'ALL' || m.subtitle === leagueFilter
   );
 
+  /** Drop events too far out to limit noise and match “soonest first” browsing. */
+  const MAX_COMMENCE_MS = 30 * 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+  const withinHorizon = leagueFiltered.filter((m) => {
+    if (m.status === 'LIVE') return true;
+    const t = new Date(m.startTime).getTime();
+    if (Number.isNaN(t)) return true;
+    return t <= nowMs + MAX_COMMENCE_MS;
+  });
+
+  const displayMarkets = [...withinHorizon].sort((a, b) => {
+    if (a.status === 'LIVE' && b.status !== 'LIVE') return -1;
+    if (b.status === 'LIVE' && a.status !== 'LIVE') return 1;
+    return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+  });
+
   return {
-    markets: filteredMarkets,
+    markets: displayMarkets,
     sportFilteredMarkets,
     hasSelectedSport: Boolean(sportFilter),
     loading,
@@ -76,6 +117,7 @@ export function useMarketsViewModel() {
     setSearchQuery,
     setLeagueFilter,
     handleSportFilter,
+    selectLeagueInSport,
     loadMarkets,
   };
 }

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -1,9 +1,10 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useReducer, useMemo } from 'react';
 import type { Market } from '../models';
 import { fetchMarketsForSportTab } from '../services/oddsApiService';
 import { SPORT_TABS } from '../models/constants';
 
-const GLOBAL_SEARCH_DEBOUNCE_MS = 400;
+/** Cap deduped events kept for instant search (memory + stale data tradeoff). */
+const MAX_MARKET_SEARCH_CACHE = 1200;
 
 /** Text used for substring search (teams often appear only on spread/h2h option labels). */
 function marketSearchHaystack(m: Market): string {
@@ -24,6 +25,17 @@ function queryMatchesHaystack(haystack: string, rawQuery: string): boolean {
   return tokens.every((t) => haystack.includes(t));
 }
 
+function mergeIntoSearchCache(cache: Map<string, Market>, incoming: Market[]) {
+  for (const m of incoming) {
+    cache.set(m.id, m);
+  }
+  while (cache.size > MAX_MARKET_SEARCH_CACHE) {
+    const first = cache.keys().next().value;
+    if (first === undefined) break;
+    cache.delete(first);
+  }
+}
+
 function defaultSportTab(): string {
   const tab = SPORT_TABS.find((t) => t !== 'ALL');
   return tab ?? 'Football';
@@ -31,9 +43,7 @@ function defaultSportTab(): string {
 
 /**
  * Odds/markets from The Odds API. Filters: sport tab, league, search.
- * Defaults to the first sport tab and loads odds on mount; league filter defaults to ALL.
- * Sport filter `ALL` = all sports (single upcoming odds request). With league ALL, boards list
- * games soonest-first and hide kickoffs beyond 30 days (LIVE always kept).
+ * Search is in-memory only: each successful tab load merges into a deduped cache (zero extra API calls).
  */
 export function useMarketsViewModel() {
   const initialSport = defaultSportTab();
@@ -43,13 +53,10 @@ export function useMarketsViewModel() {
   const [sportFilter, setSportFilter] = useState<string>(initialSport);
   const [leagueFilter, setLeagueFilter] = useState<string>('ALL');
   const [searchQuery, setSearchQuery] = useState('');
-  const [globalSearchMarkets, setGlobalSearchMarkets] = useState<Market[]>([]);
-  const [globalSearchLoading, setGlobalSearchLoading] = useState(false);
-  const [globalSearchError, setGlobalSearchError] = useState<string | null>(null);
   const fetchGeneration = useRef(0);
-  const globalSearchFetchGen = useRef(0);
-  const globalSearchPoolReadyRef = useRef(false);
   const didInitialFetch = useRef(false);
+  const marketSearchCacheRef = useRef(new Map<string, Market>());
+  const [searchCacheTick, bumpSearchCache] = useReducer((n: number) => n + 1, 0);
 
   const loadMarkets = useCallback(async (sportTab?: string) => {
     const tab = sportTab ?? sportFilter;
@@ -62,6 +69,8 @@ export function useMarketsViewModel() {
       const data = await fetchMarketsForSportTab(tab, 'us');
       if (gen !== fetchGeneration.current) return;
       setMarkets(data);
+      mergeIntoSearchCache(marketSearchCacheRef.current, data);
+      bumpSearchCache();
     } catch (e) {
       if (gen !== fetchGeneration.current) return;
       setError(e instanceof Error ? e.message : 'Failed to load odds');
@@ -97,65 +106,18 @@ export function useMarketsViewModel() {
     void loadMarkets(initialSport);
   }, [initialSport, loadMarkets]);
 
-  /** When searching from a single-sport tab, load the upcoming “all sports” feed once; reuse until search cleared or user picks ALL. */
-  useEffect(() => {
-    const q = searchQuery.trim();
-    if (!q || sportFilter === 'ALL') {
-      globalSearchFetchGen.current += 1;
-      globalSearchPoolReadyRef.current = false;
-      setGlobalSearchLoading(false);
-      setGlobalSearchError(null);
-      setGlobalSearchMarkets([]);
-      return;
-    }
-
-    if (globalSearchPoolReadyRef.current) {
-      setGlobalSearchLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    const gen = ++globalSearchFetchGen.current;
-    setGlobalSearchLoading(true);
-    setGlobalSearchError(null);
-
-    const t = window.setTimeout(async () => {
-      if (cancelled) return;
-      try {
-        const data = await fetchMarketsForSportTab('ALL', 'us');
-        if (cancelled || gen !== globalSearchFetchGen.current) return;
-        setGlobalSearchMarkets(data);
-        setGlobalSearchError(null);
-        globalSearchPoolReadyRef.current = true;
-      } catch (e) {
-        if (cancelled || gen !== globalSearchFetchGen.current) return;
-        setGlobalSearchError(e instanceof Error ? e.message : 'Failed to load odds');
-        globalSearchPoolReadyRef.current = false;
-      } finally {
-        if (!cancelled && gen === globalSearchFetchGen.current) {
-          setGlobalSearchLoading(false);
-        }
-      }
-    }, GLOBAL_SEARCH_DEBOUNCE_MS);
-
-    return () => {
-      cancelled = true;
-      window.clearTimeout(t);
-    };
-  }, [searchQuery, sportFilter]);
-
   const searchTrimmed = searchQuery.trim();
-  /** Single-sport tab + active search uses the global upcoming pool; ALL tab or no search uses the tab’s `markets`. */
-  const searchPool =
-    searchTrimmed && sportFilter !== 'ALL' ? globalSearchMarkets : markets;
+  const searchPool = useMemo(() => {
+    if (!searchTrimmed) return markets;
+    return Array.from(marketSearchCacheRef.current.values());
+  }, [searchTrimmed, markets, searchCacheTick]);
 
   // Filter by sport tab + search, then by league (league options depend on sport)
   const sportFilteredMarkets = searchPool.filter((m) => {
     if (!sportFilter) return false;
-    const inSportScope =
-      searchTrimmed && sportFilter !== 'ALL'
-        ? true
-        : sportFilter === 'ALL' || m.category === sportFilter;
+    const inSportScope = searchTrimmed
+      ? true
+      : sportFilter === 'ALL' || m.category === sportFilter;
     const matchesSearch = queryMatchesHaystack(marketSearchHaystack(m), searchQuery);
     return inSportScope && matchesSearch;
   });
@@ -189,8 +151,7 @@ export function useMarketsViewModel() {
     hasSelectedSport: Boolean(sportFilter),
     loading,
     error,
-    globalSearchLoading: Boolean(searchTrimmed && sportFilter !== 'ALL' && globalSearchLoading),
-    globalSearchError: searchTrimmed && sportFilter !== 'ALL' ? globalSearchError : null,
+    searchCacheMarketCount: marketSearchCacheRef.current.size,
     sportFilter,
     leagueFilter,
     searchQuery,

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -37,8 +37,7 @@ function mergeIntoSearchCache(cache: Map<string, Market>, incoming: Market[]) {
 }
 
 function defaultSportTab(): string {
-  const tab = SPORT_TABS.find((t) => t !== 'ALL');
-  return tab ?? 'Football';
+  return 'ALL';
 }
 
 /**

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -102,9 +102,8 @@ interface DashboardViewProps {
   markets: Market[];
   loading: boolean;
   error: string | null;
-  /** True while loading the cross-sport “upcoming” feed for search (single-sport tab only). */
-  globalSearchLoading: boolean;
-  globalSearchError: string | null;
+  /** Unique games merged into the in-memory search index (from tab loads only). */
+  searchCacheMarketCount: number;
   leaderboardEntries: LeaderboardEntry[];
   friends: Friend[];
   activity: SocialActivity[];
@@ -147,8 +146,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     markets,
     loading,
     error,
-    globalSearchLoading,
-    globalSearchError,
+    searchCacheMarketCount,
     leaderboardEntries,
     friends,
     activity,
@@ -566,7 +564,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                       <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={16} />
                       <input
                           type="text"
-                          placeholder={hasSelectedSport ? 'Search games (all sports)…' : 'Select a sport tab to load markets'}
+                          placeholder={hasSelectedSport ? 'Search loaded games…' : 'Select a sport tab to load markets'}
                           value={searchQuery}
                           onChange={(e) => onSearchChange(e.target.value)}
                           disabled={!hasSelectedSport}
@@ -648,21 +646,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                           <div className="text-center">Total</div>
                           <div className="text-center">Winner</div>
                         </div>
-                        {globalSearchError ? (
-                            <div className="col-span-full py-16 text-center px-4">
-                              <AlertCircle className="mx-auto text-amber-400 mb-3" size={40} />
-                              <h3 className="text-lg font-bold text-slate-200 mb-1">Couldn&apos;t load cross-sport search</h3>
-                              <p className="text-slate-500 text-sm mb-4">{globalSearchError}</p>
-                              <p className="text-slate-600 text-xs max-w-md mx-auto">
-                                Select <span className="font-semibold text-slate-400">All sports</span> in the sidebar, or try again in a moment.
-                              </p>
-                            </div>
-                        ) : globalSearchLoading && markets.length === 0 ? (
-                            <div className="col-span-full py-20 flex flex-col items-center gap-3">
-                              <Loader2 className="text-blue-400 animate-spin" size={40} />
-                              <p className="text-slate-400 text-sm">Searching all sports…</p>
-                            </div>
-                        ) : markets.length > 0 ? (
+                        {markets.length > 0 ? (
                             markets.map((market) => {
                               const teams = splitTeams(market.title);
                               const spreadAway = market.options.find((o) => o.marketKey === 'spreads' && o.label.toLowerCase().includes(teams.away.toLowerCase()));
@@ -742,7 +726,9 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               <h3 className="text-xl font-bold text-slate-500">No matches found</h3>
                               <p className="text-slate-600">
                                 {searchQuery.trim()
-                                  ? 'Try a different search term.'
+                                  ? searchCacheMarketCount === 0
+                                    ? 'Open a few sport tabs first so games load into search—search uses no extra API calls.'
+                                    : 'No match in loaded games. Try another word or open another sport tab to add more lines.'
                                   : leagueFilter !== 'ALL'
                                     ? `No ${leagueFilter} games at the moment. Try another league or sport.`
                                     : sportFilter === 'ALL'

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -19,8 +19,10 @@ import {
   Flame,
   Clock3,
   ChevronRight,
-  Compass,
   Sparkles,
+  Layers,
+  ChevronDown,
+  ChevronUp,
   CircleDot,
   User,
 } from 'lucide-react';
@@ -94,7 +96,8 @@ interface DashboardViewProps {
   leagueFilter: string;
   searchQuery: string;
   sportTabs: readonly string[];
-  availableLeagues: string[];
+  /** Markets for current sport + search only (ignores league chip filter), for sidebar league grouping. */
+  sportFilteredMarkets: Market[];
   markets: Market[];
   loading: boolean;
   error: string | null;
@@ -135,7 +138,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     leagueFilter,
     searchQuery,
     sportTabs,
-    availableLeagues,
+    sportFilteredMarkets,
     markets,
     loading,
     error,
@@ -162,7 +165,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const navigate = useNavigate();
   const view = pathToView(location.pathname);
   const isLightMode = themeMode === 'light';
-  const [marketLayoutMode, setMarketLayoutMode] = useState<'DISCOVER' | 'ALL_LEAGUES'>('DISCOVER');
+  const [promotionsOpen, setPromotionsOpen] = useState(false);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -196,9 +199,33 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     const date = new Date(market.startTime);
     const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     if (market.status === 'LIVE') {
-      return { label: `Live • Started ${time}`, tone: 'live' as const };
+      return { label: `Started ${time}`, tone: 'live' as const };
     }
     return { label: time, tone: 'upcoming' as const };
+  };
+
+  /** Small league tiles in the sidebar; falls back to initials when unknown. */
+  const resolveLeagueIcon = (league: string): { src: string; invert?: boolean } | null => {
+    const l = league.toLowerCase();
+    if (l.includes('mlb')) return { src: 'https://cdn.jsdelivr.net/npm/simple-icons@11.14.0/icons/mlb.svg', invert: true };
+    if (l.includes('nfl')) return { src: 'https://upload.wikimedia.org/wikipedia/en/a/a2/National_Football_League_logo.svg' };
+    if (l.includes('nba')) return { src: 'https://upload.wikimedia.org/wikipedia/en/0/03/National_Basketball_Association_logo.svg' };
+    if (l.includes('nhl')) return { src: 'https://cdn.jsdelivr.net/npm/simple-icons@11.14.0/icons/nhl.svg', invert: true };
+    if (l.includes('ncaa')) return { src: 'https://upload.wikimedia.org/wikipedia/commons/d/dd/NCAA_logo.svg' };
+    if (l.includes('brazil') || l.includes('brasileir') || l.includes('série b'))
+      return { src: 'https://upload.wikimedia.org/wikipedia/en/0/05/Flag_of_Brazil.svg' };
+    if (l.includes('argentina') || l.includes('primera'))
+      return { src: 'https://upload.wikimedia.org/wikipedia/commons/8/8d/Association_football_ball_01.svg' };
+    if (l.includes('premier league') || l.includes('epl'))
+      return { src: 'https://upload.wikimedia.org/wikipedia/en/f/f2/Premier_League_Logo.svg' };
+    if (l.includes('la liga') || l.includes('laliga'))
+      return { src: 'https://upload.wikimedia.org/wikipedia/commons/0/0f/LaLiga_logo_2023.svg' };
+    if (l.includes('bundesliga')) return { src: 'https://upload.wikimedia.org/wikipedia/en/d/df/Bundesliga_logo_%282017%29.svg' };
+    if (l.includes('serie a') && l.includes('ital')) return { src: 'https://upload.wikimedia.org/wikipedia/en/e/e1/Serie_A_logo_2022.svg' };
+    if (l.includes('mls')) return { src: 'https://upload.wikimedia.org/wikipedia/commons/7/76/MLS_crest_logo_RGB_gradient.svg' };
+    if (l.includes('uefa') || l.includes('champions') || l.includes('europa') || l.includes('world cup'))
+      return { src: 'https://upload.wikimedia.org/wikipedia/commons/8/8d/Association_football_ball_01.svg' };
+    return null;
   };
 
   const leagueBadge = (label: string) => {
@@ -261,11 +288,15 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     );
   };
 
-  const leaguesBySport: Record<string, string[]> = markets.reduce((acc, market) => {
-    if (!acc[market.category]) acc[market.category] = [];
-    if (!acc[market.category].includes(market.subtitle)) acc[market.category].push(market.subtitle);
-    return acc;
-  }, {} as Record<string, string[]>);
+  /** One row per league (with sport for subtitle + filtering). */
+  const leagueNavRows: Array<{ league: string; sport: string }> = (() => {
+    const seen = new Map<string, { league: string; sport: string }>();
+    for (const m of sportFilteredMarkets) {
+      const key = `${m.category}||${m.subtitle}`;
+      if (!seen.has(key)) seen.set(key, { league: m.subtitle, sport: m.category });
+    }
+    return Array.from(seen.values()).sort((a, b) => a.league.localeCompare(b.league));
+  })();
 
   const safeBalance = Number.isFinite(balance) ? balance : 0;
   const displayBalance = `$${Math.max(0, safeBalance).toFixed(2)}`;
@@ -387,152 +418,117 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
             <>
               <div className="grid grid-cols-1 xl:grid-cols-[220px_minmax(0,1fr)] gap-5">
                 <aside className="glass-card rounded-xl p-3 border border-slate-800/80 h-fit xl:sticky xl:top-6">
-                  <div className="grid grid-cols-2 gap-1 mb-3 rounded-lg border border-slate-800 bg-slate-900 p-1">
-                    <button
-                        onClick={() => setMarketLayoutMode('DISCOVER')}
-                        className={`market-top-pill inline-flex items-center justify-center gap-1 rounded-md px-2 py-1.5 text-[10px] font-bold transition-colors ${
-                            marketLayoutMode === 'DISCOVER' ? 'bg-slate-700 text-blue-300' : 'text-slate-500 hover:text-slate-300'
-                        }`}
-                    >
-                      <Compass size={11} />
-                      Discover
-                    </button>
-                    <button
-                        onClick={() => {
-                          setMarketLayoutMode('ALL_LEAGUES');
-                          onSportFilter('ALL');
-                          onLeagueFilter('ALL');
-                        }}
-                        className={`market-top-pill rounded-md px-2 py-1.5 text-[10px] font-bold transition-colors ${
-                            marketLayoutMode === 'ALL_LEAGUES' ? 'bg-slate-700 text-blue-300' : 'text-slate-500 hover:text-slate-300'
-                        }`}
-                    >
-                      All Leagues
-                    </button>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-3 inline-flex items-center gap-1.5">
+                    <Layers size={11} className="text-slate-500" aria-hidden />
+                    Leagues
+                  </p>
+
+                  <div className="grid grid-cols-4 gap-1.5 mb-3">
+                    {sportTabs.filter((tab) => tab !== 'ALL').slice(0, 8).map((tab) => (
+                        <button
+                            key={`tile-${tab}`}
+                            onClick={() => onSportFilter(tab)}
+                            title={tab}
+                            className={`market-top-pill rounded-lg border p-2 flex items-center justify-center text-[10px] font-black transition-all ${
+                                sportFilter === tab
+                                    ? 'border-blue-500 bg-blue-600/20 text-blue-200'
+                                    : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
+                            }`}
+                        >
+                          {renderSportIcon(tab)}
+                        </button>
+                    ))}
                   </div>
 
-                  {marketLayoutMode === 'DISCOVER' ? (
-                      <>
-                        <div className="grid grid-cols-4 gap-1.5 mb-4">
-                          {sportTabs.filter((tab) => tab !== 'ALL').slice(0, 8).map((tab) => (
+                  {leagueNavRows.length > 0 && (
+                      <div className="mb-4 space-y-0 divide-y divide-slate-800/90 rounded-lg border border-slate-800 overflow-hidden">
+                        {leagueNavRows.map(({ league, sport }) => {
+                          const icon = resolveLeagueIcon(league);
+                          const selected = leagueFilter === league && sportFilter === sport;
+                          return (
                               <button
-                                  key={`tile-${tab}`}
-                                  onClick={() => onSportFilter(tab)}
-                                  title={tab}
-                                  className={`market-top-pill rounded-lg border p-2 flex items-center justify-center text-[10px] font-black transition-all ${
-                                      sportFilter === tab
-                                          ? 'border-blue-500 bg-blue-600/20 text-blue-200'
-                                          : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
+                                  type="button"
+                                  key={`league-row-${sport}-${league}`}
+                                  onClick={() => {
+                                    if (sportFilter !== sport) onSportFilter(sport);
+                                    onLeagueFilter(league);
+                                  }}
+                                  className={`flex w-full items-center gap-2.5 px-2 py-2.5 text-left transition-colors ${
+                                      selected ? 'bg-slate-800/70' : 'bg-slate-900/40 hover:bg-slate-800/40'
                                   }`}
                               >
-                                {renderSportIcon(tab)}
+                                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-slate-700 bg-slate-950/80">
+                                  {icon ? (
+                                      <img
+                                          src={icon.src}
+                                          alt=""
+                                          className={`h-5 w-5 object-contain ${icon.invert ? 'brightness-0 invert opacity-90' : ''}`}
+                                          loading="lazy"
+                                          referrerPolicy="no-referrer"
+                                      />
+                                  ) : (
+                                      <span className="text-[9px] font-black uppercase tracking-tight text-slate-300">
+                                        {leagueBadge(league)}
+                                      </span>
+                                  )}
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate text-sm font-semibold text-slate-100">{league}</span>
+                                  <span className="block truncate text-[11px] text-slate-500">{sport}</span>
+                                </span>
                               </button>
-                          ))}
-                        </div>
-
-                        <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-2">Popular</p>
-                        <div className="space-y-1.5 mb-4">
-                          <button className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-slate-800 bg-slate-900/70 text-amber-300/90 hover:text-amber-200 transition-all inline-flex items-center gap-2">
-                            <Sparkles size={12} />
-                            Boosts
-                          </button>
-                          {/* Weekly Boosts card — sits under the Boosts button */}
-                          {uid && (
-                              <BoostsCard
-                                  uid={uid}
-                                  activeBoost={activeBoost}
-                                  onSelectBoost={setActiveBoost}
-                              />
-                          )}
-
-                          {/* ── Promotions button — expands BetOfTheDayCard below ── */}
-                          <div className="space-y-1">
-                            <button className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-slate-800 bg-slate-900/70 text-cyan-300/90 hover:text-cyan-200 transition-all inline-flex items-center gap-2">
-                              <Flame size={12} />
-                              Promotions
-                            </button>
-                            {/* Free Bet of the Day card lives here, under Promotions */}
-                            {uid && <BetOfTheDayCard uid={uid} />}
-                          </div>
-
-                          {markets.slice(0, 5).map((market) => (
-                              <button
-                                  key={`popular-${market.id}`}
-                                  onClick={() => onLeagueFilter(market.subtitle)}
-                                  className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-700 hover:bg-slate-900 transition-all truncate inline-flex items-center gap-2"
-                              >
-                                <CircleDot size={11} className="shrink-0" />
-                                <span className="truncate">{market.title.replace(' @ ', ' vs ')}</span>
-                              </button>
-                          ))}
-                        </div>
-                      </>
-                  ) : (
-                      <div className="space-y-4 mb-4">
-                        {Object.entries(leaguesBySport)
-                            .sort(([a], [b]) => a.localeCompare(b))
-                            .slice(0, 6)
-                            .map(([sport, leagues]) => (
-                                <div key={`sport-group-${sport}`} className="border-b border-slate-800 pb-3 last:border-b-0">
-                                  <div className="flex items-center justify-between mb-2">
-                                    <button
-                                        onClick={() => onSportFilter(sport)}
-                                        className="inline-flex items-center gap-2 text-sm font-semibold text-slate-200 hover:text-blue-300 transition-colors"
-                                    >
-                              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-700">
-                                {renderSportIcon(sport, 'h-3.5 w-3.5')}
-                              </span>
-                                      {sport}
-                                    </button>
-                                    <button
-                                        onClick={() => onSportFilter(sport)}
-                                        className="text-[11px] text-violet-300 hover:text-violet-200 font-bold"
-                                    >
-                                      View all {leagues.length}
-                                    </button>
-                                  </div>
-                                  <div className="space-y-1">
-                                    {leagues.slice(0, 3).map((league) => (
-                                        <button
-                                            key={`group-league-${sport}-${league}`}
-                                            onClick={() => {
-                                              onSportFilter(sport);
-                                              onLeagueFilter(league);
-                                            }}
-                                            className="block w-full text-left text-xs text-slate-400 hover:text-slate-200 transition-colors"
-                                        >
-                                          {league}
-                                        </button>
-                                    ))}
-                                  </div>
-                                </div>
-                            ))}
+                          );
+                        })}
                       </div>
                   )}
 
-                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-2">Leagues</p>
-                  <div className="space-y-1.5 max-h-[34vh] overflow-y-auto custom-scrollbar pr-1">
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-2">Popular</p>
+                  <div className="space-y-1.5 mb-4">
                     <button
-                        onClick={() => onLeagueFilter('ALL')}
-                        className={`w-full text-left px-2.5 py-2 rounded-md text-xs font-bold transition-all ${
-                            leagueFilter === 'ALL'
-                                ? 'bg-slate-700 text-blue-300 border border-slate-600'
-                                : 'bg-slate-900 text-slate-400 hover:text-slate-200 border border-slate-800'
-                        }`}
+                        type="button"
+                        className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-slate-800 bg-slate-900/70 text-amber-300/90 hover:text-amber-200 transition-all inline-flex items-center gap-2"
                     >
-                      All Leagues
+                      <Sparkles size={12} />
+                      Boosts
                     </button>
-                    {availableLeagues.map((league) => (
+                    {uid && (
+                        <BoostsCard uid={uid} activeBoost={activeBoost} onSelectBoost={setActiveBoost} />
+                    )}
+
+                    <div className="rounded-xl border border-slate-800 bg-slate-900/60 overflow-hidden">
+                      <button
+                          type="button"
+                          onClick={() => setPromotionsOpen((o) => !o)}
+                          className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-slate-800/60 transition-colors"
+                      >
+                        <span className="inline-flex items-center gap-2 text-xs font-bold text-cyan-300/90">
+                          <Flame size={13} className="text-cyan-400" />
+                          Promotions
+                        </span>
+                        {promotionsOpen ? (
+                            <ChevronUp size={14} className="text-slate-500 shrink-0" />
+                        ) : (
+                            <ChevronDown size={14} className="text-slate-500 shrink-0" />
+                        )}
+                      </button>
+                      {promotionsOpen && (
+                          <div className="px-3 pb-3 border-t border-slate-800">
+                            <div className="pt-3">{uid && <BetOfTheDayCard uid={uid} />}</div>
+                          </div>
+                      )}
+                    </div>
+
+                    {markets.slice(0, 5).map((market) => (
                         <button
-                            key={league}
-                            onClick={() => onLeagueFilter(league)}
-                            className={`w-full text-left px-2.5 py-2 rounded-md text-xs font-bold transition-all ${
-                                leagueFilter === league
-                                    ? 'bg-slate-700 text-blue-300 border border-slate-600'
-                                    : 'bg-slate-900 text-slate-400 hover:text-slate-200 border border-slate-800'
-                            }`}
+                            key={`popular-${market.id}`}
+                            type="button"
+                            onClick={() => onLeagueFilter(market.subtitle)}
+                            className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-700 hover:bg-slate-900 transition-all truncate inline-flex items-center gap-2"
                         >
-                          {league}
+                          <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-slate-800 bg-slate-950/80">
+                            {renderSportIcon(market.category, 'h-3.5 w-3.5')}
+                          </span>
+                          <span className="truncate">{market.title.replace(' @ ', ' vs ')}</span>
                         </button>
                     ))}
                   </div>

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -42,7 +42,7 @@ import { StoreView } from './StoreView';
 import { Swords, ShoppingBag } from 'lucide-react';
 import type { LeaderboardEntry, Friend, SocialActivity } from '../models';
 import { BoostType } from '@/services/dbOps.ts';
-import { DAILY_BONUS_AMOUNT } from '../models/constants';
+import { DAILY_BONUS_AMOUNT, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
 import {FriendRequest, getBets, getUserMoney, listenForChange} from "@/services/dbOps.ts";
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
@@ -102,6 +102,9 @@ interface DashboardViewProps {
   markets: Market[];
   loading: boolean;
   error: string | null;
+  /** True while loading the cross-sport “upcoming” feed for search (single-sport tab only). */
+  globalSearchLoading: boolean;
+  globalSearchError: string | null;
   leaderboardEntries: LeaderboardEntry[];
   friends: Friend[];
   activity: SocialActivity[];
@@ -144,6 +147,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     markets,
     loading,
     error,
+    globalSearchLoading,
+    globalSearchError,
     leaderboardEntries,
     friends,
     activity,
@@ -561,7 +566,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                       <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={16} />
                       <input
                           type="text"
-                          placeholder={hasSelectedSport ? 'Search games...' : 'Select a sport tab to load markets'}
+                          placeholder={hasSelectedSport ? 'Search games (all sports)…' : 'Select a sport tab to load markets'}
                           value={searchQuery}
                           onChange={(e) => onSearchChange(e.target.value)}
                           disabled={!hasSelectedSport}
@@ -597,9 +602,14 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                   </button>
                               ))}
                         </div>
-                        <button className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-slate-300 hover:text-blue-300 transition-colors">
-                          View All Games <ChevronRight size={14} />
-                        </button>
+                        {markets.length >= VIEW_ALL_GAMES_VISIBLE_THRESHOLD && (
+                          <button
+                            type="button"
+                            className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-slate-300 hover:text-blue-300 transition-colors"
+                          >
+                            View All Games <ChevronRight size={14} />
+                          </button>
+                        )}
                       </section>
                   )}
 
@@ -638,7 +648,21 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                           <div className="text-center">Total</div>
                           <div className="text-center">Winner</div>
                         </div>
-                        {markets.length > 0 ? (
+                        {globalSearchError ? (
+                            <div className="col-span-full py-16 text-center px-4">
+                              <AlertCircle className="mx-auto text-amber-400 mb-3" size={40} />
+                              <h3 className="text-lg font-bold text-slate-200 mb-1">Couldn&apos;t load cross-sport search</h3>
+                              <p className="text-slate-500 text-sm mb-4">{globalSearchError}</p>
+                              <p className="text-slate-600 text-xs max-w-md mx-auto">
+                                Select <span className="font-semibold text-slate-400">All sports</span> in the sidebar, or try again in a moment.
+                              </p>
+                            </div>
+                        ) : globalSearchLoading && markets.length === 0 ? (
+                            <div className="col-span-full py-20 flex flex-col items-center gap-3">
+                              <Loader2 className="text-blue-400 animate-spin" size={40} />
+                              <p className="text-slate-400 text-sm">Searching all sports…</p>
+                            </div>
+                        ) : markets.length > 0 ? (
                             markets.map((market) => {
                               const teams = splitTeams(market.title);
                               const spreadAway = market.options.find((o) => o.marketKey === 'spreads' && o.label.toLowerCase().includes(teams.away.toLowerCase()));
@@ -717,7 +741,13 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               <BarChart3 className="mx-auto text-slate-700 mb-4" size={48} />
                               <h3 className="text-xl font-bold text-slate-500">No matches found</h3>
                               <p className="text-slate-600">
-                                {sportFilter === 'ALL' ? 'Try a different search term.' : leagueFilter !== 'ALL' ? `No ${leagueFilter} games at the moment. Try another league or sport.` : `No ${sportFilter} games at the moment. Try another sport.`}
+                                {searchQuery.trim()
+                                  ? 'Try a different search term.'
+                                  : leagueFilter !== 'ALL'
+                                    ? `No ${leagueFilter} games at the moment. Try another league or sport.`
+                                    : sportFilter === 'ALL'
+                                      ? 'No upcoming games in this window. Try again later.'
+                                      : `No ${sportFilter} games at the moment. Try another sport.`}
                               </p>
                             </div>
                         )}

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -21,6 +21,7 @@ import {
   ChevronRight,
   Sparkles,
   Layers,
+  LayoutGrid,
   ChevronDown,
   ChevronUp,
   CircleDot,
@@ -111,6 +112,7 @@ interface DashboardViewProps {
   onLogout: () => void;
   onSetView: (view: string) => void;
   onSportFilter: (sport: string) => void;
+  onSelectLeagueInSport: (sport: string, league: string) => void;
   onLeagueFilter: (league: string) => void;
   onSearchChange: (query: string) => void;
   onRetryMarkets: () => void;
@@ -152,6 +154,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     onLogout,
     onSetView,
     onSportFilter,
+    onSelectLeagueInSport,
     onLeagueFilter,
     onSearchChange,
     onRetryMarkets,
@@ -424,23 +427,44 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                   </p>
 
                   <div className="grid grid-cols-4 gap-1.5 mb-3">
-                    {sportTabs.filter((tab) => tab !== 'ALL').slice(0, 8).map((tab) => (
+                    {sportTabs.filter((tab) => tab !== 'ALL').slice(0, 8).map((tab) => {
+                      const isSportContext = sportFilter === tab;
+                      const sportPrimarySelected = isSportContext && leagueFilter !== 'ALL';
+                      const sportMutedSelected = isSportContext && leagueFilter === 'ALL';
+                      return (
                         <button
                             key={`tile-${tab}`}
+                            type="button"
                             onClick={() => onSportFilter(tab)}
                             title={tab}
                             className={`market-top-pill rounded-lg border p-2 flex items-center justify-center text-[10px] font-black transition-all ${
-                                sportFilter === tab
+                                sportPrimarySelected
                                     ? 'border-blue-500 bg-blue-600/20 text-blue-200'
-                                    : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
+                                    : sportMutedSelected
+                                      ? 'border-slate-600 bg-slate-800/70 text-slate-300 ring-1 ring-slate-700/80'
+                                      : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
                             }`}
                         >
                           {renderSportIcon(tab)}
                         </button>
-                    ))}
+                      );
+                    })}
+                    <button
+                        type="button"
+                        onClick={() => onSportFilter('ALL')}
+                        title="All sports & leagues"
+                        aria-pressed={sportFilter === 'ALL'}
+                        className={`market-top-pill rounded-lg border p-2 flex items-center justify-center transition-all ${
+                            sportFilter === 'ALL'
+                                ? 'border-blue-500 bg-blue-600/20 text-blue-200'
+                                : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
+                        }`}
+                    >
+                      <LayoutGrid size={20} strokeWidth={2} className="shrink-0" aria-hidden />
+                    </button>
                   </div>
 
-                  {leagueNavRows.length > 0 && (
+                  {hasSelectedSport && leagueNavRows.length > 0 && (
                       <div className="mb-4 space-y-0 divide-y divide-slate-800/90 rounded-lg border border-slate-800 overflow-hidden">
                         {leagueNavRows.map(({ league, sport }) => {
                           const icon = resolveLeagueIcon(league);
@@ -449,10 +473,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               <button
                                   type="button"
                                   key={`league-row-${sport}-${league}`}
-                                  onClick={() => {
-                                    if (sportFilter !== sport) onSportFilter(sport);
-                                    onLeagueFilter(league);
-                                  }}
+                                  onClick={() => onSelectLeagueInSport(sport, league)}
                                   className={`flex w-full items-center gap-2.5 px-2 py-2.5 text-left transition-colors ${
                                       selected ? 'bg-slate-800/70' : 'bg-slate-900/40 hover:bg-slate-800/40'
                                   }`}
@@ -522,7 +543,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         <button
                             key={`popular-${market.id}`}
                             type="button"
-                            onClick={() => onLeagueFilter(market.subtitle)}
+                            onClick={() => onSelectLeagueInSport(market.category, market.subtitle)}
                             className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-700 hover:bg-slate-900 transition-all truncate inline-flex items-center gap-2"
                         >
                           <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-slate-800 bg-slate-950/80">

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -3,11 +3,10 @@ import { useLocation, useNavigate, NavLink } from 'react-router-dom';
 import {
   Trophy,
   Wallet as WalletIcon,
-  Zap,
+  Home,
   BarChart3,
   History,
   Gamepad2,
-  TrendingUp,
   Search,
   Users,
   Medal,
@@ -19,13 +18,10 @@ import {
   Flame,
   Clock3,
   ChevronRight,
-  Sparkles,
+  Ticket,
   Layers,
   LayoutGrid,
-  ChevronDown,
-  ChevronUp,
   CircleDot,
-  User,
 } from 'lucide-react';
 import type { Market, MarketOption, Bet } from '../models';
 import { BetSlip } from '../components/BetSlip';
@@ -508,13 +504,6 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
 
                   <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-2">Popular</p>
                   <div className="space-y-1.5 mb-4">
-                    <button
-                        type="button"
-                        className="w-full text-left px-2 py-1.5 rounded-md text-xs border border-slate-800 bg-slate-900/70 text-amber-300/90 hover:text-amber-200 transition-all inline-flex items-center gap-2"
-                    >
-                      <Sparkles size={12} />
-                      Boosts
-                    </button>
                     {uid && (
                         <BoostsCard uid={uid} activeBoost={activeBoost} onSelectBoost={setActiveBoost} />
                     )}
@@ -529,11 +518,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                           <Flame size={13} className="text-cyan-400" />
                           Promotions
                         </span>
-                        {promotionsOpen ? (
-                            <ChevronUp size={14} className="text-slate-500 shrink-0" />
-                        ) : (
-                            <ChevronDown size={14} className="text-slate-500 shrink-0" />
-                        )}
+                        <Ticket size={14} className="text-slate-500 shrink-0" aria-hidden />
                       </button>
                       {promotionsOpen && (
                           <div className="px-3 pb-3 border-t border-slate-800">
@@ -760,11 +745,11 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
               title="Home"
               className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center shadow-lg shadow-blue-600/40 cursor-pointer [&.active]:ring-2 [&.active]:ring-blue-400 [&.active]:ring-offset-2 [&.active]:ring-offset-slate-900"
           >
-            <Zap className="text-white" size={24} />
+            <Home className="text-white" size={24} />
           </NavLink>
           <div className="flex lg:flex-col gap-4">
             <NavLink to="/bet" title="Live betting" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-blue-600/10 text-blue-400' : 'text-slate-500 hover:bg-slate-800'}`}>
-              <TrendingUp size={24} />
+              <Ticket size={24} />
             </NavLink>
             <NavLink to="/leaderboard" title="Leaderboard" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-blue-600/10 text-blue-400' : 'text-slate-500 hover:bg-slate-800'}`}>
               <Medal size={24} />
@@ -781,23 +766,18 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
             <NavLink to="/store" title="Store" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-violet-500/10 text-violet-400' : 'text-slate-500 hover:bg-slate-800'}`}>
               <ShoppingBag size={24} />
             </NavLink>
-            <NavLink to="/profile" title="Profile" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-blue-600/10 text-blue-400' : 'text-slate-500 hover:bg-slate-800'}`}>
-              <User size={24} />
-            </NavLink>
           </div>
-          <div className="hidden lg:mt-auto lg:block">
-            <div className="flex flex-col items-center gap-2">
-              <NavLink
-                  to="/profile"
-                  className={({ isActive }) => `w-10 h-10 rounded-full bg-slate-700 flex items-center justify-center border border-slate-600 hover:border-slate-500 hover:bg-slate-600 transition-all cursor-pointer ${isActive ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''}`}
-                  title="Profile"
-              >
-                <span className="text-xs font-bold">{userInitials}</span>
-              </NavLink>
-              <button onClick={onLogout} className="text-xs text-slate-500 hover:text-slate-400 flex items-center gap-1">
-                <LogOut size={12} /> Log out
-              </button>
-            </div>
+          <div className="flex flex-col items-center gap-2 ml-auto shrink-0 lg:ml-0 lg:mt-auto">
+            <NavLink
+                to="/profile"
+                className={({ isActive }) => `w-10 h-10 rounded-full bg-slate-700 flex items-center justify-center border border-slate-600 hover:border-slate-500 hover:bg-slate-600 transition-all cursor-pointer ${isActive ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''}`}
+                title="Profile"
+            >
+              <span className="text-xs font-bold">{userInitials}</span>
+            </NavLink>
+            <button type="button" onClick={onLogout} className="text-xs text-slate-500 hover:text-slate-400 flex items-center gap-1">
+              <LogOut size={12} /> Log out
+            </button>
           </div>
         </nav>
 

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -2,12 +2,12 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   Settings,
+  Eye,
   Trophy,
   BarChart3,
   Wallet,
   Target,
   Clock3,
-  Check,
   Swords,
 } from 'lucide-react';
 import { CounterBetModal } from '../components/CounterBetModal';
@@ -89,6 +89,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   const [isEditingAchievements, setIsEditingAchievements] = useState(false);
   const [isEditingBets, setIsEditingBets] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [publicPreview, setPublicPreview] = useState(false);
 
   // Counter-Bet (head-to-head) modal target.
   const [counterBetTarget, setCounterBetTarget] = useState<Bet | null>(null);
@@ -308,140 +309,189 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   const displayedBets = recentBets.filter((bet) => profileDisplay.bets.includes(bet.id));
   const betsForSection = isOwnProfile && isEditingBets ? recentBets : displayedBets;
 
+  const viewingAsPublic = Boolean(isOwnProfile && publicPreview);
+  const showEditUi = isOwnProfile && !viewingAsPublic;
+  const statsForDisplay = !isOwnProfile || viewingAsPublic ? displayedStats : statsForSection;
+  const achievementsForDisplay = !isOwnProfile || viewingAsPublic ? displayedAchievements : achievementsForSection;
+  const betsForDisplay = !isOwnProfile || viewingAsPublic ? displayedBets : betsForSection;
+
+  const sectionShell =
+    'rounded-2xl border border-slate-800/50 bg-slate-950/40 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.03)]';
+  const sectionLabel = 'text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500';
+
   return (
-    <div className="animate-in fade-in duration-500 w-full">
-      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6 mb-8">
-        <div className="flex flex-col lg:flex-row lg:items-start gap-4 lg:gap-6 flex-1 min-w-0">
-          <div className="flex items-center gap-4 min-w-0">
-            <div className="w-20 h-20 rounded-full bg-slate-700 border-2 border-slate-600 flex items-center justify-center shrink-0 overflow-hidden">
-              {equippedAvatarUrl ? (
-                <img
-                  src={equippedAvatarUrl}
-                  alt={`${displayName}'s avatar`}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                  onError={() => setEquippedAvatarUrl(null)}
-                />
-              ) : (
-                <span className="text-2xl font-bold text-blue-400">{avatarText}</span>
-              )}
-            </div>
-            <div className="min-w-0">
-              <h2 className="text-2xl font-bold text-white">{isOwnProfile ? 'Account' : `${displayName}'s account`}</h2>
-              <p className="text-slate-400 text-sm break-all">{isOwnProfile ? userEmail : `${displayName} on BetHub`}</p>
-            </div>
-          </div>
-          <div className="flex-1 min-w-0 lg:max-w-md">
-            <div className="glass-card rounded-2xl p-4 border-slate-800">
-              <p className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
-                {isOwnProfile ? 'Public account display' : 'Visible on this account'}
-              </p>
-              <p className="text-sm text-slate-400">
-                {isOwnProfile
-                  ? 'Choose which sections other BetHub users can see when they open your account page.'
-                  : `${displayName} controls which account sections are public.`}
-              </p>
-            </div>
-          </div>
+    <div className="animate-in fade-in duration-500 mx-auto w-full max-w-5xl">
+      {loading ? (
+        <div
+          className={`${sectionShell} py-16 text-center text-sm text-slate-500`}
+        >
+          Loading account...
         </div>
-        {isOwnProfile && (
-          <button
-            onClick={() => setShowSettings((prev) => !prev)}
-            className="p-3 rounded-xl bg-slate-800 border border-slate-700 hover:bg-slate-700 hover:border-slate-600 transition-all self-start shrink-0"
-            title="Account settings"
-          >
-            <Settings className="text-slate-400 hover:text-slate-200" size={24} />
-          </button>
-        )}
-      </div>
-
-      {isOwnProfile && showSettings && (
-        <div className="mb-8 rounded-2xl border border-slate-800 bg-slate-900/35 p-5">
-          <SettingsView
-            userEmail={userEmail}
-            embedded
-            themeMode={themeMode}
-            themeSaving={themeSaving}
-            onThemeModeChange={onThemeModeChange}
-          />
-        </div>
-      )}
-
-      <div className="space-y-6">
-        <div className="space-y-6">
-          {loading ? (
-            <div className="glass-card rounded-2xl p-10 border-slate-800 text-center text-slate-400">
-              Loading account...
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {(statsForSection.length > 0 || isOwnProfile) && (
-                <section className="glass-card rounded-2xl p-6 border-slate-800">
-                  <div className="mb-4 flex items-center justify-between gap-3">
-                    <h3 className="text-lg font-bold flex items-center gap-2 text-blue-400">
-                      <BarChart3 size={20} /> Stats
-                    </h3>
+      ) : (
+        <div className="space-y-8">
+          <section className={`${sectionShell} overflow-hidden`}>
+            {viewingAsPublic && (
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-amber-500/25 bg-amber-500/[0.07] px-4 py-2.5 text-xs text-amber-100 sm:px-5">
+                <span className="font-medium">You&apos;re viewing your public profile.</span>
+                <button
+                  type="button"
+                  onClick={() => setPublicPreview(false)}
+                  className="rounded-md border border-amber-400/35 bg-amber-500/15 px-2.5 py-1 text-[11px] font-semibold text-amber-50 hover:bg-amber-500/25"
+                >
+                  Exit preview
+                </button>
+              </div>
+            )}
+            <div className={`px-5 pb-6 sm:px-8 sm:pb-8 ${viewingAsPublic ? 'pt-6 sm:pt-8' : 'pt-8 sm:pt-10'}`}>
+              <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-10">
+                <div className="flex min-w-0 flex-1 gap-4 sm:gap-5">
+                  <div className="relative shrink-0">
+                    <div className="h-24 w-24 rounded-full bg-gradient-to-br from-blue-500/25 via-slate-700 to-slate-800 p-[3px] shadow-lg shadow-black/25 ring-1 ring-white/[0.06] sm:h-28 sm:w-28">
+                      <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-full bg-slate-900">
+                        {equippedAvatarUrl ? (
+                          <img
+                            src={equippedAvatarUrl}
+                            alt={`${displayName}'s avatar`}
+                            className="h-full w-full object-cover"
+                            loading="lazy"
+                            referrerPolicy="no-referrer"
+                            onError={() => setEquippedAvatarUrl(null)}
+                          />
+                        ) : (
+                          <span className="text-2xl font-semibold tracking-tight text-blue-300 sm:text-3xl">
+                            {avatarText}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="min-w-0 flex-1 text-left">
+                    <h2 className="text-xl font-semibold tracking-tight text-slate-100 sm:text-2xl">
+                      {isOwnProfile ? 'Account' : `${displayName}'s account`}
+                    </h2>
+                    <p className="mt-1 break-words text-sm leading-relaxed text-slate-500">
+                      {isOwnProfile ? userEmail : `${displayName} on BetHub`}
+                    </p>
                     {isOwnProfile && (
-                      <button
-                        type="button"
-                        onClick={() => setIsEditingStats((prev) => !prev)}
-                        className="rounded-lg border border-slate-700 bg-slate-800/50 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
-                      >
-                        {isEditingStats ? 'View' : 'Edit'}
-                      </button>
+                      <p className="mt-3 text-[10px] font-bold tracking-[0.22em] text-slate-500">PUBLIC</p>
+                    )}
+                    {showEditUi && !publicPreview && (
+                      <div className="mt-4 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setPublicPreview(true);
+                            setIsEditingStats(false);
+                            setIsEditingAchievements(false);
+                            setIsEditingBets(false);
+                          }}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-600 bg-slate-800/50 px-3 py-1.5 text-xs font-semibold text-slate-200 transition-colors hover:border-blue-500/40 hover:bg-slate-800"
+                        >
+                          <Eye size={14} strokeWidth={2} aria-hidden />
+                          Preview public profile
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setShowSettings((prev) => !prev)}
+                          className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-semibold transition-colors ${
+                            showSettings
+                              ? 'border-blue-500/50 bg-blue-500/15 text-blue-200'
+                              : 'border-slate-600 bg-slate-800/50 text-slate-400 hover:border-slate-500 hover:bg-slate-800 hover:text-slate-200'
+                          }`}
+                          title="Advanced settings"
+                          aria-expanded={showSettings}
+                        >
+                          Settings
+                          <Settings size={16} strokeWidth={2} aria-hidden />
+                        </button>
+                      </div>
                     )}
                   </div>
-                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                    {statsForSection.map((card) => {
-                      const isSelected = profileDisplay.stats.includes(card.id);
-                      const isClickable = isOwnProfile && isEditingStats;
-                      return (
-                      <button
-                        type="button"
-                        key={card.id}
-                        onClick={isClickable ? () => toggleStat(card.id) : undefined}
-                        disabled={!isClickable}
-                        className={`p-4 rounded-xl border text-left transition-colors ${
-                          isSelected
-                            ? 'border-blue-500/60 bg-blue-500/10'
-                            : 'border-slate-700 bg-slate-800/50'
-                        } ${isClickable ? 'cursor-pointer hover:border-blue-400/70' : 'cursor-default'}`}
-                      >
-                        <p className="text-xs font-bold text-slate-500 uppercase mb-1">{card.label}</p>
-                        <p className={`text-xl font-bold ${card.tone}`}>{card.value}</p>
-                      </button>
-                    );
-                    })}
-                  </div>
-                  {isOwnProfile && !isEditingStats && statsForSection.length === 0 && (
-                    <p className="mt-4 text-sm text-slate-500">
-                      No stats are public yet. Switch to Edit to choose what others can see.
-                    </p>
-                  )}
-                </section>
-              )}
+                </div>
 
-              {(achievementsForSection.length > 0 || (isOwnProfile && unlockedAchievementCards.length > 0)) && (
-                <section className="glass-card rounded-2xl p-6 border-slate-800">
-                  <div className="mb-4 flex items-center justify-between gap-3">
-                    <h3 className="text-lg font-bold flex items-center gap-2 text-blue-400">
-                      <Trophy size={20} /> Achievements
+                {(statsForDisplay.length > 0 || isOwnProfile) && (
+                  <div className="min-w-0 flex-1 lg:border-l lg:border-slate-800/50 lg:pl-10">
+                    <div className="mb-4 flex items-center justify-between gap-3">
+                      <h3 className={`${sectionLabel} flex items-center gap-2`}>
+                        <BarChart3 size={14} className="text-blue-400/90" aria-hidden />
+                        Stats
+                      </h3>
+                      {showEditUi && (
+                        <button
+                          type="button"
+                          onClick={() => setIsEditingStats((prev) => !prev)}
+                          className="rounded-lg border border-slate-700/80 bg-slate-900/60 px-3 py-1.5 text-xs font-semibold text-slate-300 transition-colors hover:border-slate-600 hover:bg-slate-800 hover:text-white"
+                        >
+                          {isEditingStats ? 'View' : 'Edit'}
+                        </button>
+                      )}
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
+                      {statsForDisplay.map((card) => {
+                        const isSelected = profileDisplay.stats.includes(card.id);
+                        const isClickable = showEditUi && isEditingStats;
+                        return (
+                          <button
+                            type="button"
+                            key={card.id}
+                            onClick={isClickable ? () => toggleStat(card.id) : undefined}
+                            disabled={!isClickable}
+                            className={`rounded-xl border px-3 py-3.5 text-left transition-colors sm:px-4 sm:py-4 ${
+                              isSelected
+                                ? 'border-blue-500/50 bg-blue-500/10 ring-1 ring-blue-500/20'
+                                : 'border-slate-800/80 bg-slate-900/40'
+                            } ${isClickable ? 'cursor-pointer hover:border-blue-400/60 hover:bg-slate-800/30' : 'cursor-default'}`}
+                          >
+                            <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">{card.label}</p>
+                            <p className={`mt-1 text-lg font-semibold tabular-nums sm:text-xl ${card.tone}`}>{card.value}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {showEditUi && !isEditingStats && statsForDisplay.length === 0 && (
+                      <p className="mt-4 text-sm text-slate-500">
+                        No stats are public yet. Switch to Edit to choose what others can see.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {showEditUi && showSettings && (
+            <div className={`${sectionShell} p-5 sm:p-6`}>
+              <SettingsView
+                userEmail={userEmail}
+                embedded
+                themeMode={themeMode}
+                themeSaving={themeSaving}
+                onThemeModeChange={onThemeModeChange}
+              />
+            </div>
+          )}
+
+              {(achievementsForDisplay.length > 0 || (showEditUi && unlockedAchievementCards.length > 0)) && (
+                <section className={`${sectionShell} p-6 sm:p-8`}>
+                  <div className="mb-5 flex items-center justify-between gap-3">
+                    <h3 className={`${sectionLabel} flex items-center gap-2 text-slate-400`}>
+                      <Trophy size={14} className="text-amber-400/90" aria-hidden />
+                      Achievements
                     </h3>
-                    {isOwnProfile && unlockedAchievementCards.length > 0 && (
+                    {showEditUi && unlockedAchievementCards.length > 0 && (
                       <button
                         type="button"
                         onClick={() => setIsEditingAchievements((prev) => !prev)}
-                        className="rounded-lg border border-slate-700 bg-slate-800/50 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
+                        className="rounded-lg border border-slate-700/80 bg-slate-900/60 px-3 py-1.5 text-xs font-semibold text-slate-300 transition-colors hover:border-slate-600 hover:bg-slate-800 hover:text-white"
                       >
                         {isEditingAchievements ? 'View' : 'Edit'}
                       </button>
                     )}
                   </div>
                   <div className="grid gap-4 md:grid-cols-3">
-                    {achievementsForSection.map((achievement) => {
+                    {achievementsForDisplay.map((achievement) => {
                       const isSelected = profileDisplay.achievements.includes(achievement.id);
-                      const isClickable = isOwnProfile && isEditingAchievements;
+                      const isClickable = showEditUi && isEditingAchievements;
                       return (
                       <button
                         key={achievement.id}
@@ -449,10 +499,10 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                         onClick={isClickable ? () => toggleAchievement(achievement.id) : undefined}
                         className={`rounded-xl border p-4 text-left transition-colors ${
                           isSelected
-                            ? 'border-amber-400/40 bg-amber-500/10'
-                            : 'border-slate-700 bg-slate-800/40'
+                            ? 'border-amber-400/45 bg-amber-500/10 ring-1 ring-amber-400/15'
+                            : 'border-slate-800/80 bg-slate-900/35'
                         } ${
-                          isClickable ? 'cursor-pointer hover:border-amber-300/50' : 'cursor-default'
+                          isClickable ? 'cursor-pointer hover:border-amber-400/40 hover:bg-slate-800/30' : 'cursor-default'
                         }`}
                         disabled={!isClickable}
                       >
@@ -472,12 +522,12 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                     );
                     })}
                   </div>
-                  {isOwnProfile && !isEditingAchievements && achievementsForSection.length === 0 && (
+                  {showEditUi && !isEditingAchievements && achievementsForDisplay.length === 0 && (
                     <p className="mt-4 text-sm text-slate-500">
                       No achievements are public yet. Switch to Edit to choose what others can see.
                     </p>
                   )}
-                  {isOwnProfile && isEditingAchievements && unlockedAchievementCards.length === 0 && (
+                  {showEditUi && isEditingAchievements && unlockedAchievementCards.length === 0 && (
                     <p className="mt-4 text-sm text-slate-500">
                       Unlock achievements to choose which ones appear publicly.
                     </p>
@@ -485,36 +535,37 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                 </section>
               )}
 
-              {(betsForSection.length > 0 || isOwnProfile) && (
-                <section className="glass-card rounded-2xl p-6 border-slate-800">
-                  <div className="mb-4 flex items-center justify-between gap-3">
-                    <h3 className="text-lg font-bold flex items-center gap-2 text-blue-400">
-                      <Target size={20} /> Featured Bets
+              {(betsForDisplay.length > 0 || isOwnProfile) && (
+                <section className={`${sectionShell} p-6 sm:p-8`}>
+                  <div className="mb-5 flex items-center justify-between gap-3">
+                    <h3 className={`${sectionLabel} flex items-center gap-2 text-slate-400`}>
+                      <Target size={14} className="text-violet-400/90" aria-hidden />
+                      Featured Bets
                     </h3>
-                    {isOwnProfile && (
+                    {showEditUi && (
                       <button
                         type="button"
                         onClick={() => setIsEditingBets((prev) => !prev)}
-                        className="rounded-lg border border-slate-700 bg-slate-800/50 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
+                        className="rounded-lg border border-slate-700/80 bg-slate-900/60 px-3 py-1.5 text-xs font-semibold text-slate-300 transition-colors hover:border-slate-600 hover:bg-slate-800 hover:text-white"
                       >
                         {isEditingBets ? 'View' : 'Edit'}
                       </button>
                     )}
                   </div>
-                  {betsForSection.length > 0 ? (
+                  {betsForDisplay.length > 0 ? (
                     <div className="space-y-3">
-                      {betsForSection.map((bet) => {
+                      {betsForDisplay.map((bet) => {
                         const isSelected = profileDisplay.bets.includes(bet.id);
-                        const isClickable = isOwnProfile && isEditingBets;
+                        const isClickable = showEditUi && isEditingBets;
                         const fade = fadeEligibility(bet);
                         const challengerStake = Math.round(bet.stake * (bet.odds - 1) * 100) / 100;
                         return (
                         <div
                           key={bet.id}
-                          className={`rounded-xl border ${
+                          className={`overflow-hidden rounded-xl border ${
                             isSelected
-                              ? 'border-blue-500/60 bg-blue-500/10'
-                              : 'border-slate-700 bg-slate-900/60'
+                              ? 'border-blue-500/50 bg-blue-500/10 ring-1 ring-blue-500/15'
+                              : 'border-slate-800/80 bg-slate-900/40'
                           }`}
                         >
                         <button
@@ -534,7 +585,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                               <span className="rounded-full border border-slate-700 px-2.5 py-1 text-xs font-semibold text-slate-300">
                                 {(bet.status ?? 'PENDING').toLowerCase()}
                               </span>
-                              {isClickable && isSelected && <Check size={16} className="text-blue-300" />}
+                              {isClickable && isSelected && (
+                                <Eye size={16} className="text-blue-300" aria-label="Shown on public profile" />
+                              )}
                             </div>
                           </div>
                           <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-400">
@@ -572,28 +625,25 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                       })}
                     </div>
                   ) : (
-                    <div className="py-8 text-center border border-dashed border-slate-700 rounded-xl">
-                      <Target className="mx-auto text-slate-600 mb-3" size={48} />
-                      <p className="text-slate-500 font-medium">No featured bets to show yet</p>
-                      <p className="text-sm text-slate-600 mt-1">
-                        {isOwnProfile && isEditingBets
+                    <div className="rounded-xl border border-dashed border-slate-800/70 bg-slate-900/25 py-10 text-center">
+                      <Target className="mx-auto mb-3 text-slate-600" size={40} strokeWidth={1.5} />
+                      <p className="font-medium text-slate-500">No featured bets to show yet</p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {showEditUi && isEditingBets
                           ? 'Place a few bets to choose which ones appear here.'
                           : 'Once bets are placed, they can appear here on the account page.'}
                       </p>
                     </div>
                   )}
-                  {isOwnProfile && !isEditingBets && betsForSection.length === 0 && recentBets.length > 0 && (
+                  {showEditUi && !isEditingBets && betsForDisplay.length === 0 && recentBets.length > 0 && (
                     <p className="mt-4 text-sm text-slate-500">
                       No featured bets are public yet. Switch to Edit to choose which bets to show.
                     </p>
                   )}
                 </section>
               )}
-            </div>
-          )}
         </div>
-
-      </div>
+      )}
       {counterBetTarget && currentUserId && (
         <CounterBetModal
           bet={counterBetTarget}

--- a/views/SettingsView.tsx
+++ b/views/SettingsView.tsx
@@ -1,12 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import {
-  User, Bell, Shield, Palette, Sun, Moon, Wallet, Lock, Globe,
-  ChevronRight, ChevronLeft, ChevronDown, ChevronUp, Mail, Check,
+  User,
+  Bell,
+  Shield,
+  Palette,
+  Sun,
+  Moon,
+  Wallet,
+  Lock,
+  Globe,
+  ChevronRight,
+  ChevronLeft,
+  ChevronDown,
+  ChevronUp,
+  Mail,
+  Check,
+  Clock,
+  Ban,
 } from 'lucide-react';
 import { getSpendingLimits, setSpendingLimits, SpendingLimits } from '@/services/dbOps.ts';
 import { sendPasswordResetEmail, getAuth } from 'firebase/auth';
-import { APP } from '@/models/constants.ts';
 import type { UserThemeMode } from '@/services/dbOps';
 
 interface SettingsViewProps {
@@ -17,22 +31,28 @@ interface SettingsViewProps {
   onThemeModeChange: (mode: UserThemeMode) => void;
 }
 
+const RowIcon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-800/40 text-slate-400 ring-1 ring-white/[0.04]">
+    {children}
+  </span>
+);
+
 export const SettingsView: React.FC<SettingsViewProps> = ({
-                                                            userEmail,
-                                                            embedded = false,
-                                                            themeMode,
-                                                            themeSaving,
-                                                            onThemeModeChange,
-                                                          }) => {
+  userEmail,
+  embedded = false,
+  themeMode,
+  themeSaving,
+  onThemeModeChange,
+}) => {
   const [limitsExpanded, setLimitsExpanded] = useState(false);
-  const [limits, setLimits]                 = useState<SpendingLimits | null>(null);
-  const [dailyInput, setDailyInput]         = useState('');
-  const [weeklyInput, setWeeklyInput]       = useState('');
-  const [saving, setSaving]                 = useState(false);
-  const [saved, setSaved]                   = useState(false);
-  const [inputError, setInputError]         = useState<string | null>(null);
-  const [resetSent, setResetSent]           = useState(false);
-  const [resetError, setResetError]         = useState<string | null>(null);
+  const [limits, setLimits] = useState<SpendingLimits | null>(null);
+  const [dailyInput, setDailyInput] = useState('');
+  const [weeklyInput, setWeeklyInput] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [resetSent, setResetSent] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
 
   const uid = localStorage.getItem('uid') ?? '';
   const isLightMode = themeMode === 'light';
@@ -41,7 +61,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
     if (!limitsExpanded || !uid) return;
     getSpendingLimits(uid).then((l) => {
       setLimits(l);
-      setDailyInput(l.daily  != null ? String(l.daily)  : '');
+      setDailyInput(l.daily != null ? String(l.daily) : '');
       setWeeklyInput(l.weekly != null ? String(l.weekly) : '');
     });
   }, [limitsExpanded, uid]);
@@ -49,14 +69,23 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
   const handleSaveLimits = async () => {
     if (!uid) return;
     setInputError(null);
-    const daily  = dailyInput.trim()  === '' ? null : Number(dailyInput);
+    const daily = dailyInput.trim() === '' ? null : Number(dailyInput);
     const weekly = weeklyInput.trim() === '' ? null : Number(weeklyInput);
-    if (daily  != null && (!Number.isFinite(daily)  || daily  <= 0)) { setInputError('Daily limit must be a positive number.'); return; }
-    if (weekly != null && (!Number.isFinite(weekly) || weekly <= 0)) { setInputError('Weekly limit must be a positive number.'); return; }
-    if (daily != null && weekly != null && daily > weekly) { setInputError('Daily limit cannot exceed weekly limit.'); return; }
+    if (daily != null && (!Number.isFinite(daily) || daily <= 0)) {
+      setInputError('Daily limit must be a positive number.');
+      return;
+    }
+    if (weekly != null && (!Number.isFinite(weekly) || weekly <= 0)) {
+      setInputError('Weekly limit must be a positive number.');
+      return;
+    }
+    if (daily != null && weekly != null && daily > weekly) {
+      setInputError('Daily limit cannot exceed weekly limit.');
+      return;
+    }
     setSaving(true);
     await setSpendingLimits(uid, daily, weekly);
-    setLimits(prev => prev ? { ...prev, daily, weekly } : prev);
+    setLimits((prev) => (prev ? { ...prev, daily, weekly } : prev));
     setSaving(false);
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
@@ -79,214 +108,312 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
     return `$${spent.toFixed(0)} of $${limit.toFixed(0)} spent`;
   };
 
+  const sectionShell = 'rounded-2xl border border-slate-800/50 bg-slate-950/40 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.03)] overflow-hidden';
+  const rowBase =
+    'w-full flex items-center gap-4 px-4 py-3.5 text-left transition-colors hover:bg-white/[0.03] sm:px-5 sm:py-4';
+  const rowDivider = 'border-t border-slate-800/40';
+
   return (
-      <div className="animate-in fade-in duration-500 max-w-2xl">
-        {!embedded && (
-            <NavLink to="/profile" className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 mb-6 transition-colors">
-              <ChevronLeft size={18} /> Back to account
-            </NavLink>
-        )}
-        <h2 className="text-2xl font-bold mb-2 flex items-center gap-2">
-          <User className="text-blue-400" size={24} /> Settings
-        </h2>
-        <p className="text-slate-400 mb-8">Manage your account and preferences.</p>
+    <div className={`animate-in fade-in duration-500 ${embedded ? 'max-w-xl' : 'max-w-2xl'}`}>
+      {!embedded && (
+        <NavLink
+          to="/profile"
+          className="mb-8 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-300"
+        >
+          <ChevronLeft size={16} strokeWidth={2} />
+          Back to account
+        </NavLink>
+      )}
 
-        <div className="space-y-4">
+      <header className="mb-10 border-b border-slate-800/60 pb-8">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400 ring-1 ring-blue-500/20">
+            <User size={20} strokeWidth={2} />
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight text-slate-100 sm:text-2xl">Settings</h2>
+            <p className="mt-1 max-w-md text-sm leading-relaxed text-slate-500">
+              Manage your account and preferences.
+            </p>
+          </div>
+        </div>
+      </header>
 
-          {/* Account */}
-          <section className="glass-card rounded-2xl border-slate-800 overflow-hidden">
-            <h3 className="text-sm font-bold text-slate-500 uppercase tracking-wider px-6 py-3 border-b border-slate-800 flex items-center gap-2">
-              <User size={14} /> Account
-            </h3>
-            <div className="divide-y divide-slate-800">
-              <button className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                <div className="flex items-center gap-3">
-                  <Mail className="text-slate-500" size={18} />
-                  <div>
-                    <p className="font-medium text-slate-200">Email</p>
-                    <p className="text-xs text-slate-500">{userEmail}</p>
-                  </div>
-                </div>
-                <ChevronRight className="text-slate-500" size={18} />
-              </button>
+      <div className="space-y-10">
+        {/* Account */}
+        <section>
+          <h3 className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+            <User size={12} className="text-slate-600" aria-hidden />
+            Account
+          </h3>
+          <div className={sectionShell}>
+            <button type="button" className={rowBase}>
+              <RowIcon>
+                <Mail size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Email</p>
+                <p className="mt-0.5 truncate text-xs text-slate-500">{userEmail}</p>
+              </div>
+              <ChevronRight className="shrink-0 text-slate-600" size={18} strokeWidth={2} />
+            </button>
 
-              <button onClick={handlePasswordReset} className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                <div className="flex items-center gap-3">
-                  <Lock className="text-slate-500" size={18} />
-                  <div>
-                    <p className="font-medium text-slate-200">Password</p>
-                    <p className={`text-xs ${resetSent ? 'text-emerald-400' : resetError ? 'text-red-400' : 'text-slate-500'}`}>
-                      {resetSent ? '✓ Reset email sent — check your inbox' : resetError ?? 'Send a password reset email'}
-                    </p>
-                  </div>
-                </div>
-                {resetSent ? <Check className="text-emerald-400" size={18} /> : <ChevronRight className="text-slate-500" size={18} />}
-              </button>
-
-              {/* Theme toggle */}
-              <div className="w-full px-6 py-4 flex items-center justify-between gap-4">
-                <div className="flex items-center gap-3 min-w-0">
-                  <Palette className="text-slate-500" size={18} />
-                  <div>
-                    <p className="font-medium text-slate-200">Preferences - Light mode</p>
-                    <p className="text-xs text-slate-500">Switch between Ocean and Light theme.</p>
-                  </div>
-                </div>
-                <button
-                    type="button"
-                    onClick={() => onThemeModeChange(isLightMode ? 'ocean' : 'light')}
-                    disabled={themeSaving}
-                    className={`relative inline-flex h-6 w-12 items-center rounded-full transition-colors ${isLightMode ? 'bg-amber-500' : 'bg-blue-600'} ${themeSaving ? 'cursor-wait opacity-70' : 'cursor-pointer'}`}
-                    aria-pressed={isLightMode}
-                    aria-label="Toggle light mode"
+            <button type="button" onClick={handlePasswordReset} className={`${rowBase} ${rowDivider}`}>
+              <RowIcon>
+                <Lock size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Password</p>
+                <p
+                  className={`mt-0.5 text-xs leading-snug ${
+                    resetSent ? 'text-emerald-400/90' : resetError ? 'text-red-400/90' : 'text-slate-500'
+                  }`}
                 >
-                <span className={`absolute inline-flex h-5 w-5 items-center justify-center rounded-full bg-white text-slate-700 shadow transition-transform ${isLightMode ? 'translate-x-6' : 'translate-x-1'}`}>
+                  {resetSent ? '✓ Reset email sent — check your inbox' : resetError ?? 'Send a password reset email'}
+                </p>
+              </div>
+              {resetSent ? (
+                <Check className="shrink-0 text-emerald-400" size={18} strokeWidth={2} />
+              ) : (
+                <ChevronRight className="shrink-0 text-slate-600" size={18} strokeWidth={2} />
+              )}
+            </button>
+
+            <div className={`${rowBase} ${rowDivider} gap-4`}>
+              <RowIcon>
+                <Palette size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Preferences - Light mode</p>
+                <p className="mt-0.5 text-xs leading-relaxed text-slate-500">Switch between Ocean and Light theme.</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onThemeModeChange(isLightMode ? 'ocean' : 'light')}
+                disabled={themeSaving}
+                className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors ${
+                  isLightMode ? 'bg-amber-500/90' : 'bg-blue-600'
+                } ${themeSaving ? 'cursor-wait opacity-70' : 'cursor-pointer'}`}
+                aria-pressed={isLightMode}
+                aria-label="Toggle light mode"
+              >
+                <span
+                  className={`absolute inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-slate-700 shadow-md transition-transform ${
+                    isLightMode ? 'translate-x-5' : 'translate-x-0.5'
+                  }`}
+                >
                   {isLightMode ? <Sun size={12} /> : <Moon size={12} />}
                 </span>
-                </button>
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* Notifications */}
+        <section>
+          <h3 className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+            <Bell size={12} className="text-slate-600" aria-hidden />
+            Notifications
+          </h3>
+          <div className={sectionShell}>
+            <div className={rowBase}>
+              <div className="min-w-0 flex-1 pl-1 sm:pl-0">
+                <p className="text-sm font-medium text-slate-200">Bet results</p>
+                <p className="mt-0.5 text-xs text-slate-500">When your bets settle</p>
+              </div>
+              <div className="relative h-7 w-12 shrink-0 cursor-pointer rounded-full bg-blue-600">
+                <div className="absolute right-0.5 top-0.5 h-6 w-6 rounded-full bg-white shadow-sm ring-1 ring-black/5" />
               </div>
             </div>
-          </section>
-
-          {/* Notifications */}
-          <section className="glass-card rounded-2xl border-slate-800 overflow-hidden">
-            <h3 className="text-sm font-bold text-slate-500 uppercase tracking-wider px-6 py-3 border-b border-slate-800 flex items-center gap-2">
-              <Bell size={14} /> Notifications
-            </h3>
-            <div className="divide-y divide-slate-800">
-              <div className="px-6 py-4 flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-slate-200">Bet results</p>
-                  <p className="text-xs text-slate-500">When your bets settle</p>
-                </div>
-                <div className="w-10 h-5 bg-blue-600 rounded-full relative cursor-pointer">
-                  <div className="absolute right-1 top-1 w-3 h-3 bg-white rounded-full shadow" />
-                </div>
+            <div className={`${rowBase} ${rowDivider}`}>
+              <div className="min-w-0 flex-1 pl-1 sm:pl-0">
+                <p className="text-sm font-medium text-slate-200">Promotions</p>
+                <p className="mt-0.5 text-xs text-slate-500">Bonuses and offers</p>
               </div>
-              <div className="px-6 py-4 flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-slate-200">Promotions</p>
-                  <p className="text-xs text-slate-500">Bonuses and offers</p>
-                </div>
-                <div className="w-10 h-5 bg-slate-600 rounded-full relative cursor-pointer">
-                  <div className="absolute left-1 top-1 w-3 h-3 bg-white rounded-full shadow" />
-                </div>
-              </div>
-              <div className="px-6 py-4 flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-slate-200">Social & challenges</p>
-                  <p className="text-xs text-slate-500">Friend activity and challenges</p>
-                </div>
-                <div className="w-10 h-5 bg-blue-600 rounded-full relative cursor-pointer">
-                  <div className="absolute right-1 top-1 w-3 h-3 bg-white rounded-full shadow" />
-                </div>
+              <div className="relative h-7 w-12 shrink-0 cursor-pointer rounded-full bg-slate-600">
+                <div className="absolute left-0.5 top-0.5 h-6 w-6 rounded-full bg-white shadow-sm ring-1 ring-black/5" />
               </div>
             </div>
-          </section>
+            <div className={`${rowBase} ${rowDivider}`}>
+              <div className="min-w-0 flex-1 pl-1 sm:pl-0">
+                <p className="text-sm font-medium text-slate-200">Social & challenges</p>
+                <p className="mt-0.5 text-xs text-slate-500">Friend activity and challenges</p>
+              </div>
+              <div className="relative h-7 w-12 shrink-0 cursor-pointer rounded-full bg-blue-600">
+                <div className="absolute right-0.5 top-0.5 h-6 w-6 rounded-full bg-white shadow-sm ring-1 ring-black/5" />
+              </div>
+            </div>
+          </div>
+        </section>
 
-          {/* Responsible Gambling */}
-          <section className="glass-card rounded-2xl border-slate-800 overflow-hidden">
-            <h3 className="text-sm font-bold text-slate-500 uppercase tracking-wider px-6 py-3 border-b border-slate-800 flex items-center gap-2">
-              <Wallet size={14} /> Responsible Gambling
-            </h3>
-            <div className="divide-y divide-slate-800">
-              <div>
-                <button onClick={() => setLimitsExpanded(prev => !prev)} className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                  <div>
-                    <p className="font-medium text-slate-200">Spending limits</p>
-                    <p className="text-xs text-slate-500">
-                      {limits?.daily != null || limits?.weekly != null
-                          ? [limits?.daily != null ? `Daily $${limits.daily}` : null, limits?.weekly != null ? `Weekly $${limits.weekly}` : null].filter(Boolean).join(' · ')
-                          : 'Set daily or weekly limits'}
-                    </p>
-                  </div>
-                  {limitsExpanded ? <ChevronUp className="text-slate-500" size={18} /> : <ChevronDown className="text-slate-500" size={18} />}
-                </button>
-
-                {limitsExpanded && (
-                    <div className="px-6 pb-5 space-y-4 bg-slate-900/30">
-                      <p className="text-xs text-slate-500 pt-1">
-                        Bets will be blocked once you hit your limit. Free bets don't count. Leave a field blank to remove that limit.
-                      </p>
-                      <div>
-                        <label className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1 block">Daily limit</label>
-                        <div className="flex items-center gap-3">
-                          <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 flex-1">
-                            <span className="text-slate-400 text-sm mr-1">$</span>
-                            <input type="text" inputMode="decimal" placeholder="No limit" value={dailyInput}
-                                   onChange={e => { setDailyInput(e.target.value.replace(/[^\d.]/g, '')); setInputError(null); }}
-                                   className="bg-transparent text-sm font-semibold text-slate-100 outline-none w-full placeholder:text-slate-600" />
-                          </div>
-                          {limits?.daily != null && <span className="text-[10px] text-slate-500 whitespace-nowrap">{formatSpent(limits.dailySpent, limits.daily)}</span>}
-                        </div>
-                      </div>
-                      <div>
-                        <label className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1 block">Weekly limit</label>
-                        <div className="flex items-center gap-3">
-                          <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 flex-1">
-                            <span className="text-slate-400 text-sm mr-1">$</span>
-                            <input type="text" inputMode="decimal" placeholder="No limit" value={weeklyInput}
-                                   onChange={e => { setWeeklyInput(e.target.value.replace(/[^\d.]/g, '')); setInputError(null); }}
-                                   className="bg-transparent text-sm font-semibold text-slate-100 outline-none w-full placeholder:text-slate-600" />
-                          </div>
-                          {limits?.weekly != null && <span className="text-[10px] text-slate-500 whitespace-nowrap">{formatSpent(limits.weeklySpent, limits.weekly)}</span>}
-                        </div>
-                      </div>
-                      {inputError && <p className="text-xs text-red-400">{inputError}</p>}
-                      <button onClick={handleSaveLimits} disabled={saving}
-                              className={`w-full py-2.5 rounded-xl text-sm font-bold uppercase tracking-wide transition-all active:scale-95 flex items-center justify-center gap-2 ${saved ? 'bg-emerald-600 text-white' : saving ? 'bg-slate-700 text-slate-500 cursor-not-allowed' : 'bg-indigo-600 hover:bg-indigo-500 text-white'}`}>
-                        {saved ? <><Check size={14} /> Saved</> : saving ? 'Saving...' : 'Save limits'}
-                      </button>
-                    </div>
+        {/* Responsible Gambling */}
+        <section>
+          <h3 className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+            <Wallet size={12} className="text-slate-600" aria-hidden />
+            Responsible Gambling
+          </h3>
+          <div className={sectionShell}>
+            <div>
+              <button
+                type="button"
+                onClick={() => setLimitsExpanded((prev) => !prev)}
+                className={rowBase}
+              >
+                <RowIcon>
+                  <Wallet size={18} strokeWidth={2} />
+                </RowIcon>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-slate-200">Spending limits</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-slate-500">
+                    {limits?.daily != null || limits?.weekly != null
+                      ? [limits?.daily != null ? `Daily $${limits.daily}` : null, limits?.weekly != null ? `Weekly $${limits.weekly}` : null]
+                          .filter(Boolean)
+                          .join(' · ')
+                      : 'Set daily or weekly limits'}
+                  </p>
+                </div>
+                {limitsExpanded ? (
+                  <ChevronUp className="shrink-0 text-slate-500" size={18} strokeWidth={2} />
+                ) : (
+                  <ChevronDown className="shrink-0 text-slate-500" size={18} strokeWidth={2} />
                 )}
-              </div>
-
-              <button className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                <div>
-                  <p className="font-medium text-slate-200">Session reminder</p>
-                  <p className="text-xs text-slate-500">Get reminded after a set time</p>
-                </div>
-                <ChevronRight className="text-slate-500" size={18} />
               </button>
-              <button className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                <div>
-                  <p className="font-medium text-slate-200">Self-exclusion</p>
-                  <p className="text-xs text-slate-500">Take a break from betting</p>
-                </div>
-                <ChevronRight className="text-slate-500" size={18} />
-              </button>
-            </div>
-          </section>
 
-          {/* Privacy & preferences */}
-          <section className="glass-card rounded-2xl border-slate-800 overflow-hidden">
-            <h3 className="text-sm font-bold text-slate-500 uppercase tracking-wider px-6 py-3 border-b border-slate-800 flex items-center gap-2">
-              <Shield size={14} /> Privacy & preferences
-            </h3>
-            <div className="divide-y divide-slate-800">
-              <div className="px-6 py-4 flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-slate-200">Show activity to friends</p>
-                  <p className="text-xs text-slate-500">Your bets visible on social feed</p>
-                </div>
-                <div className="w-10 h-5 bg-blue-600 rounded-full relative cursor-pointer">
-                  <div className="absolute right-1 top-1 w-3 h-3 bg-white rounded-full shadow" />
-                </div>
-              </div>
-              <button className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-slate-800/30 transition-colors">
-                <div className="flex items-center gap-3">
-                  <Globe className="text-slate-500" size={18} />
-                  <div>
-                    <p className="font-medium text-slate-200">Currency & language</p>
-                    <p className="text-xs text-slate-500">USD • English</p>
+              {limitsExpanded && (
+                <div className="border-t border-slate-800/40 bg-slate-950/60 px-4 py-5 sm:px-5">
+                  <p className="mb-4 text-xs leading-relaxed text-slate-500">
+                    Bets will be blocked once you hit your limit. Free bets don&apos;t count. Leave a field blank to
+                    remove that limit.
+                  </p>
+                  <div className="space-y-4">
+                    <div>
+                      <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                        Daily limit
+                      </label>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <div className="flex min-w-0 flex-1 items-center rounded-xl border border-slate-700/80 bg-slate-900/60 px-3 py-2.5 ring-1 ring-white/[0.02]">
+                          <span className="mr-1 text-sm text-slate-500">$</span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="No limit"
+                            value={dailyInput}
+                            onChange={(e) => {
+                              setDailyInput(e.target.value.replace(/[^\d.]/g, ''));
+                              setInputError(null);
+                            }}
+                            className="w-full bg-transparent text-sm font-medium text-slate-100 outline-none placeholder:text-slate-600"
+                          />
+                        </div>
+                        {limits?.daily != null && (
+                          <span className="text-[10px] text-slate-500">{formatSpent(limits.dailySpent, limits.daily)}</span>
+                        )}
+                      </div>
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                        Weekly limit
+                      </label>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <div className="flex min-w-0 flex-1 items-center rounded-xl border border-slate-700/80 bg-slate-900/60 px-3 py-2.5 ring-1 ring-white/[0.02]">
+                          <span className="mr-1 text-sm text-slate-500">$</span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="No limit"
+                            value={weeklyInput}
+                            onChange={(e) => {
+                              setWeeklyInput(e.target.value.replace(/[^\d.]/g, ''));
+                              setInputError(null);
+                            }}
+                            className="w-full bg-transparent text-sm font-medium text-slate-100 outline-none placeholder:text-slate-600"
+                          />
+                        </div>
+                        {limits?.weekly != null && (
+                          <span className="text-[10px] text-slate-500">{formatSpent(limits.weeklySpent, limits.weekly)}</span>
+                        )}
+                      </div>
+                    </div>
+                    {inputError && <p className="text-xs text-red-400/90">{inputError}</p>}
+                    <button
+                      type="button"
+                      onClick={handleSaveLimits}
+                      disabled={saving}
+                      className={`flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold tracking-wide transition-all active:scale-[0.99] ${
+                        saved
+                          ? 'bg-emerald-600 text-white shadow-lg shadow-emerald-900/20'
+                          : saving
+                            ? 'cursor-not-allowed bg-slate-800 text-slate-500'
+                            : 'bg-indigo-600 text-white shadow-lg shadow-indigo-950/30 hover:bg-indigo-500'
+                      }`}
+                    >
+                      {saved ? (
+                        <>
+                          <Check size={16} strokeWidth={2.5} /> Saved
+                        </>
+                      ) : saving ? (
+                        'Saving...'
+                      ) : (
+                        'Save limits'
+                      )}
+                    </button>
                   </div>
                 </div>
-                <ChevronRight className="text-slate-500" size={18} />
-              </button>
+              )}
             </div>
-          </section>
 
-        </div>
+            <button type="button" className={`${rowBase} ${rowDivider}`}>
+              <RowIcon>
+                <Clock size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Session reminder</p>
+                <p className="mt-0.5 text-xs text-slate-500">Get reminded after a set time</p>
+              </div>
+              <ChevronRight className="shrink-0 text-slate-600" size={18} strokeWidth={2} />
+            </button>
+            <button type="button" className={`${rowBase} ${rowDivider}`}>
+              <RowIcon>
+                <Ban size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Self-exclusion</p>
+                <p className="mt-0.5 text-xs text-slate-500">Take a break from betting</p>
+              </div>
+              <ChevronRight className="shrink-0 text-slate-600" size={18} strokeWidth={2} />
+            </button>
+          </div>
+        </section>
+
+        {/* Privacy & preferences */}
+        <section>
+          <h3 className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+            <Shield size={12} className="text-slate-600" aria-hidden />
+            Privacy & preferences
+          </h3>
+          <div className={sectionShell}>
+            <div className={rowBase}>
+              <div className="min-w-0 flex-1 pl-1 sm:pl-0">
+                <p className="text-sm font-medium text-slate-200">Show activity to friends</p>
+                <p className="mt-0.5 text-xs text-slate-500">Your bets visible on social feed</p>
+              </div>
+              <div className="relative h-7 w-12 shrink-0 cursor-pointer rounded-full bg-blue-600">
+                <div className="absolute right-0.5 top-0.5 h-6 w-6 rounded-full bg-white shadow-sm ring-1 ring-black/5" />
+              </div>
+            </div>
+            <button type="button" className={`${rowBase} ${rowDivider}`}>
+              <RowIcon>
+                <Globe size={18} strokeWidth={2} />
+              </RowIcon>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-200">Currency & language</p>
+                <p className="mt-0.5 text-xs text-slate-500">USD • English</p>
+              </div>
+              <ChevronRight className="shrink-0 text-slate-600" size={18} strokeWidth={2} />
+            </button>
+          </div>
+        </section>
       </div>
+    </div>
   );
 };


### PR DESCRIPTION
Leaderboard: sortable columns (Rank, User, Net Worth, Win Rate, Trend); medals and displayed rank follow the active sort when not in default rank order.
Game search: in-memory Map keyed by Odds event id, merged on each successful tab load only—no extra API calls while typing.
Search haystack: title, subtitle, category, sport_key, and all option labels; multi-word queries use AND on tokens; league chip ignored during search.
Removed the slow chained-fetch search pool; clearer empty copy using cached game count.
“View All Games” only when row count ≥ VIEW_ALL_GAMES_VISIBLE_THRESHOLD in constants.
Markets default tab is ALL (upcoming) on first load instead of Football-only.
Sidebar: Home for /, Ticket for /bet.
Removed duplicate profile User nav icon; initials + log out on mobile (ml-auto / lg:mt-auto).
Popular: removed standalone Boosts row; kept Weekly Boosts + Promotions.
Weekly Boosts / Promotions headers use Ticket instead of chevrons (BoostsCard + dashboard).
App / dashboard props for search cache count and related cleanup.
Small UI consistency (icons, placeholders) with the above.

<img width="1581" height="880" alt="Screenshot 2026-05-04 185419" src="https://github.com/user-attachments/assets/d1750005-07c1-4ed6-b845-9ed427565a7b" />
<img width="1914" height="870" alt="Screenshot 2026-05-04 185427" src="https://github.com/user-attachments/assets/7343442f-a7f3-4c3b-b3f0-db394cbe72fe" />
<img width="1919" height="871" alt="Screenshot 2026-05-04 185434" src="https://github.com/user-attachments/assets/3c671918-3bb9-4f85-a3e6-2663430f061a" />
<img width="1235" height="295" alt="Screenshot 2026-05-04 185450" src="https://github.com/user-attachments/assets/ee069282-82ca-4976-bfa8-07c197d6982f" />
