### PR TITLE
Add mock NFL league flow with bet settlement

### DIFF
--- a/components/BetSlip.tsx
+++ b/components/BetSlip.tsx
@@ -35,6 +35,7 @@ export const BetSlip: React.FC<BetSlipProps> = ({
 
   const isSinglesEmpty = !selection;
   const isParlayEmpty = parlaySelections.length === 0;
+  const hasMinimumParlayLegs = parlaySelections.length >= 2;
   const stake = Number(stakeInput) || 0;
   const potentialPayout = selection ? stake * selection.option.odds : 0;
   const parlayPotentialPayout = stake * (parlaySelections.length ? parlaySelections.reduce((a, s) => a * s.option.odds, 1) : 0);
@@ -138,7 +139,7 @@ export const BetSlip: React.FC<BetSlipProps> = ({
 
   const hasAnyPick = !isSinglesEmpty || !isParlayEmpty;
   const singlesPlaceDisabled = isSinglesEmpty || !isAffordable || stake <= 0 || !!limitError;
-  const parlayPlaceDisabled  = isParlayEmpty  || !isAffordable || stake <= 0 || !!limitError;
+  const parlayPlaceDisabled  = !hasMinimumParlayLegs || !isAffordable || stake <= 0 || !!limitError;
   const tabLabels: Record<SlipTab, string> = { SINGLES: 'Singles', PARLAYS: 'Parlays' };
 
   const cardClass = 'rounded-xl border border-slate-800 bg-[#100d1f]';
@@ -395,6 +396,9 @@ export const BetSlip: React.FC<BetSlipProps> = ({
                   <LimitBanner />
                   {!isAffordable && (
                       <p className="text-red-400 text-[10px] mt-2 font-semibold">Insufficient funds</p>
+                  )}
+                  {!hasMinimumParlayLegs && (
+                      <p className="text-amber-300 text-[10px] mt-2 font-semibold">Add at least 2 legs to place a parlay.</p>
                   )}
                   <button
                       type="button"

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -50,8 +50,6 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
     return [...entries].sort(cmp);
   }, [entries, sortKey, sortDir]);
 
-  const isCanonicalRankOrder = sortKey === 'rank' && sortDir === 'asc';
-
   const SortHeader: React.FC<{
     label: string;
     colKey: SortKey;
@@ -119,7 +117,7 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
               </tr>
             ) : (
             sortedEntries.map((entry, idx) => {
-              const displayRank = isCanonicalRankOrder ? entry.rank : idx + 1;
+              const displayRank = sortKey === 'rank' ? entry.rank : idx + 1;
               return (
               <tr 
                 key={entry.id} 

--- a/models/constants.ts
+++ b/models/constants.ts
@@ -11,6 +11,26 @@ export const SPORT_TABS = ['ALL', 'Football', 'Basketball', 'Baseball', 'Hockey'
 /** Show “View All Games” only when the board already lists this many rows (avoids clutter for normal boards). */
 export const VIEW_ALL_GAMES_VISIBLE_THRESHOLD = 60;
 
+export const MOCK_NFL_TEAM_POOL = [
+  'Steelers',
+  'Eagles',
+  'Rams',
+  'Chiefs',
+  '49ers',
+  'Seahawks',
+  'Patriots',
+  'Bills',
+  'Broncos',
+  'Chargers',
+  'Lions',
+  'Bears',
+  'Ravens',
+  'Buccaneers',
+  'Commanders',
+  'Texans',
+  'Jaguars',
+] as const;
+
 export const FIREBASE_CONFIG = {
   apiKey: "AIzaSyCcgJVGV0L95RkcRZ-jqzFAepr3N73wewQ",
   authDomain: "seniorproject-ce9fe.firebaseapp.com",

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -547,6 +547,81 @@ export async function saveUserMockNflGames(uid: string, games: MockNflGameState[
     }, { merge: true });
 }
 
+/**
+ * Settles all pending bets for a finalized mock NFL game for one user.
+ * This reuses the existing settleBet() path so wallet + win/loss + history
+ * stay consistent with normal markets.
+ */
+export async function settleUserMockNflGameBets(
+    uid: string,
+    game: MockNflGameState,
+): Promise<void> {
+    if (!uid) return;
+    if (game.status !== "FINAL") return;
+    if (game.awayScore == null || game.homeScore == null) return;
+
+    const marketId = `mock-${game.id}`;
+    const pending = (await getBets(uid)).filter(
+        (b) => b.marketId === marketId && (b.status ?? "PENDING") === "PENDING",
+    );
+    if (pending.length === 0) return;
+
+    const awayTeam = game.awayTeam;
+    const homeTeam = game.homeTeam;
+    const awaySpreadLabel = `${awayTeam} ${game.spreadLine > 0 ? `+${game.spreadLine.toFixed(1)}` : game.spreadLine.toFixed(1)}`;
+    const homeSpread = -game.spreadLine;
+    const homeSpreadLabel = `${homeTeam} ${homeSpread > 0 ? `+${homeSpread.toFixed(1)}` : homeSpread.toFixed(1)}`;
+    const overLabel = `Over ${game.totalLine.toFixed(1)}`;
+    const underLabel = `Under ${game.totalLine.toFixed(1)}`;
+    const margin = game.awayScore - game.homeScore;
+    const totalScore = game.awayScore + game.homeScore;
+
+    const outcomeFor = (optionLabel: string): "WON" | "LOST" | "VOID" => {
+        const selected = optionLabel.trim();
+
+        // Moneyline
+        if (selected === awayTeam) {
+            if (game.awayScore === game.homeScore) return "VOID";
+            return game.awayScore > game.homeScore ? "WON" : "LOST";
+        }
+        if (selected === homeTeam) {
+            if (game.awayScore === game.homeScore) return "VOID";
+            return game.homeScore > game.awayScore ? "WON" : "LOST";
+        }
+
+        // Spread
+        if (selected === awaySpreadLabel) {
+            const result = margin + game.spreadLine;
+            if (result === 0) return "VOID";
+            return result > 0 ? "WON" : "LOST";
+        }
+        if (selected === homeSpreadLabel) {
+            const result = -margin - game.spreadLine;
+            if (result === 0) return "VOID";
+            return result > 0 ? "WON" : "LOST";
+        }
+
+        // Totals
+        if (selected === overLabel) {
+            if (totalScore === game.totalLine) return "VOID";
+            return totalScore > game.totalLine ? "WON" : "LOST";
+        }
+        if (selected === underLabel) {
+            if (totalScore === game.totalLine) return "VOID";
+            return totalScore < game.totalLine ? "WON" : "LOST";
+        }
+
+        // Unknown/legacy label for this mock market: void it safely.
+        return "VOID";
+    };
+
+    await Promise.all(
+        pending.map(async (bet) => {
+            await settleBet(bet, outcomeFor(bet.optionLabel));
+        }),
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────
 //  BETTING
 // ─────────────────────────────────────────────────────────────────
@@ -754,6 +829,70 @@ export async function getBets(uid: string): Promise<Bet[]> {
     });
 
     return betList;
+}
+
+/**
+ * Realtime subscription for one user's bets.
+ * Keeps local UI state in sync when bets are settled/updated server-side.
+ */
+export function subscribeToUserBets(
+    uid: string,
+    onUpdate: (bets: Bet[]) => void,
+    onError?: (err: Error) => void,
+): () => void {
+    if (!uid) {
+        onUpdate([]);
+        return () => {};
+    }
+
+    const q = query(collection(db, "bets"), where("userID", "==", uid));
+
+    return onSnapshot(
+        q,
+        (snapshot) => {
+            const betList: Bet[] = [];
+            snapshot.forEach((d) => {
+                const data = d.data();
+                const validBet: Bet = {
+                    id:              d.id,
+                    userID:          data.userID,
+                    marketId:        data.marketId,
+                    marketTitle:     data.marketTitle,
+                    optionLabel:     data.optionLabel,
+                    betType:         data.betType === "parlay" ? "parlay" : "single",
+                    stake:           data.stake,
+                    odds:            data.odds,
+                    potentialPayout: data.potentialPayout,
+                    placedAt:        data.placedAt?.toDate?.() ?? new Date(),
+                    legCount:        data.legCount ?? 1,
+                    parlayLegs: Array.isArray(data.parlayLegs)
+                        ? data.parlayLegs.map((leg: any): ParlayLeg => ({
+                            marketId:    String(leg.marketId    ?? ""),
+                            marketTitle: String(leg.marketTitle ?? ""),
+                            sportKey:    String(leg.sportKey    ?? ""),
+                            optionId:    String(leg.optionId    ?? ""),
+                            optionLabel: String(leg.optionLabel ?? ""),
+                            odds:        Number(leg.odds)        || 0,
+                            marketKey:   String(leg.marketKey   ?? "h2h"),
+                            result:      leg.result ?? "PENDING",
+                        }))
+                        : [],
+                    status:        (data.status   ?? "PENDING") as BetStatus,
+                    eventId:       data.eventId,
+                    sportKey:      data.sportKey,
+                    eventStartsAt: data.eventStartsAt?.toDate?.(),
+                    settledAt:     data.settledAt?.toDate?.(),
+                };
+                betList.push(validBet);
+            });
+            betList.sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime());
+            onUpdate(betList);
+        },
+        (err) => {
+            if (onError) onError(err);
+            else console.error("subscribeToUserBets failed", err);
+        },
+    );
 }
 
 /**

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -480,6 +480,74 @@ export async function setSpendingLimits(
 
 
 // ─────────────────────────────────────────────────────────────────
+//  MOCK NFL GAMES (PER USER)
+// ─────────────────────────────────────────────────────────────────
+
+export type MockNflWinner = "HOME" | "AWAY" | null;
+
+export interface MockNflGameState {
+    id: string;
+    week: number;
+    awayTeam: string;
+    homeTeam: string;
+    awayOdds: number;
+    homeOdds: number;
+    totalOverOdds: number;
+    totalUnderOdds: number;
+    spreadLine: number;
+    totalLine: number;
+    status: "UPCOMING" | "FINAL";
+    awayScore: number | null;
+    homeScore: number | null;
+    winner: MockNflWinner;
+    updatedAtMs: number;
+}
+
+export async function getUserMockNflGames(uid: string): Promise<MockNflGameState[]> {
+    if (!uid) return [];
+    const snap = await getDoc(doc(db, "userInfo", uid));
+    if (!snap.exists()) return [];
+    const data = snap.data();
+    const raw = data["mockNflGames"];
+    if (!Array.isArray(raw)) return [];
+
+    return raw
+        .map((row: any): MockNflGameState | null => {
+            if (!row || typeof row !== "object") return null;
+            const id = String(row.id ?? "");
+            const awayTeam = String(row.awayTeam ?? "");
+            const homeTeam = String(row.homeTeam ?? "");
+            if (!id || !awayTeam || !homeTeam) return null;
+            return {
+                id,
+                week: Math.min(18, Math.max(1, Number(row.week) || 1)),
+                awayTeam,
+                homeTeam,
+                awayOdds: Number(row.awayOdds) || 1.91,
+                homeOdds: Number(row.homeOdds) || 1.91,
+                totalOverOdds: Number(row.totalOverOdds) || 1.91,
+                totalUnderOdds: Number(row.totalUnderOdds) || 1.91,
+                spreadLine: Number(row.spreadLine) || 0,
+                totalLine: Number(row.totalLine) || 44.5,
+                status: row.status === "FINAL" ? "FINAL" : "UPCOMING",
+                awayScore: row.awayScore == null ? null : Number(row.awayScore) || 0,
+                homeScore: row.homeScore == null ? null : Number(row.homeScore) || 0,
+                winner: row.winner === "HOME" || row.winner === "AWAY" ? row.winner : null,
+                updatedAtMs: Number(row.updatedAtMs) || Date.now(),
+            };
+        })
+        .filter((row: MockNflGameState | null): row is MockNflGameState => row !== null);
+}
+
+export async function saveUserMockNflGames(uid: string, games: MockNflGameState[]): Promise<void> {
+    if (!uid) return;
+    await setDoc(doc(db, "userInfo", uid), {
+        mockNflGames: games,
+        mockNflUpdatedAt: Timestamp.now(),
+    }, { merge: true });
+}
+
+// ─────────────────────────────────────────────────────────────────
 //  BETTING
 // ─────────────────────────────────────────────────────────────────
 

--- a/viewModels/useBettingViewModel.ts
+++ b/viewModels/useBettingViewModel.ts
@@ -5,9 +5,9 @@ import {
   placeSingleBet,
   changeUserMoney,
   claimedDaily,
-  getBets,
   getUserMoney,
-  addBet, listenForChange,
+  listenForChange,
+  subscribeToUserBets,
 } from '@/services/dbOps';
 import { BoostType } from '@/services/dbOps';
 
@@ -49,15 +49,22 @@ export function useBettingViewModel() {
         setBalance(money);
       }
     });
-    getBets(uid).then((bets) => {
-      setActiveBets(bets);
-    }).catch(() => undefined);
+    const unsubBets = subscribeToUserBets(
+      uid,
+      (bets) => setActiveBets(bets),
+      () => undefined,
+    );
 
 
-    return listenForChange(uid, ({ money, hasDailyBonus }) => {
+    const unsubUserInfo = listenForChange(uid, ({ money, hasDailyBonus }) => {
       setBalance(money);
       setDailyBonusAvailable(hasDailyBonus);
     });
+
+    return () => {
+      unsubBets();
+      unsubUserInfo();
+    };
   }, [localStorage.getItem("userEmail")]);
 
   /**
@@ -73,6 +80,23 @@ export function useBettingViewModel() {
   ) => {
     console.log('handlePlaceBet called, activeBoost:', activeBoost);
     if (!betSelection || isPlacingBet) return;
+
+    // Defensive lock: mock markets are bettable only while UPCOMING.
+    // If a mock game finalized after selection but before checkout, remove it.
+    const isClosedMock = (m: Market) => m.sport_key === 'football_nfl_mock' && m.status === 'CLOSED';
+    if (isClosedMock(betSelection.market)) {
+      setParlaySelections((prev) =>
+        prev.filter((sel) => `${sel.market.id}:${sel.option.id}` !== `${betSelection.market.id}:${betSelection.option.id}`)
+      );
+      setBetSelection(null);
+      return;
+    }
+    const staleParlayMockLegs = parlaySelections.filter((sel) => isClosedMock(sel.market));
+    if (staleParlayMockLegs.length > 0) {
+      setParlaySelections((prev) => prev.filter((sel) => !isClosedMock(sel.market)));
+      if (isClosedMock(betSelection.market)) setBetSelection(null);
+      return;
+    }
 
     const uid = localStorage.getItem('uid');
     if (!uid) return;

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -45,6 +45,7 @@ function defaultSportTab(): string {
  * Search is in-memory only: each successful tab load merges into a deduped cache (zero extra API calls).
  */
 export function useMarketsViewModel() {
+  const MOCK_NFL_LEAGUE = 'NFL';
   const initialSport = defaultSportTab();
   const [markets, setMarkets] = useState<Market[]>([]);
   const [loading, setLoading] = useState(false);
@@ -83,7 +84,11 @@ export function useMarketsViewModel() {
   const handleSportFilter = useCallback(
     (sport: string) => {
       setSportFilter(sport);
-      setLeagueFilter('ALL');
+      if (sport === 'Football') {
+        setLeagueFilter(MOCK_NFL_LEAGUE);
+      } else {
+        setLeagueFilter('ALL');
+      }
       void loadMarkets(sport);
     },
     [loadMarkets]

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -39,7 +39,7 @@ import { Swords, ShoppingBag } from 'lucide-react';
 import type { LeaderboardEntry, Friend, SocialActivity } from '../models';
 import { BoostType } from '@/services/dbOps.ts';
 import { DAILY_BONUS_AMOUNT, MOCK_NFL_TEAM_POOL, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
-import { FriendRequest, getBets, getUserMoney, getUserMockNflGames, listenForChange, saveUserMockNflGames } from "@/services/dbOps.ts";
+import { FriendRequest, getBets, getUserMoney, getUserMockNflGames, listenForChange, saveUserMockNflGames, settleUserMockNflGameBets } from "@/services/dbOps.ts";
 import type { MockNflGameState } from "@/services/dbOps.ts";
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
@@ -249,6 +249,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   }, [userUid]);
 
   const simulateMockGame = async (gameId: string, mode: 'RANDOM' | 'AWAY' | 'HOME') => {
+    let finalizedGame: MockNflGameState | null = null;
     const next = mockNflGames.map((g) => {
       if (g.id !== gameId) return g;
       const awayBase = Math.floor(randomBetween(7, 38));
@@ -271,11 +272,15 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
         winner,
         updatedAtMs: Date.now(),
       };
+      finalizedGame = finalized;
       return finalized;
     });
     setMockNflGames(next);
     if (userUid) {
       await saveUserMockNflGames(userUid, next);
+      if (finalizedGame) {
+        await settleUserMockNflGameBets(userUid, finalizedGame);
+      }
     }
   };
 
@@ -500,8 +505,14 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       const key = `${m.category}||${m.subtitle}`;
       if (!seen.has(key)) seen.set(key, { league: m.subtitle, sport: m.category });
     }
-    return Array.from(seen.values()).sort((a, b) => a.league.localeCompare(b.league));
+    const rows = Array.from(seen.values()).sort((a, b) => a.league.localeCompare(b.league));
+    const hasNflRow = rows.some((r) => r.sport === 'Football' && r.league.toLowerCase() === 'nfl');
+    if (sportFilter === 'Football' && !hasNflRow) {
+      rows.unshift({ sport: 'Football', league: 'NFL' });
+    }
+    return rows;
   })();
+  const footballApiLeagues = leagueNavRows.filter((r) => r.sport === 'Football' && r.league.toLowerCase() !== 'nfl');
 
   const safeBalance = Number.isFinite(balance) ? balance : 0;
   const displayBalance = `$${Math.max(0, safeBalance).toFixed(2)}`;
@@ -619,9 +630,10 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
         );
       case 'MARKETS':
       default:
-        const showMockNflBoard =
-          sportFilter === 'Football' &&
-          (leagueFilter === 'ALL' || leagueFilter.toLowerCase().includes('nfl'));
+        const showMockNflBoard = sportFilter === 'Football' && leagueFilter.toLowerCase() === 'nfl';
+        const showApiMarketsTable = !(sportFilter === 'Football' && leagueFilter.toLowerCase() === 'nfl');
+        const showLoadingState = loading && !showMockNflBoard;
+        const showErrorState = Boolean(error) && !showMockNflBoard;
         return (
             <>
               <div className="grid grid-cols-1 xl:grid-cols-[220px_minmax(0,1fr)] gap-5">
@@ -640,7 +652,13 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         <button
                             key={`tile-${tab}`}
                             type="button"
-                            onClick={() => onSportFilter(tab)}
+                            onClick={() => {
+                              if (tab === 'Football') {
+                                onSelectLeagueInSport('Football', 'NFL');
+                                return;
+                              }
+                              onSportFilter(tab);
+                            }}
                             title={tab}
                             className={`market-top-pill rounded-lg border p-2 flex items-center justify-center text-[10px] font-black transition-all ${
                                 sportPrimarySelected
@@ -777,7 +795,13 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               .map((tab) => (
                                   <button
                                       key={`trend-tab-${tab}`}
-                                      onClick={() => onSportFilter(tab)}
+                                      onClick={() => {
+                                        if (tab === 'Football') {
+                                          onSelectLeagueInSport('Football', 'NFL');
+                                          return;
+                                        }
+                                        onSportFilter(tab);
+                                      }}
                                       className={`shrink-0 inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-bold transition-all ${
                                           sportFilter === tab
                                               ? 'border-violet-400/80 bg-violet-500/20 text-violet-200'
@@ -810,12 +834,12 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                           Pick a sport tab in the sidebar or trending row. We only fetch odds after you select a filter.
                         </p>
                       </div>
-                  ) : loading ? (
+                  ) : showLoadingState ? (
                       <div className="flex flex-col items-center justify-center py-20 gap-4">
                         <Loader2 className="text-blue-400 animate-spin" size={48} />
                         <p className="text-slate-400">Loading live odds...</p>
                       </div>
-                  ) : error ? (
+                  ) : showErrorState ? (
                       <div className="glass-card rounded-2xl p-8 text-center border-red-500/20">
                         <AlertCircle className="mx-auto text-red-400 mb-4" size={48} />
                         <h3 className="text-xl font-bold text-slate-200 mb-2">Couldn&apos;t load odds</h3>
@@ -841,6 +865,23 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                 <span className="text-xs text-slate-300">Simulate outcomes and place test bets</span>
                               </div>
                             </div>
+                            {footballApiLeagues.length > 0 && (
+                              <div className="mb-3 rounded-md border border-slate-700/80 bg-slate-900/70 px-2.5 py-2">
+                                <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1">NCAA Football (API)</p>
+                                <div className="flex flex-wrap gap-1.5">
+                                  {footballApiLeagues.slice(0, 4).map((row) => (
+                                    <button
+                                      key={`ncaa-widget-${row.league}`}
+                                      type="button"
+                                      onClick={() => onSelectLeagueInSport('Football', row.league)}
+                                      className="rounded-md border border-slate-700 bg-slate-800 px-2 py-1 text-[10px] font-semibold text-slate-200 hover:border-blue-500/70 hover:text-blue-200"
+                                    >
+                                      {row.league}
+                                    </button>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
                             <div className="space-y-2">
                               {mockNflGames.map((game) => (
                                 <div key={game.id} className="grid grid-cols-[minmax(230px,1.2fr)_repeat(3,minmax(140px,0.7fr))] items-stretch gap-2 rounded-lg border border-amber-400/25 bg-slate-900/70 p-2.5">
@@ -854,6 +895,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                     const mlHome = mockMarket.options[5];
                                     const bettable = game.status !== 'FINAL';
                                     const mockBetOutcome = resolveMockBetOutcome(game);
+                                    const latestMockBet = getLatestUserMockBet(game.id);
                                     const finalCardTone =
                                       mockBetOutcome === 'WON'
                                         ? 'border-emerald-500/30 bg-emerald-500/10'
@@ -901,6 +943,11 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                             <p className={`font-semibold ${finalTextTone}`}>
                                               Winner: {game.winner === 'AWAY' ? game.awayTeam : game.homeTeam}
                                             </p>
+                                            {latestMockBet && (
+                                              <p className={`mt-1 ${finalTextTone}`}>
+                                                Spent: ${latestMockBet.stake.toFixed(2)} • To win: ${latestMockBet.potentialPayout.toFixed(2)}
+                                              </p>
+                                            )}
                                           </div>
                                           <button
                                             type="button"
@@ -1005,6 +1052,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                             </div>
                           </div>
                         )}
+                        {showApiMarketsTable && (
+                          <>
                         <div className="grid grid-cols-[minmax(230px,1.2fr)_repeat(3,minmax(140px,0.7fr))] bg-slate-900/75 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
                           <div>Game</div>
                           <div className="text-center">Spread</div>
@@ -1102,6 +1151,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                       : `No ${sportFilter} games at the moment. Try another sport.`}
                               </p>
                             </div>
+                        )}
+                          </>
                         )}
                       </div>
                   )}

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -23,7 +23,7 @@ import {
   LayoutGrid,
   CircleDot,
 } from 'lucide-react';
-import type { Market, MarketOption, Bet } from '../models';
+import { MarketType, type Market, type MarketOption, type Bet } from '../models';
 import { BetSlip } from '../components/BetSlip';
 import { Leaderboard } from '../components/Leaderboard';
 import { SocialView } from '../components/SocialView';
@@ -38,8 +38,9 @@ import { StoreView } from './StoreView';
 import { Swords, ShoppingBag } from 'lucide-react';
 import type { LeaderboardEntry, Friend, SocialActivity } from '../models';
 import { BoostType } from '@/services/dbOps.ts';
-import { DAILY_BONUS_AMOUNT, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
-import {FriendRequest, getBets, getUserMoney, listenForChange} from "@/services/dbOps.ts";
+import { DAILY_BONUS_AMOUNT, MOCK_NFL_TEAM_POOL, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
+import { FriendRequest, getBets, getUserMoney, getUserMockNflGames, listenForChange, saveUserMockNflGames } from "@/services/dbOps.ts";
+import type { MockNflGameState } from "@/services/dbOps.ts";
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
 
@@ -168,11 +169,147 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const view = pathToView(location.pathname);
   const isLightMode = themeMode === 'light';
   const [promotionsOpen, setPromotionsOpen] = useState(false);
+  const [mockNflGames, setMockNflGames] = useState<MockNflGameState[]>([]);
+
+  const userUid = typeof localStorage !== 'undefined' ? localStorage.getItem('uid') ?? '' : '';
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
     document.documentElement.dataset.theme = isLightMode ? 'light' : 'ocean';
   }, [isLightMode]);
+
+  const normalizeSpreadLine = (line: number) => (line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1));
+  const pickRandom = <T,>(items: readonly T[]) => items[Math.floor(Math.random() * items.length)];
+  const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+  const decimalOdds = () => Number(randomBetween(1.72, 2.25).toFixed(2));
+  const randomWeek = () => Math.floor(randomBetween(1, 19));
+
+  const makeMockGame = (idPrefix: string, previous?: MockNflGameState): MockNflGameState => {
+    const teamPool = MOCK_NFL_TEAM_POOL;
+    const shouldFlip = Boolean(previous) && Math.random() < 0.5;
+    const awayTeam = shouldFlip && previous ? previous.homeTeam : pickRandom(teamPool);
+    let homeTeam = shouldFlip && previous ? previous.awayTeam : pickRandom(teamPool);
+    let guard = 0;
+    while (homeTeam === awayTeam && guard < 10) {
+      homeTeam = pickRandom(teamPool);
+      guard += 1;
+    }
+
+    const spreadMag = Number(randomBetween(1.5, 7.5).toFixed(1));
+    const awayFavored = Math.random() < 0.5;
+    const spreadLine = awayFavored ? -spreadMag : spreadMag;
+    return {
+      id: `${idPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      week: randomWeek(),
+      awayTeam,
+      homeTeam,
+      awayOdds: decimalOdds(),
+      homeOdds: decimalOdds(),
+      totalOverOdds: decimalOdds(),
+      totalUnderOdds: decimalOdds(),
+      spreadLine,
+      totalLine: Number(randomBetween(39.5, 53.5).toFixed(1)),
+      status: 'UPCOMING',
+      awayScore: null,
+      homeScore: null,
+      winner: null,
+      updatedAtMs: Date.now(),
+    };
+  };
+
+  const ensureMockBoard = (existing: MockNflGameState[]): MockNflGameState[] => {
+    const upcoming = existing.filter((g) => g.status !== 'FINAL');
+    const seeded = [...upcoming];
+    while (seeded.length < 3) {
+      seeded.push(makeMockGame('mock-nfl', seeded[seeded.length - 1]));
+    }
+    return seeded.slice(0, 3);
+  };
+
+  useEffect(() => {
+    if (!userUid) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const stored = await getUserMockNflGames(userUid);
+        if (cancelled) return;
+        const board = ensureMockBoard(stored);
+        setMockNflGames(board);
+        await saveUserMockNflGames(userUid, board);
+      } catch (err) {
+        console.error('Failed to load mock NFL games', err);
+        if (cancelled) return;
+        const board = ensureMockBoard([]);
+        setMockNflGames(board);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userUid]);
+
+  const simulateMockGame = async (gameId: string, mode: 'RANDOM' | 'AWAY' | 'HOME') => {
+    const next = mockNflGames.map((g) => {
+      if (g.id !== gameId) return g;
+      const awayBase = Math.floor(randomBetween(7, 38));
+      const homeBase = Math.floor(randomBetween(7, 38));
+      let awayScore = awayBase;
+      let homeScore = homeBase;
+      if (mode === 'AWAY') {
+        awayScore = Math.max(awayBase, homeBase + 1);
+      } else if (mode === 'HOME') {
+        homeScore = Math.max(homeBase, awayBase + 1);
+      } else if (awayScore === homeScore) {
+        homeScore += 1;
+      }
+      const winner = awayScore > homeScore ? 'AWAY' : 'HOME';
+      const finalized = {
+        ...g,
+        status: 'FINAL' as const,
+        awayScore,
+        homeScore,
+        winner,
+        updatedAtMs: Date.now(),
+      };
+      return finalized;
+    });
+    setMockNflGames(next);
+    if (userUid) {
+      await saveUserMockNflGames(userUid, next);
+    }
+  };
+
+  const createNewMockGame = async (gameId: string) => {
+    const next = mockNflGames.map((g) => {
+      if (g.id !== gameId) return g;
+      return makeMockGame('mock-nfl', g);
+    });
+    setMockNflGames(next);
+    if (userUid) {
+      await saveUserMockNflGames(userUid, next);
+    }
+  };
+
+  useEffect(() => {
+    if (mockNflGames.length === 0) return;
+    const finalizedMockMarketIds = new Set(
+      mockNflGames
+        .filter((g) => g.status === 'FINAL')
+        .map((g) => `mock-${g.id}`),
+    );
+    if (finalizedMockMarketIds.size === 0) return;
+
+    // Remove any finalized mock legs from active selection state so users
+    // cannot place singles/parlays on games that already ended.
+    const staleSelections = parlaySelections.filter((sel) => finalizedMockMarketIds.has(sel.market.id));
+    for (const stale of staleSelections) {
+      onSelectBet(stale.market, stale.option);
+    }
+
+    if (betSelection && finalizedMockMarketIds.has(betSelection.market.id)) {
+      onSelectBet(betSelection.market, betSelection.option);
+    }
+  }, [mockNflGames, parlaySelections, betSelection, onSelectBet]);
 
   // ── Boost state — lives here so BetSlip and BoostsCard share it ─
   const [activeBoost, setActiveBoost] = useState<BoostType | null>(null);
@@ -204,6 +341,72 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       return { label: `Started ${time}`, tone: 'live' as const };
     }
     return { label: time, tone: 'upcoming' as const };
+  };
+
+  const mockMarketForGame = (game: MockNflGameState): Market => ({
+    id: `mock-${game.id}`,
+    sport_key: 'football_nfl_mock',
+    title: `${game.awayTeam} @ ${game.homeTeam}`,
+    subtitle: 'NFL',
+    category: 'Football',
+    type: MarketType.SPORTS,
+    startTime: new Date(game.updatedAtMs).toISOString(),
+    status: game.status === 'FINAL' ? 'CLOSED' : 'UPCOMING',
+    options: [
+      { id: `${game.id}-spread-away`, label: `${game.awayTeam} ${normalizeSpreadLine(game.spreadLine)}`, odds: game.awayOdds, marketKey: 'spreads' },
+      { id: `${game.id}-spread-home`, label: `${game.homeTeam} ${normalizeSpreadLine(-game.spreadLine)}`, odds: game.homeOdds, marketKey: 'spreads' },
+      { id: `${game.id}-total-over`, label: `Over ${game.totalLine.toFixed(1)}`, odds: game.totalOverOdds, marketKey: 'totals' },
+      { id: `${game.id}-total-under`, label: `Under ${game.totalLine.toFixed(1)}`, odds: game.totalUnderOdds, marketKey: 'totals' },
+      { id: `${game.id}-ml-away`, label: game.awayTeam, odds: game.awayOdds, marketKey: 'h2h' },
+      { id: `${game.id}-ml-home`, label: game.homeTeam, odds: game.homeOdds, marketKey: 'h2h' },
+    ],
+  });
+
+  const isMockOptionSelected = (gameId: string, optionId: string) =>
+    parlaySelections.some((sel) => sel.market.id === `mock-${gameId}` && sel.option.id === optionId);
+
+  const getLatestUserMockBet = (gameId: string): Bet | null => {
+    const marketId = `mock-${gameId}`;
+    const matching = props.activeBets.filter((b) => b.marketId === marketId && (b.betType ?? 'single') === 'single');
+    if (matching.length === 0) return null;
+    const sorted = [...matching].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime());
+    return sorted[0] ?? null;
+  };
+
+  const resolveMockBetOutcome = (game: MockNflGameState): 'WON' | 'LOST' | 'PUSH' | 'NONE' => {
+    if (game.status !== 'FINAL' || game.awayScore == null || game.homeScore == null) return 'NONE';
+    const bet = getLatestUserMockBet(game.id);
+    if (!bet) return 'NONE';
+
+    const awaySpreadLabel = `${game.awayTeam} ${normalizeSpreadLine(game.spreadLine)}`;
+    const homeSpreadLabel = `${game.homeTeam} ${normalizeSpreadLine(-game.spreadLine)}`;
+    const overLabel = `Over ${game.totalLine.toFixed(1)}`;
+    const underLabel = `Under ${game.totalLine.toFixed(1)}`;
+    const margin = game.awayScore - game.homeScore;
+    const totalScore = game.awayScore + game.homeScore;
+    const selected = bet.optionLabel.trim();
+
+    if (selected === game.awayTeam) return game.awayScore > game.homeScore ? 'WON' : 'LOST';
+    if (selected === game.homeTeam) return game.homeScore > game.awayScore ? 'WON' : 'LOST';
+    if (selected === awaySpreadLabel) {
+      const spreadResult = margin + game.spreadLine;
+      if (spreadResult === 0) return 'PUSH';
+      return spreadResult > 0 ? 'WON' : 'LOST';
+    }
+    if (selected === homeSpreadLabel) {
+      const spreadResult = -margin - game.spreadLine;
+      if (spreadResult === 0) return 'PUSH';
+      return spreadResult > 0 ? 'WON' : 'LOST';
+    }
+    if (selected === overLabel) {
+      if (totalScore === game.totalLine) return 'PUSH';
+      return totalScore > game.totalLine ? 'WON' : 'LOST';
+    }
+    if (selected === underLabel) {
+      if (totalScore === game.totalLine) return 'PUSH';
+      return totalScore < game.totalLine ? 'WON' : 'LOST';
+    }
+    return 'NONE';
   };
 
   /** Small league tiles in the sidebar; falls back to initials when unknown. */
@@ -416,6 +619,9 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
         );
       case 'MARKETS':
       default:
+        const showMockNflBoard =
+          sportFilter === 'Football' &&
+          (leagueFilter === 'ALL' || leagueFilter.toLowerCase().includes('nfl'));
         return (
             <>
               <div className="grid grid-cols-1 xl:grid-cols-[220px_minmax(0,1fr)] gap-5">
@@ -625,6 +831,180 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                       </div>
                   ) : (
                       <div className="overflow-hidden rounded-xl border border-slate-800/90 bg-slate-950/35">
+                        {showMockNflBoard && (
+                          <div className="border-b border-slate-800/90 bg-gradient-to-r from-amber-500/10 via-slate-900/80 to-amber-500/10 px-4 py-3">
+                            <div className="mb-3 flex items-center justify-between">
+                              <div className="inline-flex items-center gap-2">
+                                <span className="inline-flex rounded-full border border-amber-400/50 bg-amber-500/20 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-amber-200">
+                                  Mock NFL
+                                </span>
+                                <span className="text-xs text-slate-300">Simulate outcomes and place test bets</span>
+                              </div>
+                            </div>
+                            <div className="space-y-2">
+                              {mockNflGames.map((game) => (
+                                <div key={game.id} className="grid grid-cols-[minmax(230px,1.2fr)_repeat(3,minmax(140px,0.7fr))] items-stretch gap-2 rounded-lg border border-amber-400/25 bg-slate-900/70 p-2.5">
+                                  {(() => {
+                                    const mockMarket = mockMarketForGame(game);
+                                    const spreadAway = mockMarket.options[0];
+                                    const spreadHome = mockMarket.options[1];
+                                    const totalOver = mockMarket.options[2];
+                                    const totalUnder = mockMarket.options[3];
+                                    const mlAway = mockMarket.options[4];
+                                    const mlHome = mockMarket.options[5];
+                                    const bettable = game.status !== 'FINAL';
+                                    const mockBetOutcome = resolveMockBetOutcome(game);
+                                    const finalCardTone =
+                                      mockBetOutcome === 'WON'
+                                        ? 'border-emerald-500/30 bg-emerald-500/10'
+                                        : mockBetOutcome === 'LOST'
+                                          ? 'border-red-500/30 bg-red-500/10'
+                                          : 'border-slate-700/90 bg-slate-900/95';
+                                    const finalTextTone =
+                                      mockBetOutcome === 'WON'
+                                        ? 'text-emerald-300'
+                                        : mockBetOutcome === 'LOST'
+                                          ? 'text-red-300'
+                                          : 'text-slate-300';
+                                    return (
+                                      <>
+                                  <div className="pr-2">
+                                    <p className="text-[10px] font-bold uppercase tracking-wider text-slate-400">NFL • Week {game.week}</p>
+                                    <div className="mt-1 space-y-0.5">
+                                      <p className="text-sm font-semibold text-amber-300">
+                                        {game.awayTeam} <span className="text-amber-200/80">@</span> {game.homeTeam}
+                                      </p>
+                                      {game.status === 'FINAL' && (
+                                        <p className="text-[12px] text-slate-300">
+                                          <span className={game.winner === 'AWAY' ? 'font-semibold text-emerald-300' : 'text-slate-400'}>
+                                            {game.awayTeam} {game.awayScore}
+                                          </span>
+                                          <span className="mx-1.5 text-slate-500">|</span>
+                                          <span className={game.winner === 'HOME' ? 'font-semibold text-emerald-300' : 'text-slate-400'}>
+                                            {game.homeTeam} {game.homeScore}
+                                          </span>
+                                        </p>
+                                      )}
+                                    </div>
+                                    <p className="mt-2 text-[11px] text-slate-400">
+                                      Odds {game.awayOdds.toFixed(2)} / {game.homeOdds.toFixed(2)}
+                                    </p>
+                                    <div className="mt-2 space-y-1">
+                                      {game.status === 'FINAL' ? (
+                                        <>
+                                          <div className={`rounded-md border px-2 py-1.5 text-[10px] ${finalCardTone}`}>
+                                            <p className={`font-bold uppercase tracking-wider ${finalTextTone}`}>
+                                              Final
+                                              {mockBetOutcome !== 'NONE' ? ` • ${mockBetOutcome}` : ''}
+                                            </p>
+                                            <p className={finalTextTone}>{game.awayScore} - {game.homeScore}</p>
+                                            <p className={`font-semibold ${finalTextTone}`}>
+                                              Winner: {game.winner === 'AWAY' ? game.awayTeam : game.homeTeam}
+                                            </p>
+                                          </div>
+                                          <button
+                                            type="button"
+                                            onClick={() => void createNewMockGame(game.id)}
+                                            className="w-full rounded-md border border-emerald-400/50 bg-emerald-500/20 px-2 py-1.5 text-[10px] font-semibold text-emerald-100 hover:bg-emerald-500/30"
+                                          >
+                                            Create New Game
+                                          </button>
+                                        </>
+                                      ) : (
+                                        <div className="grid grid-cols-3 gap-1">
+                                          <button
+                                            type="button"
+                                            onClick={() => void simulateMockGame(game.id, 'RANDOM')}
+                                            className="rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-[10px] font-semibold text-slate-200 hover:border-amber-400/70 hover:text-amber-200"
+                                          >
+                                            Random
+                                          </button>
+                                          <button
+                                            type="button"
+                                            onClick={() => void simulateMockGame(game.id, 'AWAY')}
+                                            className="rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-[10px] font-semibold text-slate-200 hover:border-amber-400/70 hover:text-amber-200"
+                                          >
+                                            Away Win
+                                          </button>
+                                          <button
+                                            type="button"
+                                            onClick={() => void simulateMockGame(game.id, 'HOME')}
+                                            className="rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-[10px] font-semibold text-slate-200 hover:border-amber-400/70 hover:text-amber-200"
+                                          >
+                                            Home Win
+                                          </button>
+                                        </div>
+                                      )}
+                                    </div>
+                                  </div>
+
+                                  <div className="flex flex-col justify-center gap-1">
+                                    <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 text-center">Spread</p>
+                                    {[spreadAway, spreadHome].map((opt) => (
+                                      <button
+                                        key={opt.id}
+                                        type="button"
+                                        disabled={!bettable}
+                                        onClick={() => onSelectBet(mockMarket, opt)}
+                                        className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
+                                          isMockOptionSelected(game.id, opt.id)
+                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                        } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
+                                      >
+                                        <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                      </button>
+                                    ))}
+                                  </div>
+
+                                  <div className="flex flex-col justify-center gap-1">
+                                    <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 text-center">Total</p>
+                                    {[totalOver, totalUnder].map((opt) => (
+                                      <button
+                                        key={opt.id}
+                                        type="button"
+                                        disabled={!bettable}
+                                        onClick={() => onSelectBet(mockMarket, opt)}
+                                        className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
+                                          isMockOptionSelected(game.id, opt.id)
+                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                        } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
+                                      >
+                                        <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                      </button>
+                                    ))}
+                                  </div>
+
+                                  <div className="flex flex-col justify-center gap-1">
+                                    <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 text-center">Winner</p>
+                                    {[mlAway, mlHome].map((opt) => (
+                                      <button
+                                        key={opt.id}
+                                        type="button"
+                                        disabled={!bettable}
+                                        onClick={() => onSelectBet(mockMarket, opt)}
+                                        className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
+                                          isMockOptionSelected(game.id, opt.id)
+                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                        } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
+                                      >
+                                        <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                      </button>
+                                    ))}
+                                  </div>
+                                      </>
+                                    );
+                                  })()}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
                         <div className="grid grid-cols-[minmax(230px,1.2fr)_repeat(3,minmax(140px,0.7fr))] bg-slate-900/75 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
                           <div>Game</div>
                           <div className="text-center">Spread</div>
@@ -671,8 +1051,9 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         <span>{market.subtitle}</span>
                                       </p>
                                       <div className="space-y-1">
-                                        <p className="text-sm font-semibold text-slate-100 leading-tight">{teams.away}</p>
-                                        <p className="text-sm font-semibold text-slate-200 leading-tight">{teams.home}</p>
+                                        <p className="text-sm font-semibold text-slate-100 leading-tight">
+                                          {teams.away} <span className="text-slate-400">@</span> {teams.home}
+                                        </p>
                                       </div>
                                     </div>
 


### PR DESCRIPTION
## Summary
- Added mock NFL team pool (top half of all teams) for realistic rotating matchups.
- Added per-user mock NFL game state in Firestore user docs. did not touch existing DB that worked.
- Added 3 always-available mock NFL games with randomized teams/odds/spread/total/week.
- Added simulation controls (`Random`, `Away Win`, `Home Win`) for fast game finalization during demos.
- Added manual `Create New Game` flow so finalized mock games stay visible until regenerated.
- Added final-game UI states with winner highlighting and clearer finalized-game feedback.
- Added result-color mapping based on user outcome (green won, red lost, neutral no matched bet).
- Added final widget money details (`Spent` and `To win`) sourced from the user’s mock bet.
- Made mock spread/total/winner tiles fully selectable through the existing betslip flow.
- Added checkout protection to remove finalized mock selections from singles/parlays before placement.
- Added backend helper to settle finalized mock bets via existing `settleBet` architecture.
- Added realtime user-bet subscription so history/status updates immediately after settlement.
- Updated football UX to auto-select NFL as the default football league.
- Added NCAA football API mini-widget while keeping NFL as mock-only in the football view.
- Suppressed Odds API loading/error panels for NFL mock league so quota errors do not block mock usage.
<img width="1200" height="677" alt="Screenshot 2026-05-05 022748" src="https://github.com/user-attachments/assets/52b6e80d-cfe9-4b39-8d2a-a49a3f7bdffa" />
<img width="1673" height="612" alt="Screenshot 2026-05-05 022821" src="https://github.com/user-attachments/assets/6e72219b-bab0-417f-8630-e0a19124dcce" />

## Test plan
- [ ] Select Football and confirm NFL auto-selects.
- [ ] Confirm NFL mock board renders without API error banner.
- [ ] Place a single mock bet and verify it appears in betslip/history.
- [ ] Place a 2+ leg parlay and verify parlay placement behavior.
- [ ] Confirm 1-leg parlay cannot be placed and shows helper text.
- [ ] Simulate mock game final and verify pending mock bets settle automatically.
- [ ] Verify finalized mock selection is removed from checkout state.
- [ ] Verify final card color reflects user outcome and shows spent/to-win values.
- [ ] Verify `Create New Game` regenerates matchup and odds cleanly.