### PR TITLE
Peer betting, mock NFL, bet slip & parlays, social DMs, leaderboard — merge to main

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -73,6 +73,7 @@ const App: React.FC = () => {
         onPlaceBet={dashboard.betting.handlePlaceBet}
         onClearBet={dashboard.betting.clearBetSelection}
         onSelectBet={dashboard.betting.selectBet}
+        onFocusQueuedSelection={dashboard.betting.focusQueuedSelection}
         onDailyBonus={dashboard.betting.handleDailyBonus}
         onLogout={dashboard.auth.logout}
         onSetView={dashboard.setView}

--- a/App.tsx
+++ b/App.tsx
@@ -82,7 +82,6 @@ const App: React.FC = () => {
         onLeagueFilter={dashboard.markets.setLeagueFilter}
         onSearchChange={dashboard.markets.setSearchQuery}
         onRetryMarkets={dashboard.markets.loadMarkets}
-        onChallenge={dashboard.handleChallenge}
         themeMode={dashboard.themeMode}
         themeSaving={dashboard.themeSaving}
         onThemeModeChange={dashboard.updateThemeMode}

--- a/components/BetSlip.tsx
+++ b/components/BetSlip.tsx
@@ -1,16 +1,20 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Bet, Market, MarketOption } from '../models';
-import { Trash2, X, Minus, TrendingUp, RefreshCcw, AlertCircle } from 'lucide-react';
+import { X, TrendingUp, RefreshCcw, AlertCircle, Info, Wallet, History, CornerDownRight } from 'lucide-react';
 import { BoostType } from '@/services/dbOps.ts';
-import { computeParlayRollup } from '@/services/parlayRollup';
 
-type SlipTab = 'SINGLES' | 'PARLAYS';
+type SlipTab = 'SINGLES' | 'PARLAYS' | 'ACTIVE';
+type ActivePendingFilter = 'ALL' | 'SINGLES' | 'PARLAYS';
 
 interface BetSlipProps {
   selection: { market: Market; option: MarketOption } | null;
   parlaySelections: Array<{ market: Market; option: MarketOption }>;
   activeBets: Bet[];
-  onPlaceBet: (stake: number, betType?: 'single' | 'parlay') => void;
+  onPlaceBet: (
+    stake: number,
+    betType?: 'single' | 'parlay',
+    singleTarget?: { market: Market; option: MarketOption } | null,
+  ) => void;
   onClose: () => void;
   onClear: () => void;
   onSelectBet: (market: Market, option: MarketOption) => void;
@@ -24,44 +28,49 @@ interface BetSlipProps {
    *  `limitError` so it does NOT disable the place-bet button — the user
    *  may still have a valid parlay queued up. */
   parlayRuleError?: string | null;
-  /** Click handler for the "View all" link in the Recent Bets card header.
-   *  Wired by the parent to react-router navigate('/history'). Optional so
-   *  the BetSlip stays usable in screens where /history isn't reachable. */
-  onViewAllHistory?: () => void;
+  /** Paper slip in light theme; dark chrome when app uses ocean theme. */
+  isLightMode?: boolean;
+  /** Active tab: open full betting history (e.g. react-router `navigate('/history')`). */
+  onGoToHistory?: () => void;
 }
 
 export const BetSlip: React.FC<BetSlipProps> = ({
-                                                  selection,
-                                                  parlaySelections,
-                                                  activeBets,
-                                                  onPlaceBet,
-                                                  onClose,
-                                                  onClear,
-                                                  onSelectBet,
-                                                  onFocusSelection,
-                                                  balance,
-                                                  activeBoost,
-                                                  limitError,
-                                                  parlayRuleError,
-                                                  onViewAllHistory,
-                                                }) => {
+  selection,
+  parlaySelections,
+  activeBets,
+  onPlaceBet,
+  onClose,
+  onClear,
+  onSelectBet,
+  onFocusSelection,
+  balance,
+  activeBoost,
+  limitError,
+  parlayRuleError,
+  isLightMode = true,
+  onGoToHistory,
+}) => {
   const [stakeInput, setStakeInput] = useState<string>('20');
+  /** Per-queued-pick stake on Singles tab (each pick is its own ticket). */
+  const [singleStakes, setSingleStakes] = useState<Record<string, string>>({});
   const [tab, setTab] = useState<SlipTab>('SINGLES');
+  const [activePendingFilter, setActivePendingFilter] = useState<ActivePendingFilter>('ALL');
   const [expandedParlays, setExpandedParlays] = useState<Record<string, boolean>>({});
   const previousParlayCount = useRef(0);
   const previousSelectionKey = useRef<string | null>(null);
 
-  const isSinglesEmpty = !selection;
-  const isParlayEmpty = parlaySelections.length === 0;
+  const isQueueEmpty = parlaySelections.length === 0;
   const hasMinimumParlayLegs = parlaySelections.length >= 2;
   const stake = Number(stakeInput) || 0;
   const potentialPayout = selection ? stake * selection.option.odds : 0;
-  const parlayPotentialPayout = stake * (parlaySelections.length ? parlaySelections.reduce((a, s) => a * s.option.odds, 1) : 0);
+  const parlayPotentialPayout =
+    parlaySelections.length > 0
+      ? stake * parlaySelections.reduce((a, s) => a * s.option.odds, 1)
+      : 0;
   const isAffordable = stake <= balance;
-  // "Current" = still pending (game hasn't finalized yet). As soon as a bet
-  // settles via the realtime onSnapshot listener we want it OUT of the
-  // current section so the user sees a live transition from Current ->
-  // Recent Bets without a refresh.
+  const darkSlip = !isLightMode;
+  const cx = (...parts: Array<string | false | undefined>) => parts.filter(Boolean).join(' ');
+
   const isPending = (b: Bet) => (b.status ?? 'PENDING') === 'PENDING';
   const singleBets = useMemo(
     () => activeBets.filter((b) => (b.betType ?? 'single') === 'single' && isPending(b)),
@@ -72,28 +81,18 @@ export const BetSlip: React.FC<BetSlipProps> = ({
     [activeBets],
   );
 
-  // Settled bets, newest-first by settledAt (fall back to placedAt for
-  // legacy rows that pre-date the settledAt write). Capped at 10 per tab
-  // to keep the slip from turning into a history page; the dedicated
-  // history view in DashboardView handles longer-term browsing.
-  const settledSortKey = (b: Bet) =>
-    (b.settledAt?.getTime?.() ?? b.placedAt.getTime());
-  const recentSingles = useMemo(
-    () => activeBets
-        .filter((b) => (b.betType ?? 'single') === 'single' && !isPending(b))
-        .sort((a, b) => settledSortKey(b) - settledSortKey(a))
-        .slice(0, 10),
-    [activeBets],
+  const sortedPendingSingles = useMemo(
+    () => [...singleBets].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()),
+    [singleBets],
   );
-  const recentParlays = useMemo(
-    () => activeBets
-        .filter((b) => b.betType === 'parlay' && !isPending(b))
-        .sort((a, b) => settledSortKey(b) - settledSortKey(a))
-        .slice(0, 10),
-    [activeBets],
+  const sortedPendingParlays = useMemo(
+    () => [...parlayBets].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()),
+    [parlayBets],
   );
 
-  // Boosted payout display (profit doubled for double_payout)
+  const previewSingle = sortedPendingSingles[0];
+  const previewParlay = sortedPendingParlays[0];
+
   const boostedSinglePayout = useMemo(() => {
     if (!selection || activeBoost !== 'double_payout') return null;
     const profit = potentialPayout - stake;
@@ -107,10 +106,10 @@ export const BetSlip: React.FC<BetSlipProps> = ({
   }, [parlaySelections, activeBoost, parlayPotentialPayout, stake]);
 
   const boostLabel = activeBoost === 'double_payout'
-      ? { icon: <TrendingUp size={10} />, text: 'Double Payout active', color: 'text-amber-300' }
-      : activeBoost === 'money_back'
-          ? { icon: <RefreshCcw size={10} />, text: 'Money Back active', color: 'text-cyan-300' }
-          : null;
+    ? { icon: <TrendingUp size={10} />, text: 'Double Payout active', color: darkSlip ? 'text-amber-200' : 'text-amber-800' }
+    : activeBoost === 'money_back'
+      ? { icon: <RefreshCcw size={10} />, text: 'Money Back active', color: darkSlip ? 'text-cyan-200' : 'text-cyan-800' }
+      : null;
 
   const decimalToAmerican = (decimalOdds: number) => {
     if (!Number.isFinite(decimalOdds) || decimalOdds <= 1) return 0;
@@ -118,22 +117,14 @@ export const BetSlip: React.FC<BetSlipProps> = ({
     return Math.round(-100 / (decimalOdds - 1));
   };
 
+  const fmtAmerican = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+
   const marketToneLabel = (key?: MarketOption['marketKey']) => {
-    if (key === 'h2h') return 'TO WIN';
-    if (key === 'spreads') return 'SPREAD';
-    if (key === 'totals') return 'TOTAL';
-    return 'PICK';
+    if (key === 'h2h') return 'Moneyline';
+    if (key === 'spreads') return 'Spread';
+    if (key === 'totals') return 'Total';
+    return 'Pick';
   };
-
-  const marketTone = useMemo(() => {
-    if (!selection) return '';
-    return marketToneLabel(selection.option.marketKey);
-  }, [selection]);
-
-  const singleAmericanOdds = useMemo(() => {
-    if (!selection) return 0;
-    return decimalToAmerican(selection.option.odds);
-  }, [selection]);
 
   const combinedParlayDecimalOdds = useMemo(() => {
     if (parlaySelections.length === 0) return 0;
@@ -141,26 +132,29 @@ export const BetSlip: React.FC<BetSlipProps> = ({
   }, [parlaySelections]);
 
   const parlayAmericanOdds = useMemo(
-      () => decimalToAmerican(combinedParlayDecimalOdds),
-      [combinedParlayDecimalOdds]
+    () => decimalToAmerican(combinedParlayDecimalOdds),
+    [combinedParlayDecimalOdds],
   );
 
   const parlayLegs = useMemo(
-      () =>
-          parlaySelections.map((sel) => {
-            const odds = decimalToAmerican(sel.option.odds);
-            return {
-              id: `${sel.market.id}:${sel.option.id}`,
-              market: sel.market,
-              option: sel.option,
-              name: sel.option.label,
-              matchup: sel.market.title,
-              odds: odds >= 0 ? `+${odds}` : `${odds}`,
-              lineLabel: marketToneLabel(sel.option.marketKey),
-            };
-          }),
-      [parlaySelections]
+    () =>
+      parlaySelections.map((sel) => {
+        const am = decimalToAmerican(sel.option.odds);
+        return {
+          id: `${sel.market.id}:${sel.option.id}`,
+          market: sel.market,
+          option: sel.option,
+          name: sel.option.label,
+          matchup: sel.market.title,
+          odds: fmtAmerican(am),
+          lineLabel: marketToneLabel(sel.option.marketKey),
+          isLive: sel.market.status === 'LIVE',
+        };
+      }),
+    [parlaySelections],
   );
+
+  const anyParlayLegLive = parlayLegs.some((l) => l.isLive);
 
   useEffect(() => {
     const wasParlay = previousParlayCount.current >= 2;
@@ -179,11 +173,24 @@ export const BetSlip: React.FC<BetSlipProps> = ({
     const key = `${selection.market.id}:${selection.option.id}`;
     if (previousSelectionKey.current === key) return;
     previousSelectionKey.current = key;
-    // With 2+ legs we’re building a parlay queue; don’t force Singles when
-    // the user adds another pick (that was hiding the Parlays tab).
     if (parlaySelections.length >= 2) return;
     setTab('SINGLES');
   }, [selection, parlaySelections.length]);
+
+  useEffect(() => {
+    setSingleStakes((prev) => {
+      const next = { ...prev };
+      for (const s of parlaySelections) {
+        const id = `${s.market.id}:${s.option.id}`;
+        if (next[id] === undefined) next[id] = '20';
+      }
+      const allowed = new Set(parlaySelections.map((s) => `${s.market.id}:${s.option.id}`));
+      for (const k of Object.keys(next)) {
+        if (!allowed.has(k)) delete next[k];
+      }
+      return next;
+    });
+  }, [parlaySelections]);
 
   const setStakeFromInput = (raw: string) => {
     const cleaned = raw.replace(/[^\d.]/g, '');
@@ -197,628 +204,975 @@ export const BetSlip: React.FC<BetSlipProps> = ({
     setStakeInput(cleaned.startsWith('.') ? `0${cleaned}` : cleaned);
   };
 
+  const setLegStakeFromInput = (legId: string, raw: string) => {
+    const cleaned = raw.replace(/[^\d.]/g, '');
+    if (cleaned === '') {
+      setSingleStakes((p) => ({ ...p, [legId]: '0' }));
+      return;
+    }
+    const parts = cleaned.split('.');
+    if (parts.length > 2) return;
+    if (parts[1] && parts[1].length > 2) return;
+    const normalized = cleaned.startsWith('.') ? `0${cleaned}` : cleaned;
+    setSingleStakes((p) => ({ ...p, [legId]: normalized }));
+  };
+
   const toggleParlayDetails = (betId: string) => {
     setExpandedParlays((prev) => ({ ...prev, [betId]: !prev[betId] }));
   };
 
-  const hasAnyPick = !isSinglesEmpty || !isParlayEmpty;
-  const singlesPlaceDisabled = isSinglesEmpty || !isAffordable || stake <= 0 || !!limitError;
-  const parlayPlaceDisabled  = !hasMinimumParlayLegs || !isAffordable || stake <= 0 || !!limitError;
-  const tabLabels: Record<SlipTab, string> = { SINGLES: 'Singles', PARLAYS: 'Parlays' };
-  const selectionKey =
-    selection ? `${selection.market.id}:${selection.option.id}` : '';
-  const hasMultipleQueuedPicks = parlaySelections.length >= 2;
+  const hasAnyPick = !isQueueEmpty;
+  const parlayPlaceDisabled = !hasMinimumParlayLegs || !isAffordable || stake <= 0 || !!limitError;
 
-  const cardClass = 'rounded-xl border border-slate-800 bg-[#100d1f]';
+  const slipShell = cx(
+    'rounded-t-2xl lg:rounded-none shadow-xl lg:shadow-none',
+    darkSlip
+      ? 'border-t border-[#3FA9F5]/25 lg:border-t-0 lg:border-l border-slate-700/75 bg-[#171427] text-slate-100'
+      : 'border border-slate-200 bg-white lg:border-l lg:border-slate-200 text-slate-900',
+  );
+  const slipAccentBtn = 'bg-[#3FA9F5] hover:bg-[#2e9ae8] text-slate-900';
+  const slipAccentBtnDisabled = darkSlip ? 'bg-slate-700 text-slate-500' : 'bg-slate-200 text-slate-400';
 
-  // Boost banner shown inside the bet card when a boost is active
-  const BoostBanner = () => boostLabel ? (
-      <div className={`mt-2 flex items-center gap-1.5 rounded-lg border border-slate-700/60 bg-slate-900/60 px-2.5 py-1.5 text-[10px] font-semibold ${boostLabel.color}`}>
+  const headerBadgeCount =
+    tab === 'ACTIVE' ? singleBets.length + parlayBets.length : parlaySelections.length;
+
+  const BoostBanner = () =>
+    boostLabel ? (
+      <div
+        className={cx(
+          'mt-3 flex flex-wrap items-center gap-1.5 rounded-lg border px-2.5 py-2 text-[10px] font-semibold',
+          darkSlip ? 'border-amber-500/35 bg-amber-500/10' : 'border-amber-200 bg-amber-50',
+          boostLabel.color,
+        )}
+      >
         {boostLabel.icon}
         {boostLabel.text}
         {activeBoost === 'double_payout' && (
-            <span className="ml-auto text-slate-400 normal-case font-normal">
-          Payout doubles to <span className="text-amber-200 font-bold">
-            ${(tab === 'SINGLES' ? boostedSinglePayout : boostedParlayPayout)?.toFixed(2) ?? '—'}
+          <span className={cx('ml-auto normal-case font-normal', darkSlip ? 'text-slate-400' : 'text-slate-600')}>
+            {tab === 'SINGLES' && parlaySelections.length >= 2 ? (
+              <>Doubles the win payout on each single you place.</>
+            ) : (
+              <>
+                Payout doubles to{' '}
+                <span className={cx('font-bold', darkSlip ? 'text-amber-100' : 'text-amber-900')}>
+                  ${(tab === 'SINGLES' ? boostedSinglePayout : boostedParlayPayout)?.toFixed(2) ?? '—'}
+                </span>
+              </>
+            )}
           </span>
-        </span>
         )}
         {activeBoost === 'money_back' && (
-            <span className="ml-auto text-slate-400 normal-case font-normal">Stake refunded if you lose</span>
+          <span className={cx('ml-auto normal-case font-normal', darkSlip ? 'text-slate-400' : 'text-slate-600')}>
+            Stake refunded if you lose
+          </span>
         )}
       </div>
-  ) : null;
+    ) : null;
 
-  // Limit error banner
-  const LimitBanner = () => limitError ? (
-      <div className="mt-2 flex items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-2.5 py-1.5 text-[10px] font-semibold text-red-400">
+  const LimitBanner = () =>
+    limitError ? (
+      <div
+        className={cx(
+          'mt-3 flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-[10px] font-semibold',
+          darkSlip ? 'border-red-500/35 bg-red-500/10 text-red-300' : 'border-red-200 bg-red-50 text-red-700',
+        )}
+      >
         <AlertCircle size={11} />
         {limitError}
       </div>
-  ) : null;
+    ) : null;
 
-  // Compute the actual amount returned to the wallet for a settled bet.
-  // Singles and non-reduced parlays use stored potentialPayout; reduced
-  // parlays (some legs pushed) get recomputed via computeParlayRollup so
-  // the slip never overstates winnings. Boost adjustments are not
-  // reflected here yet — see TODO when we surface boost-aware payouts.
-  const settledReturn = (bet: Bet): { kind: 'WON' | 'PUSH' | 'LOST' | 'VOID' | 'CANCELLED'; amount: number } => {
-    const status = (bet.status ?? 'PENDING').toUpperCase();
-    if (status === 'WON') {
-      if (bet.betType === 'parlay' && bet.parlayLegs?.length) {
-        const rollup = computeParlayRollup(bet.parlayLegs, bet.stake);
-        if (rollup.state === 'WON') return { kind: 'WON', amount: rollup.payout };
-      }
-      return { kind: 'WON', amount: bet.potentialPayout };
-    }
-    if (status === 'PUSH' || status === 'VOID' || status === 'CANCELLED') {
-      return { kind: status, amount: bet.stake };
-    }
-    return { kind: 'LOST', amount: 0 };
-  };
-
-  // Recent settled bets card — sibling of "Current Singles/Parlays" cards.
-  // Uses one component for both kinds so we don't duplicate empty-state /
-  // header / scroll-frame styling four times across the tab branches.
-  const RecentBetsCard: React.FC<{ title: string; bets: Bet[]; emptyText: string; kind: 'single' | 'parlay' }> =
-      ({ title, bets, emptyText, kind }) => (
-      <div className={`${cardClass} p-3.5`}>
-        <div className="mb-2.5 flex items-center justify-between gap-2">
-          <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">{title}</p>
-          <div className="flex items-center gap-2">
-            {onViewAllHistory ? (
-                <button
-                    type="button"
-                    onClick={onViewAllHistory}
-                    className="text-[10px] font-bold uppercase tracking-wider text-violet-300 hover:text-violet-200 transition-colors"
-                >
-                  View all
-                </button>
-            ) : null}
-            <span className="rounded-full border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{bets.length}</span>
-          </div>
-        </div>
-        {bets.length === 0 ? (
-            <p className="text-xs text-slate-500">{emptyText}</p>
-        ) : (
-            <div className="space-y-2.5 max-h-56 overflow-y-auto pr-1">
-              {bets.map((bet) => {
-                const { kind: outcome, amount } = settledReturn(bet);
-                const tone =
-                    outcome === 'WON'  ? { row: 'border-l-emerald-500',  pill: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-300', label: `Won $${amount.toFixed(2)}` } :
-                    outcome === 'LOST' ? { row: 'border-l-red-500',      pill: 'border-red-500/40 bg-red-500/15 text-red-300',           label: 'Lost' } :
-                    outcome === 'PUSH' ? { row: 'border-l-amber-500',    pill: 'border-amber-500/40 bg-amber-500/15 text-amber-300',     label: `Push $${amount.toFixed(2)}` } :
-                                          { row: 'border-l-slate-500',    pill: 'border-slate-500/40 bg-slate-500/15 text-slate-300',     label: outcome === 'VOID' ? 'Void' : 'Cancelled' };
-                return (
-                    <div key={bet.id} className={`rounded-xl border-l-4 ${tone.row} border-y border-r border-slate-700/80 bg-gradient-to-b from-slate-900 to-slate-900/70 p-2.5 shadow-[0_1px_0_rgba(148,163,184,0.12)_inset]`}>
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm font-semibold text-slate-100 truncate">{bet.optionLabel}</p>
-                          <p className="mt-0.5 text-[11px] text-slate-400 truncate">{bet.marketTitle}</p>
-                        </div>
-                        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide ${tone.pill}`}>
-                          {tone.label}
-                        </span>
-                      </div>
-                      <div className="mt-2 flex items-center justify-between text-[11px]">
-                        <span className="rounded-md border border-violet-500/25 bg-violet-500/10 px-1.5 py-0.5 font-semibold text-violet-200">Stake ${bet.stake.toFixed(2)}</span>
-                        <span className="font-semibold text-slate-400">@ {bet.odds.toFixed(2)}</span>
-                      </div>
-                      {kind === 'parlay' && !!bet.parlayLegs?.length && (
-                          <>
-                            <button
-                                type="button"
-                                onClick={() => toggleParlayDetails(bet.id)}
-                                className="mt-1.5 text-[10px] font-semibold text-violet-300 hover:text-violet-200"
-                            >
-                              {expandedParlays[bet.id] ? 'hide legs' : `show ${bet.parlayLegs.length} legs`}
-                            </button>
-                            {expandedParlays[bet.id] && (
-                                <div className="mt-2 rounded-lg border border-slate-800 bg-slate-950/60 p-2">
-                                  <div className="space-y-1.5">
-                                    {bet.parlayLegs.map((leg, idx) => {
-                                      const legResult = (leg.result ?? 'PENDING').toUpperCase();
-                                      const legColor =
-                                          legResult === 'WON'  ? 'text-emerald-300' :
-                                          legResult === 'LOST' ? 'text-red-300' :
-                                          legResult === 'PUSH' ? 'text-amber-300' :
-                                          legResult === 'VOID' ? 'text-slate-400' :
-                                                                  'text-slate-500';
-                                      return (
-                                          <div key={`${bet.id}-leg-${idx}`} className="flex items-center justify-between gap-2 rounded-md border border-slate-800/70 bg-slate-900/70 px-2 py-1.5">
-                                            <div className="min-w-0">
-                                              <p className="text-[10px] font-semibold text-slate-200 truncate">{leg.optionLabel}</p>
-                                              <p className="text-[9px] text-slate-500 truncate">{leg.marketTitle}</p>
-                                            </div>
-                                            <span className={`shrink-0 text-[9px] font-bold uppercase ${legColor}`}>{legResult}</span>
-                                          </div>
-                                      );
-                                    })}
-                                  </div>
-                                </div>
-                            )}
-                          </>
-                      )}
-                    </div>
-                );
-              })}
-            </div>
+  const StakeField = ({ compact, fullWidth }: { compact?: boolean; fullWidth?: boolean }) => (
+    <div
+      className={cx(
+        'flex items-center rounded-md border px-2',
+        fullWidth ? 'w-full py-2' : compact ? 'w-[4.75rem] shrink-0 py-1' : 'min-w-[4.5rem] py-1.5',
+        darkSlip ? 'border-slate-600 bg-slate-950' : 'border-slate-300 bg-white',
+      )}
+    >
+      <span className={cx('text-xs mr-0.5 shrink-0', darkSlip ? 'text-slate-500' : 'text-slate-400')}>$</span>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={stakeInput}
+        onChange={(e) => setStakeFromInput(e.target.value)}
+        className={cx(
+          'min-w-0 flex-1 bg-transparent text-xs font-semibold outline-none tabular-nums',
+          compact && !fullWidth ? 'text-right' : '',
+          darkSlip ? 'text-slate-100' : 'text-slate-900',
         )}
-      </div>
+        aria-label="Wager amount"
+      />
+    </div>
   );
 
+  const TabButton = ({ id, label }: { id: SlipTab; label: string }) => (
+    <button
+      type="button"
+      onClick={() => setTab(id)}
+      className={cx(
+        'flex-1 rounded-md px-2 py-2 text-[10px] font-bold uppercase tracking-wide transition-colors',
+        tab === id
+          ? darkSlip
+            ? 'bg-[#3FA9F5]/20 text-[#a5e6ff] ring-1 ring-[#3FA9F5]/35 shadow-none'
+            : 'bg-slate-900 text-white shadow-sm'
+          : darkSlip
+            ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-200'
+            : 'text-slate-500 hover:bg-slate-100 hover:text-slate-800',
+      )}
+    >
+      {label}
+    </button>
+  );
+
+  const CurrentBetPreview = () => {
+    if (tab === 'ACTIVE') return null;
+
+    const isSinglesContext = tab === 'SINGLES';
+    const bet = isSinglesContext ? previewSingle : previewParlay;
+    const count = isSinglesContext ? singleBets.length : parlayBets.length;
+    const label = isSinglesContext ? 'Current single' : 'Current parlay';
+
+    if (!bet && count === 0) return null;
+
+    const am = fmtAmerican(decimalToAmerican(bet.odds));
+    const marketLine =
+      bet.betType === 'parlay'
+        ? `${bet.parlayLegs?.length ?? 0}-leg parlay`
+        : marketToneLabel(bet.pickedMarketKey);
+
+    return (
+      <div
+        className={cx(
+          'mt-4 rounded-xl border-2 border-[#3FA9F5] overflow-hidden shadow-sm',
+          darkSlip ? 'bg-slate-900/70' : 'bg-white',
+        )}
+      >
+        <div
+          className={cx(
+            'flex items-center justify-between gap-2 border-b px-3 py-2',
+            darkSlip ? 'border-slate-700 bg-slate-800/80' : 'border-slate-200 bg-slate-50',
+          )}
+        >
+          <span className={cx('text-xs font-bold', darkSlip ? 'text-slate-100' : 'text-slate-800')}>
+            {label}
+            {count > 0 ? (
+              <span className={cx('ml-1.5 font-semibold', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+                ({count})
+              </span>
+            ) : null}
+          </span>
+          <button
+            type="button"
+            onClick={() => setTab('ACTIVE')}
+            className="text-[10px] font-bold uppercase tracking-wider text-[#3FA9F5] hover:text-[#7dd3fc]"
+          >
+            View all
+          </button>
+        </div>
+        {bet ? (
+          <div className="p-3">
+            <div className="flex items-start gap-2">
+              <p className={cx('min-w-0 flex-1 text-sm font-bold leading-tight pr-1', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+                {bet.optionLabel}
+              </p>
+              <div className="flex w-[4.75rem] shrink-0 flex-col items-end gap-0.5 text-right">
+                <span className={cx('text-sm font-bold tabular-nums', darkSlip ? 'text-[#7dd3fc]' : 'text-slate-900')}>{am}</span>
+              </div>
+            </div>
+            <div className="mt-1 flex gap-2">
+              <div className="min-w-0 flex-1 pr-1">
+                <p className={cx('text-[10px] font-semibold uppercase tracking-wide', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                  {marketLine}
+                </p>
+                <p className={cx('mt-0.5 text-xs leading-snug', darkSlip ? 'text-slate-400' : 'text-slate-600')}>{bet.marketTitle}</p>
+              </div>
+              <div className="flex w-[4.75rem] shrink-0 flex-col items-end justify-start pt-0.5">
+                <p className={cx('text-[9px] font-bold uppercase tracking-wide', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                  Total wager
+                </p>
+                <p className={cx('text-sm font-bold tabular-nums', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+                  ${bet.stake.toFixed(2)}
+                </p>
+              </div>
+            </div>
+
+            {bet.betType === 'parlay' && !!bet.parlayLegs?.length && (
+              <ul className={cx('mt-2 space-y-1 border-t pt-2', darkSlip ? 'border-slate-700' : 'border-slate-100')}>
+                {bet.parlayLegs.slice(0, 4).map((leg, idx) => (
+                  <li key={`${bet.id}-p-${idx}`} className="flex gap-2 text-[11px]">
+                    <span className="text-slate-500">×</span>
+                    <span
+                      className={cx('min-w-0 font-semibold truncate', darkSlip ? 'text-slate-200' : 'text-slate-800')}
+                    >
+                      {leg.optionLabel}
+                    </span>
+                  </li>
+                ))}
+                {(bet.parlayLegs?.length ?? 0) > 4 ? (
+                  <li className={cx('text-[10px] pl-4', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                    +{(bet.parlayLegs!.length ?? 0) - 4} more
+                  </li>
+                ) : null}
+              </ul>
+            )}
+
+            <div className={cx('mt-3 border-t pt-3', darkSlip ? 'border-slate-700' : 'border-slate-200')}>
+              <div className="flex items-end justify-between gap-3">
+                <div className="min-w-0">
+                  <p className={cx('text-[9px] font-bold uppercase tracking-wide', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                    Total payout
+                  </p>
+                  <p className={cx('text-sm font-bold tabular-nums', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+                    ${bet.potentialPayout.toFixed(2)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p className={cx('p-3 text-xs', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+            No pending {isSinglesContext ? 'singles' : 'parlays'}.
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  /** Active-tab card matching sportsbook “pending bet” layout (teal border, header strip, wager/payout, cashout row). */
+  const PendingBetActiveCard: React.FC<{ bet: Bet; variant: 'single' | 'parlay' }> = ({ bet, variant }) => {
+    const am = fmtAmerican(decimalToAmerican(bet.odds));
+    const marketLine =
+      variant === 'parlay'
+        ? `${bet.parlayLegs?.length ?? 0}-PICK PARLAY`
+        : marketToneLabel(bet.pickedMarketKey).toUpperCase();
+    const matchup =
+      variant === 'parlay' ? bet.marketTitle.replace(/\s*\|\s*/g, ' · ') : bet.marketTitle;
+    const stakeStr = bet.stake.toFixed(2);
+    const payoutStr = bet.potentialPayout.toFixed(2);
+
+    return (
+      <div
+        className={cx(
+          'overflow-hidden rounded-xl border-2 border-[#3FA9F5] shadow-sm',
+          darkSlip ? 'bg-slate-950/50' : 'bg-white',
+        )}
+      >
+        <div
+          className={cx(
+            'flex items-center justify-between border-b px-3 py-2.5',
+            darkSlip ? 'border-slate-700 bg-slate-800/90' : 'border-slate-200 bg-slate-100',
+          )}
+        >
+          <span className={cx('text-xs font-bold tracking-tight', darkSlip ? 'text-slate-100' : 'text-slate-800')}>
+            Active {variant === 'single' ? 'Bet' : 'Parlay'}
+          </span>
+        </div>
+
+        <div className={cx('border-b px-3 py-3', darkSlip ? 'border-slate-700' : 'border-slate-200')}>
+          <div className="flex items-start justify-between gap-2">
+            <p className={cx('min-w-0 text-sm font-bold leading-snug', darkSlip ? 'text-slate-50' : 'text-slate-900')}>
+              {bet.optionLabel}
+            </p>
+            <span className={cx('shrink-0 text-sm font-bold tabular-nums', darkSlip ? 'text-slate-50' : 'text-slate-900')}>
+              {am}
+            </span>
+          </div>
+          <p
+            className={cx(
+              'mt-1.5 text-[10px] font-semibold uppercase tracking-[0.12em]',
+              darkSlip ? 'text-slate-500' : 'text-slate-500',
+            )}
+          >
+            {marketLine}
+          </p>
+          <p className={cx('mt-1 text-xs leading-snug', darkSlip ? 'text-slate-400' : 'text-slate-600')}>{matchup}</p>
+
+          {variant === 'parlay' && !!bet.parlayLegs?.length ? (
+            <>
+              <button
+                type="button"
+                onClick={() => toggleParlayDetails(bet.id)}
+                className="mt-2 text-[10px] font-bold uppercase tracking-wide text-[#3FA9F5] hover:text-[#7dd3fc]"
+              >
+                {expandedParlays[bet.id] ? 'Hide legs' : `Show ${bet.parlayLegs.length} legs`}
+              </button>
+              {expandedParlays[bet.id] ? (
+                <ul
+                  className={cx(
+                    'mt-2 space-y-1.5 rounded-lg border px-2.5 py-2',
+                    darkSlip ? 'border-slate-700 bg-black/20' : 'border-slate-200 bg-slate-50',
+                  )}
+                >
+                  {bet.parlayLegs.map((leg, idx) => (
+                    <li key={`${bet.id}-leg-${idx}`} className="text-[11px] leading-snug">
+                      <span className={cx('font-semibold', darkSlip ? 'text-slate-200' : 'text-slate-800')}>
+                        {leg.optionLabel}
+                      </span>
+                      <span className={cx(darkSlip ? 'text-slate-500' : 'text-slate-500')}> · {leg.marketTitle}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+
+        <div
+          className={cx(
+            'relative border-b px-3 py-3',
+            darkSlip ? 'border-slate-700' : 'border-slate-200',
+          )}
+        >
+          <div
+            className={cx(
+              'pointer-events-none absolute inset-0 opacity-[0.06]',
+              darkSlip ? 'text-white' : 'text-slate-900',
+            )}
+            style={{
+              backgroundImage:
+                'radial-gradient(circle at 90% 40%, currentColor 0%, transparent 55%), radial-gradient(circle at 10% 80%, currentColor 0%, transparent 50%)',
+            }}
+            aria-hidden
+          />
+          <div className="relative grid grid-cols-2 gap-4">
+            <div>
+              <p className={cx('text-base font-bold tabular-nums', darkSlip ? 'text-slate-50' : 'text-slate-900')}>
+                ${stakeStr}
+              </p>
+              <p
+                className={cx(
+                  'mt-0.5 text-[9px] font-bold uppercase tracking-[0.14em]',
+                  darkSlip ? 'text-slate-500' : 'text-slate-500',
+                )}
+              >
+                Total wager
+              </p>
+            </div>
+            <div className="text-right">
+              <p className={cx('text-base font-bold tabular-nums', darkSlip ? 'text-slate-50' : 'text-slate-900')}>
+                ${payoutStr}
+              </p>
+              <p
+                className={cx(
+                  'mt-0.5 text-[9px] font-bold uppercase tracking-[0.14em]',
+                  darkSlip ? 'text-slate-500' : 'text-slate-500',
+                )}
+              >
+                Total payout
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-3">
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            title="Cashout is not available yet."
+            className={cx(
+              'flex w-full items-center justify-center gap-2 rounded-lg bg-[#3FA9F5] py-3 text-xs font-bold uppercase tracking-wide text-white opacity-60 cursor-not-allowed',
+            )}
+          >
+            <Wallet size={16} strokeWidth={2.25} className="shrink-0 opacity-95" aria-hidden />
+            Cashout ${stakeStr}
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderActiveTab = () => {
+    const showSingles = activePendingFilter === 'ALL' || activePendingFilter === 'SINGLES';
+    const showParlays = activePendingFilter === 'ALL' || activePendingFilter === 'PARLAYS';
+
+    const ActiveFilterChip = ({ id, label }: { id: ActivePendingFilter; label: string }) => (
+      <button
+        type="button"
+        onClick={() => setActivePendingFilter(id)}
+        className={cx(
+          'flex-1 rounded-md px-1.5 py-2 text-[10px] font-bold uppercase tracking-wide transition-colors',
+          activePendingFilter === id
+            ? darkSlip
+              ? 'bg-[#3FA9F5]/25 text-[#a5e6ff] ring-1 ring-[#3FA9F5]/40'
+              : 'bg-white text-slate-900 shadow-sm'
+            : darkSlip
+              ? 'text-slate-500 hover:bg-slate-800 hover:text-slate-300'
+              : 'text-slate-600 hover:bg-slate-200/80',
+        )}
+      >
+        {label}
+      </button>
+    );
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col items-center">
+          <p className={cx('text-[11px] font-black uppercase tracking-[0.22em]', darkSlip ? 'text-slate-300' : 'text-slate-600')}>
+            Active
+          </p>
+          <div className="mt-2.5 w-full max-w-[280px] space-y-2">
+            <div className={cx('flex gap-0.5 rounded-lg p-0.5', darkSlip ? 'bg-slate-900/85' : 'bg-slate-100')}>
+              <ActiveFilterChip id="ALL" label="All" />
+              <ActiveFilterChip id="SINGLES" label="Singles" />
+              <ActiveFilterChip id="PARLAYS" label="Parlays" />
+            </div>
+            {onGoToHistory ? (
+              <button
+                type="button"
+                onClick={onGoToHistory}
+                className={cx(
+                  'flex w-full items-center justify-center gap-1.5 rounded-lg border py-2 text-[11px] font-semibold transition-colors',
+                  darkSlip
+                    ? 'border-slate-600 text-slate-300 hover:border-[#3FA9F5]/50 hover:bg-slate-800 hover:text-slate-100'
+                    : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:bg-white',
+                )}
+              >
+                <History size={14} strokeWidth={2} aria-hidden />
+                History
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        {showSingles ? (
+          <div>
+            <p className={cx('mb-2 text-[10px] font-bold uppercase tracking-[0.14em]', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+              Pending singles
+            </p>
+            {singleBets.length === 0 ? (
+              <p className={cx('text-xs', darkSlip ? 'text-slate-500' : 'text-slate-500')}>None yet.</p>
+            ) : (
+              <div className="no-scrollbar max-h-[min(56vh,28rem)] space-y-3 overflow-y-auto pr-1">
+                {sortedPendingSingles.map((bet) => (
+                  <PendingBetActiveCard key={bet.id} bet={bet} variant="single" />
+                ))}
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        {showParlays ? (
+          <div>
+            <p className={cx('mb-2 text-[10px] font-bold uppercase tracking-[0.14em]', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+              Pending parlays
+            </p>
+            {parlayBets.length === 0 ? (
+              <p className={cx('text-xs', darkSlip ? 'text-slate-500' : 'text-slate-500')}>None yet.</p>
+            ) : (
+              <div className="no-scrollbar max-h-[min(56vh,28rem)] space-y-3 overflow-y-auto pr-1">
+                {sortedPendingParlays.map((bet) => (
+                  <PendingBetActiveCard key={bet.id} bet={bet} variant="parlay" />
+                ))}
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
   return (
-      <div className="fixed bottom-0 left-0 right-0 z-50 lg:static lg:z-auto lg:shrink-0 lg:w-[330px] lg:min-h-0 lg:h-full lg:overflow-y-auto lg:overscroll-contain animate-in slide-in-from-bottom lg:slide-in-from-right duration-300">
-        <div className="betslip-shell mx-4 mb-4 flex min-h-0 flex-col lg:mx-0 lg:mb-0 lg:min-h-full rounded-t-2xl lg:rounded-none lg:h-full p-4 lg:px-4 lg:pb-4 lg:pt-5 shadow-2xl border-t border-violet-500/40 lg:border-t-0 lg:border-l border-slate-700/70 bg-[#171427]">
-          <div className="flex items-center justify-between mb-3">
-            <div className="inline-flex items-center gap-2 rounded-full bg-slate-900/70 px-2 py-1 text-[11px]">
-              <span className="text-slate-300">Balance</span>
-              <span className="font-bold text-violet-300">${balance.toFixed(2)}</span>
+    <div className="no-scrollbar fixed bottom-0 left-0 right-0 z-50 lg:static lg:z-auto lg:shrink-0 lg:w-[340px] lg:min-h-0 lg:h-full lg:overflow-y-auto lg:overscroll-contain animate-in slide-in-from-bottom lg:slide-in-from-right duration-300">
+      <div className={`betslip-shell mx-4 mb-4 flex min-h-0 flex-col lg:mx-0 lg:mb-0 lg:min-h-full lg:h-full p-4 lg:px-4 lg:pb-4 lg:pt-4 ${slipShell}`}>
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#3FA9F5] text-xs font-black text-slate-900">
+              {headerBadgeCount > 99 ? '99+' : headerBadgeCount}
+            </span>
+            <h2 className={cx('text-sm font-black uppercase tracking-wide truncate', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+              Bet slip
+            </h2>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="relative inline-flex shrink-0">
+              <button
+                type="button"
+                className={cx(
+                  'peer flex h-7 w-7 items-center justify-center rounded-full border outline-none',
+                  darkSlip
+                    ? 'border-slate-600 text-[#7dd3fc] hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-[#3FA9F5]/50'
+                    : 'border-blue-200 text-blue-600 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-[#3FA9F5]/40',
+                )}
+                aria-label="Bet slip help"
+                aria-describedby="betslip-help-tooltip"
+              >
+                <Info size={14} strokeWidth={2.5} />
+              </button>
+              <div
+                id="betslip-help-tooltip"
+                role="tooltip"
+                className={cx(
+                  'pointer-events-none invisible absolute right-0 top-full z-[70] mt-1.5 w-[min(calc(100vw-2rem),14rem)] rounded-lg border px-3 py-2 text-left text-[10px] leading-snug shadow-lg opacity-0 transition-opacity duration-150',
+                  'peer-hover:visible peer-hover:opacity-100 peer-focus-visible:visible peer-focus-visible:opacity-100',
+                  darkSlip
+                    ? 'border-slate-600 bg-slate-900 text-slate-300 ring-1 ring-white/5'
+                    : 'border-slate-200 bg-white text-slate-600 shadow-slate-900/10',
+                )}
+              >
+                <p className="font-bold text-[11px] text-current">How this slip works</p>
+                <ul className="mt-1.5 list-disc space-y-1 pl-3.5 marker:text-current/70">
+                  <li>
+                    <strong className="font-semibold">Singles</strong>: lines you tap appear here; set stake and place one bet at a time for the
+                    focused pick.
+                  </li>
+                  <li>
+                    <strong className="font-semibold">Parlays</strong>: need at least two legs; odds multiply together. Same parlay rules as on the
+                    board still apply.
+                  </li>
+                  <li>
+                    <strong className="font-semibold">Active</strong>: bets you&apos;ve placed that are still pending.
+                  </li>
+                </ul>
+              </div>
             </div>
             <button
               type="button"
               onClick={onClose}
-              className="text-slate-500 hover:text-slate-300 transition-colors"
+              className={cx(
+                'transition-colors',
+                darkSlip ? 'text-slate-500 hover:text-slate-300' : 'text-slate-400 hover:text-slate-700',
+              )}
               title="Close bet slip"
               aria-label="Close bet slip"
             >
-              <X size={16} />
+              <X size={18} />
             </button>
           </div>
+        </div>
 
-          {parlayRuleError ? (
-              <div
-                  role="alert"
-                  aria-live="polite"
-                  className="mb-3 flex items-center gap-1.5 rounded-lg border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[10px] font-semibold text-amber-300"
-              >
-                <AlertCircle size={11} />
-                {parlayRuleError}
-              </div>
-          ) : null}
+        <div className="mb-3 flex items-center justify-between gap-2 text-[11px]">
+          <span className={darkSlip ? 'text-slate-400' : 'text-slate-500'}>Balance</span>
+          <span className={cx('font-bold', darkSlip ? 'text-slate-100' : 'text-slate-900')}>${balance.toFixed(2)}</span>
+        </div>
 
-          <div className="flex border-b border-slate-800 mb-2">
-            {(['SINGLES', 'PARLAYS'] as const).map((t) => (
-                <button
-                    key={t}
-                    type="button"
-                    onClick={() => setTab(t)}
-                    className={`flex-1 pb-2.5 text-[11px] font-bold uppercase tracking-wide border-b-2 -mb-px transition-colors ${
-                        tab === t
-                            ? 'border-violet-400 text-violet-200'
-                            : 'border-transparent text-slate-500 hover:text-slate-400'
-                    }`}
-                >
-                  {tabLabels[t]}
-                </button>
-            ))}
-          </div>
-
-          <button
-              type="button"
-              onClick={onClear}
-              disabled={!hasAnyPick}
-              className="mb-3 flex w-full items-center justify-center gap-1.5 text-[11px] font-semibold text-violet-400 hover:text-violet-300 disabled:opacity-40 disabled:hover:text-violet-400"
+        {parlayRuleError ? (
+          <div
+            role="alert"
+            aria-live="polite"
+            className={cx(
+              'mb-3 flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-[10px] font-semibold',
+              darkSlip ? 'border-amber-500/35 bg-amber-500/10 text-amber-200' : 'border-amber-200 bg-amber-50 text-amber-900',
+            )}
           >
-            <Trash2 size={14} strokeWidth={2} />
-            Remove all selections
-          </button>
+            <AlertCircle size={11} />
+            {parlayRuleError}
+          </div>
+        ) : null}
 
-          {/* ——— Singles ——— */}
-          {tab === 'SINGLES' && selection ? (
-              <div className="mb-4 flex flex-col gap-3">
-                <div className={`${cardClass} p-3`}>
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                  <span className="inline-block rounded bg-violet-600 px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
-                    Single
-                  </span>
-                      <p className="mt-2 text-xs font-medium text-slate-200 truncate">{selection.option.label}</p>
-                    </div>
-                    <span className="shrink-0 text-lg font-black text-violet-300">
-                  {singleAmericanOdds >= 0 ? `+${singleAmericanOdds}` : singleAmericanOdds}
-                </span>
-                  </div>
-                  <div className="mt-4 grid grid-cols-2 gap-3">
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Wager</p>
-                      <div className="mt-1 flex items-center rounded-lg border border-slate-700 bg-slate-900/80 px-2.5 py-2">
-                        <span className="text-slate-400 text-sm mr-0.5">$</span>
-                        <input
-                            type="text"
-                            inputMode="decimal"
-                            value={stakeInput}
-                            onChange={(e) => setStakeFromInput(e.target.value)}
-                            className="min-w-0 flex-1 bg-transparent text-sm font-semibold text-slate-100 outline-none"
-                            aria-label="Wager amount"
-                        />
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Payout</p>
-                      {boostedSinglePayout ? (
-                          <div className="mt-1">
-                            <p className="text-sm font-semibold line-through text-slate-500">${potentialPayout.toFixed(2)}</p>
-                            <p className="text-2xl font-semibold leading-tight text-amber-300">${boostedSinglePayout.toFixed(2)}</p>
-                          </div>
-                      ) : (
-                          <p className="mt-1 text-2xl font-semibold leading-tight text-slate-100">${potentialPayout.toFixed(2)}</p>
-                      )}
-                    </div>
-                  </div>
-                  <BoostBanner />
-                  <LimitBanner />
-                  {!isAffordable && (
-                      <p className="text-red-400 text-[10px] mt-2 font-semibold">Insufficient funds</p>
+        <div className={cx('mb-3 flex gap-1 rounded-lg p-1', darkSlip ? 'bg-slate-900/80' : 'bg-slate-100')}>
+          <TabButton id="SINGLES" label="Singles" />
+          <TabButton id="PARLAYS" label="Parlays" />
+          <TabButton id="ACTIVE" label="Active" />
+        </div>
+
+        <div className="min-h-0 flex-1">
+          {tab === 'SINGLES' && (
+            <div className="flex flex-col">
+              {isQueueEmpty ? (
+                <div
+                  className={cx(
+                    'rounded-xl border border-dashed px-4 py-12 text-center',
+                    darkSlip ? 'border-slate-600 bg-slate-900/40' : 'border-slate-200 bg-slate-50',
                   )}
-                  <button
-                      type="button"
-                      disabled={singlesPlaceDisabled}
-                      onClick={() => onPlaceBet(stake, 'single')}
-                      className={`mt-3 w-full font-bold py-3 rounded-lg shadow-lg active:scale-[0.99] transition-all text-xs uppercase tracking-wide text-white ${
-                          singlesPlaceDisabled
-                              ? 'bg-slate-700 text-slate-500'
-                              : activeBoost
-                                  ? 'bg-amber-600 hover:bg-amber-500 shadow-amber-600/20'
-                                  : 'bg-violet-600 hover:bg-violet-500 shadow-violet-600/20'
-                      }`}
-                  >
-                    {activeBoost ? `PLACE BET + ${activeBoost === 'double_payout' ? '2× PAYOUT' : 'MONEY BACK'}` : 'PLACE BET'}
-                  </button>
+                >
+                  <p className={cx('text-sm font-semibold', darkSlip ? 'text-slate-200' : 'text-slate-700')}>No picks yet</p>
+                  <p className={cx('mt-1 text-xs', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                    Choose a line from the board to add it here.
+                  </p>
                 </div>
-
-                {hasMultipleQueuedPicks ? (
-                  <div className={`${cardClass} p-2.5`}>
-                    <div className="mb-2 flex items-center justify-between">
-                      <p className="text-[10px] font-bold uppercase tracking-wider text-blue-300">
-                        {parlaySelections.length} queued singles
-                      </p>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className={cx('text-[10px] font-bold uppercase tracking-[0.14em]', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+                          Separate picks
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={onClear}
+                        className={cx(
+                          'shrink-0 rounded-md px-2 py-1 text-[10px] font-semibold transition-colors',
+                          darkSlip ? 'text-slate-400 hover:bg-slate-800 hover:text-slate-200' : 'text-slate-600 hover:bg-slate-100',
+                        )}
+                      >
+                        Clear all
+                      </button>
                     </div>
-                    <div className="max-h-52 space-y-2 overflow-y-auto pr-0.5">
+
+                    <div className="no-scrollbar flex max-h-[min(58vh,32rem)] flex-col gap-3 overflow-y-auto pr-0.5">
                       {parlayLegs.map((leg) => {
-                        const isActive = `${leg.market.id}:${leg.option.id}` === selectionKey;
-                        const cardPayout = stake > 0 ? stake * leg.option.odds : 0;
+                        const raw = singleStakes[leg.id] ?? '20';
+                        const legStake = Number(raw) || 0;
+                        const basePayout = legStake * leg.option.odds;
+                        const boostedPay =
+                          activeBoost === 'double_payout' && legStake > 0
+                            ? basePayout + (basePayout - legStake)
+                            : null;
+                        const legAffordable = legStake <= balance && legStake > 0;
+                        const betDisabled = !legAffordable || !!limitError;
                         return (
                           <div
                             key={leg.id}
-                            className={`rounded-lg border p-2 ${
-                              isActive
-                                ? 'border-blue-500/60 bg-blue-500/10'
-                                : 'border-slate-700/80 bg-slate-900/70'
-                            }`}
+                            className={cx(
+                              'rounded-xl border p-3 shadow-sm',
+                              darkSlip ? 'border-slate-600 bg-slate-900/85' : 'border-slate-200 bg-white',
+                            )}
                           >
-                            <div className="mb-1 flex items-center justify-between gap-2">
-                              <span className="shrink-0 rounded-full bg-white px-1.5 py-0.5 text-[8px] font-black uppercase tracking-wide text-black">
-                                Single
-                              </span>
-                              <span className="text-sm font-bold text-violet-300">{leg.odds}</span>
-                            </div>
-                            <p className="truncate text-base font-bold text-slate-100">{leg.option.label}</p>
-                            <div className="mt-1.5 grid grid-cols-2 gap-2 text-[10px]">
-                              <div>
-                                <p className="font-bold uppercase tracking-wide text-slate-500">Wager</p>
-                                <p className="font-semibold text-slate-200">${stake.toFixed(2)}</p>
-                              </div>
-                              <div className="text-right">
-                                <p className="font-bold uppercase tracking-wide text-slate-500">Payout</p>
-                                <p className="font-semibold text-slate-100">${cardPayout.toFixed(2)}</p>
-                              </div>
-                            </div>
-                            <div className="mt-2 grid grid-cols-2 gap-2">
+                            <div className="flex gap-2">
                               <button
                                 type="button"
-                                onClick={() => {
-                                  if (isActive) onPlaceBet(stake, 'single');
-                                  else onFocusSelection(leg.market, leg.option);
-                                }}
-                                disabled={stake <= 0 || !isAffordable || !!limitError}
-                                className={`rounded-md py-1.5 text-[10px] font-bold uppercase tracking-wide transition-colors ${
-                                  stake <= 0 || !isAffordable || !!limitError
-                                    ? 'bg-slate-700 text-slate-500'
-                                    : isActive
-                                      ? 'bg-violet-600 text-white hover:bg-violet-500'
-                                      : 'border border-slate-600 bg-slate-800 text-slate-100 hover:border-blue-500/70'
-                                }`}
+                                onClick={() => onSelectBet(leg.market, leg.option)}
+                                className={cx(
+                                  'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded',
+                                  darkSlip ? 'text-slate-500 hover:bg-slate-800' : 'text-slate-400 hover:bg-slate-100',
+                                )}
+                                aria-label="Remove pick"
                               >
-                                {isActive ? 'Place Single' : 'Select'}
+                                <X size={14} strokeWidth={2} />
                               </button>
-                              <button
-                                type="button"
-                                onClick={() => setTab('PARLAYS')}
-                                className="rounded-md border border-violet-500/50 bg-violet-600/25 py-1.5 text-[10px] font-bold uppercase tracking-wide text-violet-100 transition-colors hover:bg-violet-600/40"
-                              >
-                                Add to Parlay
-                              </button>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-start justify-between gap-2">
+                                  <div className="min-w-0">
+                                    <div className="flex flex-wrap items-center gap-1.5">
+                                      {leg.isLive ? (
+                                        <span className="rounded px-1 py-0.5 text-[8px] font-bold uppercase bg-slate-900 text-white">
+                                          Live
+                                        </span>
+                                      ) : null}
+                                      <p className={cx('text-sm font-bold leading-snug', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+                                        {leg.name}
+                                      </p>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className={cx(
+                                      'shrink-0 text-sm font-black tabular-nums',
+                                      darkSlip ? 'text-[#7dd3fc]' : 'text-emerald-700',
+                                    )}
+                                  >
+                                    {leg.odds}
+                                  </span>
+                                </div>
+
+                                <div className="mt-2 flex items-end justify-between gap-2">
+                                  <p
+                                    className={cx(
+                                      'text-[10px] font-bold uppercase tracking-wide',
+                                      darkSlip ? 'text-slate-500' : 'text-slate-500',
+                                    )}
+                                  >
+                                    {leg.lineLabel}
+                                  </p>
+                                  <div
+                                    className={cx(
+                                      'flex w-[5.5rem] shrink-0 items-center rounded-md border px-2 py-1.5',
+                                      darkSlip ? 'border-slate-600 bg-slate-950' : 'border-slate-300 bg-white',
+                                    )}
+                                  >
+                                    <span className={cx('mr-0.5 shrink-0 text-xs', darkSlip ? 'text-slate-500' : 'text-slate-400')}>$</span>
+                                    <input
+                                      type="text"
+                                      inputMode="decimal"
+                                      value={raw}
+                                      onChange={(e) => setLegStakeFromInput(leg.id, e.target.value)}
+                                      className={cx(
+                                        'min-w-0 flex-1 bg-transparent text-right text-xs font-semibold tabular-nums outline-none',
+                                        darkSlip ? 'text-slate-100' : 'text-slate-900',
+                                      )}
+                                      aria-label={`Wager for ${leg.name}`}
+                                    />
+                                  </div>
+                                </div>
+
+                                <div className="mt-2 flex items-start justify-between gap-2 text-[11px]">
+                                  <span className={cx('flex min-w-0 items-start gap-1', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                                    <CornerDownRight size={12} className="mt-0.5 shrink-0 opacity-70" aria-hidden />
+                                    <span className="leading-snug">{leg.matchup}</span>
+                                  </span>
+                                  <div className="shrink-0 text-right">
+                                    {boostedPay != null ? (
+                                      <div>
+                                        <p className={cx('text-[10px]', darkSlip ? 'text-slate-500' : 'text-slate-500')}>Payout</p>
+                                        <p className={cx('text-[10px] line-through', darkSlip ? 'text-slate-500' : 'text-slate-400')}>
+                                          ${basePayout.toFixed(2)}
+                                        </p>
+                                        <p className={cx('text-xs font-bold tabular-nums', darkSlip ? 'text-amber-300' : 'text-amber-700')}>
+                                          ${boostedPay.toFixed(2)}
+                                        </p>
+                                      </div>
+                                    ) : (
+                                      <p className={cx('tabular-nums', darkSlip ? 'text-slate-300' : 'text-slate-700')}>
+                                        <span className={darkSlip ? 'text-slate-500' : 'text-slate-500'}>Payout: </span>
+                                        <span className="font-semibold">${basePayout.toFixed(2)}</span>
+                                      </p>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
                             </div>
+
+                            <button
+                              type="button"
+                              disabled={betDisabled}
+                              onClick={() => onPlaceBet(legStake, 'single', { market: leg.market, option: leg.option })}
+                              className={cx(
+                                'mt-3 w-full rounded-lg py-2.5 text-xs font-black uppercase tracking-wide active:scale-[0.99]',
+                                betDisabled
+                                  ? slipAccentBtnDisabled
+                                  : activeBoost
+                                    ? 'bg-amber-500 text-slate-900 hover:bg-amber-400'
+                                    : slipAccentBtn,
+                              )}
+                            >
+                              {activeBoost
+                                ? `Bet · ${activeBoost === 'double_payout' ? '2× payout' : 'Money back'}`
+                                : 'Bet'}
+                            </button>
+                            {!legAffordable && legStake > 0 ? (
+                              <p className={cx('mt-1.5 text-center text-[10px] font-semibold', darkSlip ? 'text-red-400' : 'text-red-600')}>
+                                Insufficient funds
+                              </p>
+                            ) : null}
                           </div>
                         );
                       })}
                     </div>
-                  </div>
-                ) : null}
 
-                {!hasMultipleQueuedPicks ? (
-                <div className={`${cardClass} p-3`}>
-                  <div className="flex gap-2.5">
-                    <button
+                    {hasMinimumParlayLegs ? (
+                      <button
                         type="button"
-                        onClick={() => onSelectBet(selection.market, selection.option)}
-                        className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-red-500/70 bg-red-500/10 text-red-400 hover:bg-red-500/20"
-                        aria-label="Remove selection"
-                    >
-                      <Minus size={14} strokeWidth={2.5} />
-                    </button>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-bold text-slate-100 truncate">{selection.option.label}</p>
-                      <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">{marketTone}</p>
-                      <p className="text-xs text-slate-500 truncate mt-0.5">{selection.market.title}</p>
-                    </div>
-                    <span className="shrink-0 text-base font-bold text-violet-300">
-                  {singleAmericanOdds >= 0 ? `+${singleAmericanOdds}` : singleAmericanOdds}
-                </span>
-                  </div>
-                </div>
-                ) : null}
+                        onClick={() => setTab('PARLAYS')}
+                        className={cx(
+                          'w-full rounded-lg border py-2.5 text-center text-[11px] font-semibold transition-colors',
+                          darkSlip
+                            ? 'border-[#3FA9F5]/40 text-[#a5e6ff] hover:border-[#3FA9F5]/60 hover:bg-[#3FA9F5]/10'
+                            : 'border-slate-300 text-slate-800 hover:border-[#3FA9F5] hover:bg-[#3FA9F5]/5',
+                        )}
+                      >
+                        Combine picks into a parlay
+                      </button>
+                    ) : null}
 
-                <div className={`${cardClass} p-3.5`}>
-                  <div className="mb-2.5 flex items-center justify-between">
-                    <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">Current Singles</p>
-                    <span className="rounded-full border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{singleBets.length}</span>
+                    <BoostBanner />
+                    <LimitBanner />
                   </div>
-                  {singleBets.length === 0 ? (
-                      <p className="text-xs text-slate-500">No single bets placed yet.</p>
-                  ) : (
-                      <div className="space-y-2.5 max-h-48 overflow-y-auto pr-1">
-                        {singleBets.slice(0, 10).map((bet) => (
-                            <div key={bet.id} className="rounded-xl border border-slate-700/80 bg-gradient-to-b from-slate-900 to-slate-900/70 p-2.5 shadow-[0_1px_0_rgba(148,163,184,0.12)_inset]">
-                              <p className="text-sm font-semibold text-slate-100 truncate">{bet.optionLabel}</p>
-                              <p className="mt-0.5 text-[11px] text-slate-400 truncate">{bet.marketTitle}</p>
-                              <div className="mt-2 flex items-center justify-between text-[11px]">
-                                <span className="rounded-md border border-violet-500/25 bg-violet-500/10 px-1.5 py-0.5 font-semibold text-violet-200">Stake ${bet.stake.toFixed(2)}</span>
-                                <span className="font-semibold text-emerald-300">To win ${bet.potentialPayout.toFixed(2)}</span>
-                              </div>
-                            </div>
-                        ))}
-                      </div>
-                  )}
-                </div>
-                <RecentBetsCard
-                    title="Recent Bets"
-                    bets={recentSingles}
-                    emptyText="No settled singles yet. Once a game ends, results land here."
-                    kind="single"
-                />
-              </div>
-          ) : tab === 'SINGLES' ? (
-              <div className="mb-4 flex flex-col gap-3">
-                <div className={`${cardClass} px-4 py-10 text-center text-slate-400 lg:min-h-[28vh] flex flex-col items-center justify-center`}>
-                  <p className="text-sm font-semibold text-slate-300 mb-1">No singles yet</p>
-                  <p className="text-xs text-slate-500">Pick a line from the board to add it here.</p>
-                </div>
-                <div className={`${cardClass} p-3.5`}>
-                  <div className="mb-2.5 flex items-center justify-between">
-                    <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">Current Singles</p>
-                    <span className="rounded-full border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{singleBets.length}</span>
-                  </div>
-                  {singleBets.length === 0 ? (
-                      <p className="text-xs text-slate-500">No single bets placed yet.</p>
-                  ) : (
-                      <div className="space-y-2.5 max-h-48 overflow-y-auto pr-1">
-                        {singleBets.slice(0, 10).map((bet) => (
-                            <div key={bet.id} className="rounded-xl border border-slate-700/80 bg-gradient-to-b from-slate-900 to-slate-900/70 p-2.5 shadow-[0_1px_0_rgba(148,163,184,0.12)_inset]">
-                              <p className="text-sm font-semibold text-slate-100 truncate">{bet.optionLabel}</p>
-                              <p className="mt-0.5 text-[11px] text-slate-400 truncate">{bet.marketTitle}</p>
-                              <div className="mt-2 flex items-center justify-between text-[11px]">
-                                <span className="rounded-md border border-violet-500/25 bg-violet-500/10 px-1.5 py-0.5 font-semibold text-violet-200">Stake ${bet.stake.toFixed(2)}</span>
-                                <span className="font-semibold text-emerald-300">To win ${bet.potentialPayout.toFixed(2)}</span>
-                              </div>
-                            </div>
-                        ))}
-                      </div>
-                  )}
-                </div>
-                <RecentBetsCard
-                    title="Recent Bets"
-                    bets={recentSingles}
-                    emptyText="No settled singles yet. Once a game ends, results land here."
-                    kind="single"
-                />
-              </div>
-          ) : null}
+                </>
+              )}
+              <CurrentBetPreview />
+            </div>
+          )}
 
-          {/* ——— Parlays ——— */}
-          {tab === 'PARLAYS' && !isParlayEmpty ? (
-              <div className="mb-4 flex flex-col gap-3">
-                <div className={`${cardClass} p-3`}>
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex min-w-0 items-center gap-2">
-                  <span className="shrink-0 rounded bg-violet-600 px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
-                    Parlay
-                  </span>
-                      <span className="text-sm font-semibold text-slate-200 truncate">
-                    {parlayLegs.length}-Bet Parlay
-                  </span>
-                    </div>
-                    <span className="shrink-0 text-lg font-black text-violet-300">
-                  {parlayAmericanOdds >= 0 ? `+${parlayAmericanOdds}` : parlayAmericanOdds}
-                </span>
-                  </div>
-                  <div className="mt-4 grid grid-cols-2 gap-3">
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Wager</p>
-                      <div className="mt-1 flex items-center rounded-lg border border-slate-700 bg-slate-900/80 px-2.5 py-2">
-                        <span className="text-slate-400 text-sm mr-0.5">$</span>
-                        <input
-                            type="text"
-                            inputMode="decimal"
-                            value={stakeInput}
-                            onChange={(e) => setStakeFromInput(e.target.value)}
-                            className="min-w-0 flex-1 bg-transparent text-sm font-semibold text-slate-100 outline-none"
-                            aria-label="Wager amount"
-                        />
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Payout</p>
-                      {boostedParlayPayout ? (
-                          <div className="mt-1">
-                            <p className="text-sm font-semibold line-through text-slate-500">${parlayPotentialPayout.toFixed(2)}</p>
-                            <p className="text-2xl font-semibold leading-tight text-amber-300">${boostedParlayPayout.toFixed(2)}</p>
-                          </div>
-                      ) : (
-                          <p className="mt-1 text-2xl font-semibold leading-tight text-slate-100">${parlayPotentialPayout.toFixed(2)}</p>
-                      )}
-                    </div>
-                  </div>
-                  <BoostBanner />
-                  <LimitBanner />
-                  {!isAffordable && (
-                      <p className="text-red-400 text-[10px] mt-2 font-semibold">Insufficient funds</p>
+          {tab === 'PARLAYS' && (
+            <div className="flex flex-col">
+              {isQueueEmpty ? (
+                <div
+                  className={cx(
+                    'rounded-xl border border-dashed px-4 py-12 text-center',
+                    darkSlip ? 'border-slate-600 bg-slate-900/40' : 'border-slate-200 bg-slate-50',
                   )}
-                  {!hasMinimumParlayLegs && (
-                      <p className="text-amber-300 text-[10px] mt-2 font-semibold">Add at least 2 legs to place a parlay.</p>
-                  )}
-                  <button
-                      type="button"
-                      disabled={parlayPlaceDisabled}
-                      onClick={() => onPlaceBet(stake, 'parlay')}
-                      className={`mt-3 w-full font-bold py-3 rounded-lg shadow-lg active:scale-[0.99] transition-all text-xs uppercase tracking-wide text-white ${
-                          parlayPlaceDisabled
-                              ? 'bg-slate-700 text-slate-500'
-                              : activeBoost
-                                  ? 'bg-amber-600 hover:bg-amber-500 shadow-amber-600/20'
-                                  : 'bg-violet-600 hover:bg-violet-500 shadow-violet-600/20'
-                      }`}
+                >
+                  <p className={cx('text-sm font-semibold', darkSlip ? 'text-slate-200' : 'text-slate-700')}>Build a parlay</p>
+                  <p className={cx('mt-1 text-xs', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                    Add picks from the board — strict parlay rules still apply.
+                  </p>
+                </div>
+              ) : !hasMinimumParlayLegs ? (
+                <div className={cx('rounded-xl border overflow-hidden', darkSlip ? 'border-slate-700 bg-slate-900/50' : 'border-slate-200 bg-white')}>
+                  <div
+                    className={cx(
+                      'border-b px-3 py-2',
+                      darkSlip ? 'border-slate-700 bg-amber-500/10' : 'border-slate-100 bg-amber-50',
+                    )}
                   >
-                    {activeBoost ? `PLACE BET + ${activeBoost === 'double_payout' ? '2× PAYOUT' : 'MONEY BACK'}` : 'PLACE BET'}
-                  </button>
-                </div>
-
-                <div className={`${cardClass} divide-y divide-slate-800/90`}>
-                  {parlayLegs.map((leg) => (
-                      <div key={leg.id} className="flex gap-2.5 p-3">
+                    <p className={cx('text-[11px] font-semibold', darkSlip ? 'text-amber-200' : 'text-amber-900')}>
+                      Add at least one more leg to place a parlay.
+                    </p>
+                  </div>
+                  <div className={cx('divide-y', darkSlip ? 'divide-slate-700' : 'divide-slate-100')}>
+                    {parlayLegs.map((leg) => (
+                      <div key={leg.id} className="flex gap-2 p-3">
                         <button
-                            type="button"
-                            onClick={() => onSelectBet(leg.market, leg.option)}
-                            className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-red-500/70 bg-red-500/10 text-red-400 hover:bg-red-500/20"
-                            aria-label="Remove leg"
+                          type="button"
+                          onClick={() => onSelectBet(leg.market, leg.option)}
+                          className={cx(
+                            'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded',
+                            darkSlip ? 'text-slate-500 hover:bg-slate-800' : 'text-slate-400 hover:bg-slate-100',
+                          )}
+                          aria-label="Remove leg"
                         >
-                          <Minus size={14} strokeWidth={2.5} />
+                          <X size={14} />
                         </button>
                         <div className="min-w-0 flex-1">
-                          <p className="text-sm font-bold text-slate-100 truncate">{leg.name}</p>
-                          <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">{leg.lineLabel}</p>
-                          <p className="text-xs text-slate-500 truncate mt-0.5">{leg.matchup}</p>
+                          <p className={cx('text-sm font-bold', darkSlip ? 'text-slate-100' : 'text-slate-900')}>{leg.name}</p>
+                          <p className={cx('text-[11px]', darkSlip ? 'text-slate-400' : 'text-slate-500')}>{leg.lineLabel}</p>
+                          <p className={cx('text-[11px] truncate', darkSlip ? 'text-slate-400' : 'text-slate-500')}>{leg.matchup}</p>
                         </div>
-                        <span className="shrink-0 text-base font-bold text-violet-300">{leg.odds}</span>
+                        <span className={cx('shrink-0 text-sm font-bold', darkSlip ? 'text-[#7dd3fc]' : 'text-slate-900')}>{leg.odds}</span>
                       </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
+              ) : (
+                <>
+                  <div
+                    className={cx(
+                      'overflow-hidden rounded-xl border shadow-sm',
+                      darkSlip ? 'border-slate-700 bg-slate-900/50' : 'border-slate-200 bg-white',
+                    )}
+                  >
+                    <div
+                      className={cx(
+                        'flex items-center justify-between border-b px-3 py-2',
+                        darkSlip ? 'border-slate-700' : 'border-slate-200',
+                      )}
+                    >
+                      <span className={cx('text-[10px] font-bold uppercase tracking-wide', darkSlip ? 'text-slate-500' : 'text-slate-500')}>
+                        Legs
+                      </span>
+                      <button
+                        type="button"
+                        onClick={onClear}
+                        disabled={!hasAnyPick}
+                        className={cx(
+                          'text-[10px] font-bold uppercase tracking-wide transition-colors disabled:opacity-35',
+                          darkSlip
+                            ? 'text-slate-400 hover:text-slate-200 disabled:hover:text-slate-400'
+                            : 'text-slate-600 hover:text-slate-900 disabled:hover:text-slate-600',
+                        )}
+                      >
+                        Clear all
+                      </button>
+                    </div>
 
-                <div className={`${cardClass} p-3.5`}>
-                  <div className="mb-2.5 flex items-center justify-between">
-                    <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">Current Parlays</p>
-                    <span className="rounded-full border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{parlayBets.length}</span>
-                  </div>
-                  {parlayBets.length === 0 ? (
-                      <p className="text-xs text-slate-500">No parlay bets placed yet.</p>
-                  ) : (
-                      <div className="space-y-2.5 max-h-48 overflow-y-auto pr-1">
-                        {parlayBets.slice(0, 10).map((bet) => (
-                            <div key={bet.id} className="rounded-xl border border-slate-700/80 bg-gradient-to-b from-slate-900 to-slate-900/70 p-2.5 shadow-[0_1px_0_rgba(148,163,184,0.12)_inset]">
-                              <p className="text-sm font-semibold text-slate-100 truncate">{bet.optionLabel}</p>
-                              <p className="mt-0.5 text-[11px] text-slate-400 truncate">{bet.marketTitle}</p>
-                              <p className="mt-1 text-[10px] text-slate-500">{bet.parlayLegs?.length ?? 0} legs</p>
-                              {!!bet.parlayLegs?.length && (
-                                  <button type="button" onClick={() => toggleParlayDetails(bet.id)} className="mt-1 text-[10px] font-semibold text-violet-300 hover:text-violet-200">
-                                    {expandedParlays[bet.id] ? 'hide legs' : 'show legs'}
-                                  </button>
-                              )}
-                              {!!bet.parlayLegs?.length && expandedParlays[bet.id] && (
-                                  <div className="mt-2 rounded-lg border border-slate-800 bg-slate-950/60 p-2">
-                                    <div className="space-y-1.5">
-                                      {bet.parlayLegs.map((leg, idx) => (
-                                          <div key={`${bet.id}-leg-${idx}`} className="rounded-md border border-slate-800/70 bg-slate-900/70 px-2 py-1.5">
-                                            <p className="text-[10px] font-semibold text-slate-200 truncate">{leg.optionLabel}</p>
-                                            <p className="text-[10px] text-slate-500 truncate">{leg.marketTitle}</p>
-                                            <p className="text-[10px] text-slate-400">odds {leg.odds.toFixed(2)}</p>
-                                          </div>
-                                      ))}
-                                    </div>
-                                  </div>
-                              )}
-                              <div className="mt-2 flex items-center justify-between text-[11px]">
-                                <span className="rounded-md border border-violet-500/25 bg-violet-500/10 px-1.5 py-0.5 font-semibold text-violet-200">Stake ${bet.stake.toFixed(2)}</span>
-                                <span className="font-semibold text-emerald-300">To win ${bet.potentialPayout.toFixed(2)}</span>
-                              </div>
-                            </div>
-                        ))}
+                    <div className={cx('divide-y', darkSlip ? 'divide-slate-700' : 'divide-slate-100')}>
+                      {parlayLegs.map((leg) => (
+                        <div key={leg.id} className="flex gap-2 p-3">
+                          <button
+                            type="button"
+                            onClick={() => onSelectBet(leg.market, leg.option)}
+                            className={cx(
+                              'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded',
+                              darkSlip ? 'text-slate-500 hover:bg-slate-800' : 'text-slate-400 hover:bg-slate-100',
+                            )}
+                            aria-label="Remove leg"
+                          >
+                            <X size={14} />
+                          </button>
+                          <div className="min-w-0 flex-1">
+                            <p className={cx('text-sm font-bold', darkSlip ? 'text-slate-100' : 'text-slate-900')}>{leg.name}</p>
+                            <p className={cx('text-[11px]', darkSlip ? 'text-slate-400' : 'text-slate-500')}>{leg.lineLabel}</p>
+                          </div>
+                          <span className={cx('shrink-0 text-sm font-bold tabular-nums', darkSlip ? 'text-[#7dd3fc]' : 'text-slate-900')}>
+                            {leg.odds}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div
+                      className={cx(
+                        'space-y-4 px-3 py-3',
+                        darkSlip ? 'bg-slate-900/70' : 'bg-slate-50/95',
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            {anyParlayLegLive ? (
+                              <span className="rounded px-1 py-0.5 text-[8px] font-bold uppercase bg-slate-900 text-white">
+                                Live
+                              </span>
+                            ) : null}
+                            <span className="rounded px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wide bg-violet-600 text-white">
+                              Parlay
+                            </span>
+                            <span className={cx('text-sm font-semibold', darkSlip ? 'text-slate-100' : 'text-slate-800')}>
+                              {parlayLegs.length}-Bet Parlay
+                            </span>
+                          </div>
+                        </div>
+                        <span
+                          className={cx(
+                            'shrink-0 text-base font-black tabular-nums leading-none',
+                            darkSlip ? 'text-violet-300' : 'text-violet-600',
+                          )}
+                        >
+                          {fmtAmerican(parlayAmericanOdds)}
+                        </span>
                       </div>
-                  )}
-                </div>
-                <RecentBetsCard
-                    title="Recent Bets"
-                    bets={recentParlays}
-                    emptyText="No settled parlays yet. Once every leg finalizes, results land here."
-                    kind="parlay"
-                />
-              </div>
-          ) : tab === 'PARLAYS' ? (
-              <div className="mb-4 flex flex-col gap-3">
-                <div className={`${cardClass} px-4 py-10 text-center text-slate-400 lg:min-h-[28vh] flex flex-col items-center justify-center`}>
-                  <p className="text-sm font-semibold text-slate-300 mb-1">No parlay legs yet</p>
-                  <p className="text-xs text-slate-500">Add two or more picks to build a parlay.</p>
-                </div>
-                <div className={`${cardClass} p-3.5`}>
-                  <div className="mb-2.5 flex items-center justify-between">
-                    <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">Current Parlays</p>
-                    <span className="rounded-full border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{parlayBets.length}</span>
-                  </div>
-                  {parlayBets.length === 0 ? (
-                      <p className="text-xs text-slate-500">No parlay bets placed yet.</p>
-                  ) : (
-                      <div className="space-y-2.5 max-h-48 overflow-y-auto pr-1">
-                        {parlayBets.slice(0, 10).map((bet) => (
-                            <div key={bet.id} className="rounded-xl border border-slate-700/80 bg-gradient-to-b from-slate-900 to-slate-900/70 p-2.5 shadow-[0_1px_0_rgba(148,163,184,0.12)_inset]">
-                              <p className="text-sm font-semibold text-slate-100 truncate">{bet.optionLabel}</p>
-                              <p className="mt-0.5 text-[11px] text-slate-400 truncate">{bet.marketTitle}</p>
-                              <p className="mt-1 text-[10px] text-slate-500">{bet.parlayLegs?.length ?? 0} legs</p>
-                              {!!bet.parlayLegs?.length && (
-                                  <button type="button" onClick={() => toggleParlayDetails(bet.id)} className="mt-1 text-[10px] font-semibold text-violet-300 hover:text-violet-200">
-                                    {expandedParlays[bet.id] ? 'hide legs' : 'show legs'}
-                                  </button>
-                              )}
-                              {!!bet.parlayLegs?.length && expandedParlays[bet.id] && (
-                                  <div className="mt-2 rounded-lg border border-slate-800 bg-slate-950/60 p-2">
-                                    <div className="space-y-1.5">
-                                      {bet.parlayLegs.map((leg, idx) => (
-                                          <div key={`${bet.id}-leg-${idx}`} className="rounded-md border border-slate-800/70 bg-slate-900/70 px-2 py-1.5">
-                                            <p className="text-[10px] font-semibold text-slate-200 truncate">{leg.optionLabel}</p>
-                                            <p className="text-[10px] text-slate-500 truncate">{leg.marketTitle}</p>
-                                            <p className="text-[10px] text-slate-400">odds {leg.odds.toFixed(2)}</p>
-                                          </div>
-                                      ))}
-                                    </div>
-                                  </div>
-                              )}
-                              <div className="mt-2 flex items-center justify-between text-[11px]">
-                                <span className="rounded-md border border-violet-500/25 bg-violet-500/10 px-1.5 py-0.5 font-semibold text-violet-200">Stake ${bet.stake.toFixed(2)}</span>
-                                <span className="font-semibold text-emerald-300">To win ${bet.potentialPayout.toFixed(2)}</span>
-                              </div>
+
+                      <div className="grid grid-cols-2 gap-6">
+                        <div>
+                          <p className={cx('text-[9px] font-bold uppercase tracking-wide', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+                            Wager
+                          </p>
+                          <div className="mt-1.5">
+                            <StakeField fullWidth />
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <p className={cx('text-[9px] font-bold uppercase tracking-wide', darkSlip ? 'text-slate-400' : 'text-slate-500')}>
+                            Payout
+                          </p>
+                          {boostedParlayPayout ? (
+                            <div className="mt-1.5">
+                              <p className={cx('text-xs line-through', darkSlip ? 'text-slate-500' : 'text-slate-400')}>
+                                ${parlayPotentialPayout.toFixed(2)}
+                              </p>
+                              <p className={cx('text-xl font-bold tabular-nums', darkSlip ? 'text-amber-300' : 'text-amber-700')}>
+                                ${boostedParlayPayout.toFixed(2)}
+                              </p>
                             </div>
-                        ))}
+                          ) : (
+                            <p className={cx('mt-1.5 text-xl font-bold tabular-nums', darkSlip ? 'text-slate-100' : 'text-slate-900')}>
+                              ${parlayPotentialPayout.toFixed(2)}
+                            </p>
+                          )}
+                        </div>
                       </div>
-                  )}
-                </div>
-                <RecentBetsCard
-                    title="Recent Bets"
-                    bets={recentParlays}
-                    emptyText="No settled parlays yet. Once every leg finalizes, results land here."
-                    kind="parlay"
-                />
-              </div>
-          ) : null}
+
+                      <div>
+                        <BoostBanner />
+                        <LimitBanner />
+                        {!isAffordable && (
+                          <p className={cx('text-[10px] mt-2 font-semibold', darkSlip ? 'text-red-400' : 'text-red-600')}>
+                            Insufficient funds
+                          </p>
+                        )}
+                        <button
+                          type="button"
+                          disabled={parlayPlaceDisabled}
+                          onClick={() => onPlaceBet(stake, 'parlay')}
+                          className={cx(
+                            'mt-3 w-full rounded-lg py-3 text-xs font-black uppercase tracking-wide active:scale-[0.99]',
+                            parlayPlaceDisabled
+                              ? slipAccentBtnDisabled
+                              : activeBoost
+                                ? 'bg-amber-500 text-slate-900 hover:bg-amber-400'
+                                : slipAccentBtn,
+                          )}
+                        >
+                          {activeBoost
+                            ? `Place parlay · ${activeBoost === 'double_payout' ? '2× payout' : 'Money back'}`
+                            : 'Place parlay'}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </>
+              )}
+              <CurrentBetPreview />
+            </div>
+          )}
+
+          {tab === 'ACTIVE' && renderActiveTab()}
         </div>
+
       </div>
+    </div>
   );
 };

--- a/components/BetSlip.tsx
+++ b/components/BetSlip.tsx
@@ -14,6 +14,7 @@ interface BetSlipProps {
   onClose: () => void;
   onClear: () => void;
   onSelectBet: (market: Market, option: MarketOption) => void;
+  onFocusSelection: (market: Market, option: MarketOption) => void;
   balance: number;
   activeBoost: BoostType | null;
   limitError: string | null;
@@ -37,6 +38,7 @@ export const BetSlip: React.FC<BetSlipProps> = ({
                                                   onClose,
                                                   onClear,
                                                   onSelectBet,
+                                                  onFocusSelection,
                                                   balance,
                                                   activeBoost,
                                                   limitError,
@@ -177,8 +179,11 @@ export const BetSlip: React.FC<BetSlipProps> = ({
     const key = `${selection.market.id}:${selection.option.id}`;
     if (previousSelectionKey.current === key) return;
     previousSelectionKey.current = key;
+    // With 2+ legs we’re building a parlay queue; don’t force Singles when
+    // the user adds another pick (that was hiding the Parlays tab).
+    if (parlaySelections.length >= 2) return;
     setTab('SINGLES');
-  }, [selection]);
+  }, [selection, parlaySelections.length]);
 
   const setStakeFromInput = (raw: string) => {
     const cleaned = raw.replace(/[^\d.]/g, '');
@@ -200,6 +205,9 @@ export const BetSlip: React.FC<BetSlipProps> = ({
   const singlesPlaceDisabled = isSinglesEmpty || !isAffordable || stake <= 0 || !!limitError;
   const parlayPlaceDisabled  = !hasMinimumParlayLegs || !isAffordable || stake <= 0 || !!limitError;
   const tabLabels: Record<SlipTab, string> = { SINGLES: 'Singles', PARLAYS: 'Parlays' };
+  const selectionKey =
+    selection ? `${selection.market.id}:${selection.option.id}` : '';
+  const hasMultipleQueuedPicks = parlaySelections.length >= 2;
 
   const cardClass = 'rounded-xl border border-slate-800 bg-[#100d1f]';
 
@@ -459,6 +467,77 @@ export const BetSlip: React.FC<BetSlipProps> = ({
                   </button>
                 </div>
 
+                {hasMultipleQueuedPicks ? (
+                  <div className={`${cardClass} p-2.5`}>
+                    <div className="mb-2 flex items-center justify-between">
+                      <p className="text-[10px] font-bold uppercase tracking-wider text-blue-300">
+                        {parlaySelections.length} queued singles
+                      </p>
+                    </div>
+                    <div className="max-h-52 space-y-2 overflow-y-auto pr-0.5">
+                      {parlayLegs.map((leg) => {
+                        const isActive = `${leg.market.id}:${leg.option.id}` === selectionKey;
+                        const cardPayout = stake > 0 ? stake * leg.option.odds : 0;
+                        return (
+                          <div
+                            key={leg.id}
+                            className={`rounded-lg border p-2 ${
+                              isActive
+                                ? 'border-blue-500/60 bg-blue-500/10'
+                                : 'border-slate-700/80 bg-slate-900/70'
+                            }`}
+                          >
+                            <div className="mb-1 flex items-center justify-between gap-2">
+                              <span className="shrink-0 rounded-full bg-white px-1.5 py-0.5 text-[8px] font-black uppercase tracking-wide text-black">
+                                Single
+                              </span>
+                              <span className="text-sm font-bold text-violet-300">{leg.odds}</span>
+                            </div>
+                            <p className="truncate text-base font-bold text-slate-100">{leg.option.label}</p>
+                            <div className="mt-1.5 grid grid-cols-2 gap-2 text-[10px]">
+                              <div>
+                                <p className="font-bold uppercase tracking-wide text-slate-500">Wager</p>
+                                <p className="font-semibold text-slate-200">${stake.toFixed(2)}</p>
+                              </div>
+                              <div className="text-right">
+                                <p className="font-bold uppercase tracking-wide text-slate-500">Payout</p>
+                                <p className="font-semibold text-slate-100">${cardPayout.toFixed(2)}</p>
+                              </div>
+                            </div>
+                            <div className="mt-2 grid grid-cols-2 gap-2">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  if (isActive) onPlaceBet(stake, 'single');
+                                  else onFocusSelection(leg.market, leg.option);
+                                }}
+                                disabled={stake <= 0 || !isAffordable || !!limitError}
+                                className={`rounded-md py-1.5 text-[10px] font-bold uppercase tracking-wide transition-colors ${
+                                  stake <= 0 || !isAffordable || !!limitError
+                                    ? 'bg-slate-700 text-slate-500'
+                                    : isActive
+                                      ? 'bg-violet-600 text-white hover:bg-violet-500'
+                                      : 'border border-slate-600 bg-slate-800 text-slate-100 hover:border-blue-500/70'
+                                }`}
+                              >
+                                {isActive ? 'Place Single' : 'Select'}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setTab('PARLAYS')}
+                                className="rounded-md border border-violet-500/50 bg-violet-600/25 py-1.5 text-[10px] font-bold uppercase tracking-wide text-violet-100 transition-colors hover:bg-violet-600/40"
+                              >
+                                Add to Parlay
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+
+                {!hasMultipleQueuedPicks ? (
                 <div className={`${cardClass} p-3`}>
                   <div className="flex gap-2.5">
                     <button
@@ -479,6 +558,7 @@ export const BetSlip: React.FC<BetSlipProps> = ({
                 </span>
                   </div>
                 </div>
+                ) : null}
 
                 <div className={`${cardClass} p-3.5`}>
                   <div className="mb-2.5 flex items-center justify-between">

--- a/components/Betofthedaycard.tsx
+++ b/components/Betofthedaycard.tsx
@@ -212,12 +212,12 @@ export const BetOfTheDayCard: React.FC<BetOfTheDayCardProps> = ({ uid }) => {
                                             onClick={() => setSelected(prev => prev?.id === opt.id ? null : opt)}
                                             className={`rounded-lg border px-3 py-2 text-left transition-all ${
                                                 selectedOption?.id === opt.id
-                                                    ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
-                                                    : 'border-slate-700 bg-slate-900 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                                    ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 shadow-[0_0_0_1px_rgba(63,169,245,0.45)]'
+                                                    : 'border-slate-700 bg-slate-900 hover:border-[#3FA9F5]/75 hover:bg-[#3FA9F5]/12'
                                             }`}
                                         >
                                             <p className="text-[10px] text-slate-400 truncate">{opt.label}</p>
-                                            <p className={`text-sm font-semibold ${selectedOption?.id === opt.id ? 'text-violet-200' : 'text-blue-300'}`}>
+                                            <p className={`text-sm font-semibold ${selectedOption?.id === opt.id ? 'text-[#7dd3fc]' : 'text-[#3FA9F5]'}`}>
                                                 {opt.odds.toFixed(2)}
                                             </p>
                                         </button>
@@ -231,7 +231,7 @@ export const BetOfTheDayCard: React.FC<BetOfTheDayCardProps> = ({ uid }) => {
                             disabled={!selectedOption || isSubmitting}
                             className={`w-full py-2.5 rounded-xl text-sm font-bold uppercase tracking-wide transition-all active:scale-95 ${
                                 selectedOption && !isSubmitting
-                                    ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-md shadow-indigo-700/30'
+                                    ? 'bg-[#3FA9F5] hover:bg-[#2e9ae8] text-slate-950 shadow-md shadow-[#3FA9F5]/25'
                                     : 'bg-slate-700 text-slate-500 cursor-not-allowed'
                             }`}
                         >

--- a/components/CounterBetDmCard.tsx
+++ b/components/CounterBetDmCard.tsx
@@ -12,7 +12,7 @@ interface CounterBetDmCardProps {
 }
 
 const STATUS: Record<HeadToHeadStatus, string> = {
-  PENDING_ACCEPT: 'Waiting for them to accept your counter',
+  PENDING_ACCEPT: 'Pending',
   ACCEPTED: 'Accepted',
   DECLINED: 'They declined',
   CANCELLED: 'Withdrawn',

--- a/components/CounterBetDmCard.tsx
+++ b/components/CounterBetDmCard.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import { useNavigate } from 'react-router-dom';
+import type { HeadToHeadStatus } from '@/models';
+
+const H2H = 'headToHead';
+
+interface CounterBetDmCardProps {
+  h2hId: string;
+  currentUserId: string;
+}
+
+const STATUS: Record<HeadToHeadStatus, string> = {
+  PENDING_ACCEPT: 'Waiting for them to accept your counter',
+  ACCEPTED: 'Accepted',
+  DECLINED: 'They declined',
+  CANCELLED: 'Withdrawn',
+  WON_BY_ORIGINAL: 'Settled (they kept the pick)',
+  WON_BY_CHALLENGER: 'Settled (you won the fade)',
+  PUSH: 'Push',
+};
+
+export const CounterBetDmCard: React.FC<CounterBetDmCardProps> = ({ h2hId, currentUserId }) => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [side, setSide] = useState('');
+  const [stake, setStake] = useState(0);
+  const [cStake, setCStake] = useState(0);
+  const [status, setStatus] = useState<HeadToHeadStatus | null>(null);
+  const [originalUid, setOriginalUid] = useState('');
+  const [challengerUid, setChallengerUid] = useState('');
+
+  useEffect(() => {
+    const r = doc(db, H2H, h2hId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) {
+        setStatus(null);
+        return;
+      }
+      const d = snap.data();
+      setTitle(String(d.marketTitle ?? ''));
+      setSide(String(d.originalSide ?? ''));
+      setStake(Number(d.originalStake) || 0);
+      setCStake(Number(d.challengerStake) || 0);
+      setStatus((d.status as HeadToHeadStatus) ?? 'PENDING_ACCEPT');
+      setOriginalUid(String(d.originalUserId ?? ''));
+      setChallengerUid(String(d.challengerUserId ?? ''));
+    });
+    return () => unsub();
+  }, [h2hId]);
+
+  if (status === null) {
+    return (
+      <div className="rounded-lg border border-slate-700/60 bg-slate-950/40 px-3 py-2 text-xs text-slate-500">
+        Loading counter-bet…
+      </div>
+    );
+  }
+
+  const perspective =
+    currentUserId === originalUid ? 'original' : currentUserId === challengerUid ? 'challenger' : 'spectator';
+
+  return (
+    <div className="rounded-xl border border-red-500/35 bg-red-500/[0.07] px-3 py-3 text-left">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-red-300/90">Counter-bet</p>
+      <p className="mt-1 text-sm font-bold text-slate-100 line-clamp-2">{title}</p>
+      <p className="mt-1 text-[11px] text-slate-300">
+        Their pick: <span className="text-blue-300">{side}</span>
+      </p>
+      <p className="mt-1 text-[11px] text-slate-500">
+        Stakes (escrow): ${stake.toFixed(2)} vs ${cStake.toFixed(2)}
+      </p>
+      <p className="mt-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+        {STATUS[status]}
+        {perspective === 'spectator' ? ' · Open Head-to-Head if this is your thread.' : ''}
+      </p>
+      <button
+        type="button"
+        onClick={() => navigate('/head-to-head')}
+        className="mt-2 w-full rounded-lg border border-slate-600 bg-slate-950/40 py-1.5 text-[11px] font-bold uppercase tracking-wide text-slate-200 hover:bg-slate-800/80"
+      >
+        Open head-to-head
+      </button>
+    </div>
+  );
+};

--- a/components/CounterBetModal.tsx
+++ b/components/CounterBetModal.tsx
@@ -14,6 +14,10 @@ interface CounterBetModalProps {
   onConfirm: (originalBetId: string) => Promise<ProposeHeadToHeadResult>;
   /** Closes the modal without proposing. */
   onClose: () => void;
+  /** When set, called instead of onClose after a successful proposal (e.g. parent closes a wrapper modal). */
+  onAfterSuccess?: () => void;
+  /** Stacking order for nested modals (default z-50). */
+  overlayZIndexClass?: string;
 }
 
 /**
@@ -31,6 +35,8 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
   balance,
   onConfirm,
   onClose,
+  onAfterSuccess,
+  overlayZIndexClass = 'z-50',
 }) => {
   const [submitting, setSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -49,7 +55,8 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
     try {
       const result = await onConfirm(bet.id);
       if (result.success) {
-        onClose();
+        if (onAfterSuccess) onAfterSuccess();
+        else onClose();
       } else {
         setErrorMsg(friendlyError(result.error));
       }
@@ -62,7 +69,7 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+    <div className={`fixed inset-0 ${overlayZIndexClass} flex items-center justify-center bg-black/70 backdrop-blur-sm p-4 animate-in fade-in duration-200`}>
       <div className="w-full max-w-md rounded-2xl border border-slate-700 bg-slate-900 shadow-2xl shadow-red-900/20 animate-in zoom-in-95 duration-200">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-slate-800 px-5 py-4">

--- a/components/CounterBetModal.tsx
+++ b/components/CounterBetModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Swords, X, AlertCircle, Wallet, Target } from 'lucide-react';
 import type { Bet } from '../models';
-import type { ProposeHeadToHeadResult } from '../services/dbOps';
+import { notifyHeadToHeadProposalDm, type ProposeHeadToHeadResult } from '../services/dbOps';
 
 interface CounterBetModalProps {
   /** The bet being faded (someone else's pending bet). */
@@ -18,6 +18,8 @@ interface CounterBetModalProps {
   onAfterSuccess?: () => void;
   /** Stacking order for nested modals (default z-50). */
   overlayZIndexClass?: string;
+  /** When set, posts optional note + counter invite into the DM thread after a successful proposal. */
+  counterDm?: { messagingFromUserId: string; opponentUserId: string };
 }
 
 /**
@@ -37,9 +39,11 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
   onClose,
   onAfterSuccess,
   overlayZIndexClass = 'z-50',
+  counterDm,
 }) => {
   const [submitting, setSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [dmNote, setDmNote] = useState('');
 
   // Odds-matched math. Mirror the server-side computeChallengerStake so the
   // user sees the exact value that will be debited.
@@ -55,6 +59,14 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
     try {
       const result = await onConfirm(bet.id);
       if (result.success) {
+        if (counterDm?.messagingFromUserId && counterDm.opponentUserId && result.h2hId) {
+          await notifyHeadToHeadProposalDm({
+            challengerUid: counterDm.messagingFromUserId,
+            opponentUid: counterDm.opponentUserId,
+            h2hId: result.h2hId,
+            optionalNote: dmNote.trim() || undefined,
+          });
+        }
         if (onAfterSuccess) onAfterSuccess();
         else onClose();
       } else {
@@ -112,6 +124,23 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
             </div>
           </div>
 
+          {counterDm && (
+            <div>
+              <label className="text-[10px] font-bold uppercase tracking-wider text-slate-500" htmlFor="counter-dm-note">
+                Optional message (sent first in chat)
+              </label>
+              <textarea
+                id="counter-dm-note"
+                value={dmNote}
+                onChange={(e) => setDmNote(e.target.value)}
+                rows={2}
+                maxLength={500}
+                placeholder="Trash talk or context…"
+                className="mt-1 w-full resize-none rounded-xl border border-slate-700 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 outline-none focus:border-red-500/40"
+              />
+            </div>
+          )}
+
           {/* The math */}
           <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-3 space-y-2 text-sm">
             <div className="flex items-center justify-between">
@@ -132,7 +161,9 @@ export const CounterBetModal: React.FC<CounterBetModalProps> = ({
           <p className="text-[11px] text-slate-500 leading-relaxed">
             Stakes are odds-matched. {ownerName} must <span className="text-slate-300">accept</span>
             {' '}before the H2H is locked in. If they decline, you&apos;re refunded in full.
-            No fades after kickoff.
+            {(bet.marketId ?? '').startsWith('mock-')
+              ? ' Simulated mock games ignore synthetic kickoff times for fades.'
+              : ' No fades after kickoff on real-odds events.'}
           </p>
 
           {/* Errors */}

--- a/components/CounterBetSettlementDmCard.tsx
+++ b/components/CounterBetSettlementDmCard.tsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import { useNavigate } from 'react-router-dom';
+import { Swords, Trophy, ChevronDown, ChevronUp, Sparkles, Skull } from 'lucide-react';
+import type { Bet, HeadToHeadStatus, ParlayLeg } from '@/models';
+
+const H2H = 'headToHead';
+
+interface CounterBetSettlementDmCardProps {
+  h2hId: string;
+  currentUserId: string;
+}
+
+function outcomeForViewer(
+  status: HeadToHeadStatus,
+  currentUserId: string,
+  originalUid: string,
+  challengerUid: string,
+): 'win' | 'loss' | 'push' | 'pending' {
+  if (status === 'PUSH') return 'push';
+  if (status === 'WON_BY_ORIGINAL') {
+    if (currentUserId === originalUid) return 'win';
+    if (currentUserId === challengerUid) return 'loss';
+  }
+  if (status === 'WON_BY_CHALLENGER') {
+    if (currentUserId === challengerUid) return 'win';
+    if (currentUserId === originalUid) return 'loss';
+  }
+  return 'pending';
+}
+
+/**
+ * Rich DM bubble after a counter-bet settles — gold for your win, bronze/red for a loss, actions to run it back.
+ */
+export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProps> = ({ h2hId, currentUserId }) => {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<HeadToHeadStatus | null>(null);
+  const [marketTitle, setMarketTitle] = useState('');
+  const [originalSide, setOriginalSide] = useState('');
+  const [originalStake, setOriginalStake] = useState(0);
+  const [challengerStake, setChallengerStake] = useState(0);
+  const [originalUid, setOriginalUid] = useState('');
+  const [challengerUid, setChallengerUid] = useState('');
+  const [originalBetId, setOriginalBetId] = useState('');
+  const [linkedBet, setLinkedBet] = useState<Bet | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
+
+  useEffect(() => {
+    const r = doc(db, H2H, h2hId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) {
+        setStatus(null);
+        return;
+      }
+      const d = snap.data();
+      setStatus((d.status as HeadToHeadStatus) ?? 'PENDING_ACCEPT');
+      setMarketTitle(String(d.marketTitle ?? ''));
+      setOriginalSide(String(d.originalSide ?? ''));
+      setOriginalStake(Number(d.originalStake) || 0);
+      setChallengerStake(Number(d.challengerStake) || 0);
+      setOriginalUid(String(d.originalUserId ?? ''));
+      setChallengerUid(String(d.challengerUserId ?? ''));
+      setOriginalBetId(String(d.originalBetId ?? ''));
+    });
+    return () => unsub();
+  }, [h2hId]);
+
+  useEffect(() => {
+    if (!originalBetId) return;
+    let cancelled = false;
+    void getDoc(doc(db, 'bets', originalBetId)).then((snap) => {
+      if (cancelled || !snap.exists()) return;
+      const data = snap.data();
+      const legs: ParlayLeg[] = Array.isArray(data.parlayLegs)
+        ? data.parlayLegs.map((leg: Record<string, unknown>): ParlayLeg => ({
+            marketId: String(leg.marketId ?? ''),
+            marketTitle: String(leg.marketTitle ?? ''),
+            sportKey: String(leg.sportKey ?? ''),
+            optionId: String(leg.optionId ?? ''),
+            optionLabel: String(leg.optionLabel ?? ''),
+            odds: Number(leg.odds) || 0,
+            marketKey: (leg.marketKey as ParlayLeg['marketKey']) ?? 'h2h',
+            result: (leg.result as ParlayLeg['result']) ?? 'PENDING',
+          }))
+        : [];
+      const b: Bet = {
+        id: snap.id,
+        userID: String(data.userID ?? ''),
+        marketId: String(data.marketId ?? ''),
+        marketTitle: String(data.marketTitle ?? ''),
+        optionLabel: String(data.optionLabel ?? ''),
+        betType: data.betType === 'parlay' ? 'parlay' : 'single',
+        stake: Number(data.stake) || 0,
+        odds: Number(data.odds) || 0,
+        potentialPayout: Number(data.potentialPayout) || 0,
+        placedAt: data.placedAt?.toDate?.() ?? new Date(),
+        legCount: Number(data.legCount) ?? 1,
+        parlayLegs: legs,
+        status: (data.status ?? 'PENDING') as Bet['status'],
+        settledAt: data.settledAt?.toDate?.(),
+      };
+      setLinkedBet(b);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [originalBetId]);
+
+  if (status === null) {
+    return (
+      <div className="rounded-xl border border-slate-700/60 bg-slate-950/50 px-3 py-2 text-xs text-slate-500">
+        Loading counter result…
+      </div>
+    );
+  }
+
+  const viewer = outcomeForViewer(status, currentUserId, originalUid, challengerUid);
+  const opponentUid = currentUserId === originalUid ? challengerUid : originalUid;
+  const totalEscrow = originalStake + challengerStake;
+
+  const shell =
+    viewer === 'win'
+      ? 'border-amber-400/50 bg-gradient-to-br from-amber-500/20 via-yellow-500/10 to-orange-600/15 shadow-[0_0_28px_rgba(251,191,36,0.35)]'
+      : viewer === 'loss'
+        ? 'border-rose-500/45 bg-gradient-to-br from-rose-950/80 via-orange-950/50 to-slate-950/90 shadow-[0_0_22px_rgba(244,63,94,0.28)]'
+        : viewer === 'push'
+          ? 'border-slate-500/40 bg-slate-900/80 shadow-[0_0_16px_rgba(148,163,184,0.2)]'
+          : 'border-slate-600/50 bg-slate-950/60';
+
+  const headline =
+    viewer === 'win'
+      ? 'You took the bag'
+      : viewer === 'loss'
+        ? 'Not your night'
+        : viewer === 'push'
+          ? 'Split the difference'
+          : 'Counter-bet update';
+
+  const sub =
+    viewer === 'win'
+      ? status === 'WON_BY_ORIGINAL'
+        ? 'Your pick held — full escrow is yours.'
+        : 'The fade hit — you cleared the counter.'
+      : viewer === 'loss'
+        ? status === 'WON_BY_ORIGINAL'
+          ? 'Their pick stood — they walk with the counter pot.'
+          : 'Your side didn’t cash — they earned the fade.'
+        : viewer === 'push'
+          ? 'Push — both escrows returned to wallets.'
+          : 'Still settling…';
+
+  return (
+    <div className={`rounded-2xl border px-3.5 py-3.5 text-left ${shell}`}>
+      <div className="flex items-start gap-2">
+        {viewer === 'win' ? (
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/40">
+            <Trophy className="h-5 w-5 drop-shadow-[0_0_8px_rgba(251,191,36,0.9)]" />
+          </div>
+        ) : viewer === 'loss' ? (
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/35">
+            <Skull className="h-5 w-5" />
+          </div>
+        ) : (
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-600/30 text-slate-200">
+            <Sparkles className="h-4 w-4" />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p
+            className={`text-[10px] font-black uppercase tracking-[0.2em] ${
+              viewer === 'win' ? 'text-amber-200/90' : viewer === 'loss' ? 'text-rose-200/85' : 'text-slate-400'
+            }`}
+          >
+            Counter settled
+          </p>
+          <h4
+            className={`mt-1 text-lg font-black tracking-tight ${
+              viewer === 'win'
+                ? 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 drop-shadow-[0_0_12px_rgba(253,224,71,0.45)]'
+                : viewer === 'loss'
+                  ? 'text-transparent bg-clip-text bg-gradient-to-r from-rose-200 via-orange-200 to-amber-900/80'
+                  : 'text-slate-100'
+            }`}
+          >
+            {headline}
+          </h4>
+          <p className="mt-1 text-[12px] leading-snug text-slate-300">{sub}</p>
+          <p className="mt-2 text-sm font-bold text-slate-100 line-clamp-2">{marketTitle}</p>
+          <p className="mt-0.5 text-[11px] text-slate-400">
+            Faded side: <span className="text-sky-300">{originalSide}</span>
+          </p>
+          <p className="mt-1 text-[11px] font-semibold text-slate-400">
+            Escrow pot <span className="text-slate-200">${totalEscrow.toFixed(2)}</span>
+          </p>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setShowDetails((v) => !v)}
+        className="mt-3 flex w-full items-center justify-center gap-1 rounded-lg border border-slate-600/60 bg-slate-950/40 py-2 text-[11px] font-bold uppercase tracking-wide text-slate-300 hover:bg-slate-800/60"
+      >
+        {showDetails ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        {showDetails ? 'Hide ticket' : 'View full bet'}
+      </button>
+
+      {showDetails && linkedBet && (
+        <div className="mt-2 rounded-xl border border-slate-700/70 bg-slate-950/70 p-3 text-[11px] text-slate-300">
+          <p className="font-semibold text-slate-200">{linkedBet.optionLabel}</p>
+          <p className="mt-1 text-slate-500">{linkedBet.marketTitle}</p>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <div>
+              <span className="text-slate-500">Stake</span>
+              <p className="font-mono text-slate-200">${linkedBet.stake.toFixed(2)}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Odds</span>
+              <p className="font-mono text-slate-200">{linkedBet.odds.toFixed(2)}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Result</span>
+              <p className="font-mono text-slate-200">{linkedBet.status}</p>
+            </div>
+          </div>
+        </div>
+      )}
+      {showDetails && !linkedBet && originalBetId ? (
+        <p className="mt-2 text-center text-[11px] text-slate-500">Loading ticket…</p>
+      ) : null}
+
+      {opponentUid && viewer !== 'pending' ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={() =>
+              navigate(`/profile/${opponentUid}`, {
+                state: { openGameChallenge: true },
+              })
+            }
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-amber-500/40 bg-amber-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-amber-100 hover:bg-amber-500/20"
+          >
+            <Trophy size={14} />
+            Challenge
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              navigate(`/profile/${opponentUid}`, {
+                state: { openCounter: true },
+              })
+            }
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-red-500/40 bg-red-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-red-100 hover:bg-red-500/20"
+          >
+            <Swords size={14} />
+            Counter
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/components/CounterBetSettlementDmCard.tsx
+++ b/components/CounterBetSettlementDmCard.tsx
@@ -10,6 +10,8 @@ const H2H = 'headToHead';
 interface CounterBetSettlementDmCardProps {
   h2hId: string;
   currentUserId: string;
+  /** Opens full-screen win/loss recap (from parent / chat host). */
+  onOpenFull?: () => void;
 }
 
 function outcomeForViewer(
@@ -33,7 +35,11 @@ function outcomeForViewer(
 /**
  * Rich DM bubble after a counter-bet settles — gold for your win, bronze/red for a loss, actions to run it back.
  */
-export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProps> = ({ h2hId, currentUserId }) => {
+export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProps> = ({
+  h2hId,
+  currentUserId,
+  onOpenFull,
+}) => {
   const navigate = useNavigate();
   const [status, setStatus] = useState<HeadToHeadStatus | null>(null);
   const [marketTitle, setMarketTitle] = useState('');
@@ -152,6 +158,19 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
 
   return (
     <div className={`rounded-2xl border px-3.5 py-3.5 text-left ${shell}`}>
+      <div
+        role={onOpenFull ? 'button' : undefined}
+        tabIndex={onOpenFull ? 0 : undefined}
+        className={onOpenFull ? 'cursor-pointer rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50' : undefined}
+        onClick={() => onOpenFull?.()}
+        onKeyDown={(e) => {
+          if (!onOpenFull) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onOpenFull();
+          }
+        }}
+      >
       <div className="flex items-start gap-2">
         {viewer === 'win' ? (
           <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/40">
@@ -193,12 +212,19 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
           <p className="mt-1 text-[11px] font-semibold text-slate-400">
             Escrow pot <span className="text-slate-200">${totalEscrow.toFixed(2)}</span>
           </p>
+          {onOpenFull ? (
+            <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">Tap for full-screen recap</p>
+          ) : null}
         </div>
+      </div>
       </div>
 
       <button
         type="button"
-        onClick={() => setShowDetails((v) => !v)}
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowDetails((v) => !v);
+        }}
         className="mt-3 flex w-full items-center justify-center gap-1 rounded-lg border border-slate-600/60 bg-slate-950/40 py-2 text-[11px] font-bold uppercase tracking-wide text-slate-300 hover:bg-slate-800/60"
       >
         {showDetails ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
@@ -233,11 +259,12 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
         <div className="mt-3 grid gap-2 sm:grid-cols-2">
           <button
             type="button"
-            onClick={() =>
+            onClick={(e) => {
+              e.stopPropagation();
               navigate(`/profile/${opponentUid}`, {
                 state: { openGameChallenge: true },
-              })
-            }
+              });
+            }}
             className="flex items-center justify-center gap-1.5 rounded-xl border border-amber-500/40 bg-amber-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-amber-100 hover:bg-amber-500/20"
           >
             <Trophy size={14} />
@@ -245,11 +272,12 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
           </button>
           <button
             type="button"
-            onClick={() =>
+            onClick={(e) => {
+              e.stopPropagation();
               navigate(`/profile/${opponentUid}`, {
                 state: { openCounter: true },
-              })
-            }
+              });
+            }}
             className="flex items-center justify-center gap-1.5 rounded-xl border border-red-500/40 bg-red-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-red-100 hover:bg-red-500/20"
           >
             <Swords size={14} />

--- a/components/CounterBetSettlementDmCard.tsx
+++ b/components/CounterBetSettlementDmCard.tsx
@@ -191,7 +191,7 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
               viewer === 'win' ? 'text-amber-200/90' : viewer === 'loss' ? 'text-rose-200/85' : 'text-slate-400'
             }`}
           >
-            Counter settled
+            Counter settled.
           </p>
           <h4
             className={`mt-1 text-lg font-black tracking-tight ${
@@ -213,7 +213,7 @@ export const CounterBetSettlementDmCard: React.FC<CounterBetSettlementDmCardProp
             Escrow pot <span className="text-slate-200">${totalEscrow.toFixed(2)}</span>
           </p>
           {onOpenFull ? (
-            <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">Tap for full-screen recap</p>
+            <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">View Recap:</p>
           ) : null}
         </div>
       </div>

--- a/components/CounterOpponentModal.tsx
+++ b/components/CounterOpponentModal.tsx
@@ -136,7 +136,7 @@ export const CounterOpponentModal: React.FC<CounterOpponentModalProps> = ({
                 {opponentDisplayName}
               </h2>
               <p className="text-[11px] leading-snug text-slate-400">
-                Pick one of their pending slips to fade — same head-to-head counter as on their profile.
+                Choose one of their pending slips to counter.
               </p>
             </div>
           </div>
@@ -255,6 +255,11 @@ export const CounterOpponentModal: React.FC<CounterOpponentModalProps> = ({
           ownerName={opponentDisplayName}
           balance={balance}
           overlayZIndexClass="z-[65]"
+          counterDm={
+            currentUserId && opponentUserId
+              ? { messagingFromUserId: currentUserId, opponentUserId }
+              : undefined
+          }
           onConfirm={(originalBetId) => proposeHeadToHead(originalBetId, currentUserId)}
           onAfterSuccess={onClose}
           onClose={() => setConfirmBet(null)}

--- a/components/CounterOpponentModal.tsx
+++ b/components/CounterOpponentModal.tsx
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Swords, X, Wallet, Target, Clock3, Loader2, ChevronRight } from 'lucide-react';
+import type { Bet } from '@/models';
+import { challengeBetEligibility } from '@/lib/challengeBetEligibility';
+import { getBets, proposeHeadToHead } from '@/services/dbOps';
+import { CounterBetModal } from '@/components/CounterBetModal';
+
+export interface CounterOpponentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  opponentUserId: string;
+  opponentDisplayName: string;
+  opponentAvatarUrl?: string | null;
+  /** Hero-style image URL (same family as profile cover). */
+  backgroundImageUrl: string;
+  currentUserId: string | null;
+  balance: number;
+  /** When provided, skips fetching (e.g. profile already loaded their bets). Omit to load via getBets. */
+  prefetchedBets?: Bet[];
+}
+
+/**
+ * Pick one of the opponent's open slips to fade (head-to-head counter).
+ */
+export const CounterOpponentModal: React.FC<CounterOpponentModalProps> = ({
+  isOpen,
+  onClose,
+  opponentUserId,
+  opponentDisplayName,
+  opponentAvatarUrl,
+  backgroundImageUrl,
+  currentUserId,
+  balance,
+  prefetchedBets,
+}) => {
+  const [bets, setBets] = useState<Bet[] | null>(prefetchedBets ? [...prefetchedBets] : null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadingBets, setLoadingBets] = useState(false);
+  const [selectedBetId, setSelectedBetId] = useState<string | null>(null);
+  const [confirmBet, setConfirmBet] = useState<Bet | null>(null);
+
+  // Reset selection only when opening / switching opponent — not when prefetched array identity changes.
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelectedBetId(null);
+    setConfirmBet(null);
+    setLoadError(null);
+  }, [isOpen, opponentUserId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (prefetchedBets !== undefined) {
+      setBets([...prefetchedBets].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()));
+      return;
+    }
+    let cancelled = false;
+    setLoadingBets(true);
+    setBets(null);
+    void getBets(opponentUserId)
+      .then((rows) => {
+        if (cancelled) return;
+        setBets([...rows].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()));
+        setLoadError(null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoadError('Could not load their bets.');
+        setBets([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingBets(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, opponentUserId, prefetchedBets]);
+
+  const selectedBet = useMemo(
+    () => bets?.find((b) => b.id === selectedBetId) ?? null,
+    [bets, selectedBetId],
+  );
+
+  const handleBackdropClose = useCallback(() => {
+    if (confirmBet) {
+      setConfirmBet(null);
+      return;
+    }
+    onClose();
+  }, [confirmBet, onClose]);
+
+  if (!isOpen) return null;
+
+  const safeBg = backgroundImageUrl.replace(/"/g, '\\"');
+
+  return (
+    <div
+      className="fixed inset-0 z-[55] flex items-center justify-center p-3 sm:p-5 animate-in fade-in duration-200"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="counter-modal-title"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 z-0 cursor-default bg-slate-950/80"
+        aria-label="Close"
+        onClick={handleBackdropClose}
+      />
+      <div
+        className="pointer-events-none absolute inset-0 z-[1] bg-cover bg-center opacity-[0.22]"
+        style={{ backgroundImage: `url("${safeBg}")` }}
+        aria-hidden
+      />
+      <div className="pointer-events-none absolute inset-0 z-[2] bg-gradient-to-b from-slate-950/88 via-slate-950/78 to-slate-950/92" aria-hidden />
+
+      <div className="pointer-events-auto relative z-10 flex max-h-[min(90vh,720px)] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-slate-700/90 bg-slate-900/95 shadow-2xl shadow-black/50 backdrop-blur-md animate-in zoom-in-95 duration-200">
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-800/90 px-4 py-3 sm:px-5 sm:py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-slate-600/80 bg-slate-950">
+              {opponentAvatarUrl ? (
+                <img
+                  src={opponentAvatarUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                />
+              ) : (
+                <span className="flex h-full w-full items-center justify-center text-sm font-bold text-slate-300">
+                  {opponentDisplayName.slice(0, 2).toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Counter</p>
+              <h2 id="counter-modal-title" className="truncate text-lg font-black text-white">
+                {opponentDisplayName}
+              </h2>
+              <p className="text-[11px] leading-snug text-slate-400">
+                Pick one of their pending slips to fade — same head-to-head counter as on their profile.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleBackdropClose}
+            className="shrink-0 rounded-lg p-2 text-slate-500 transition-colors hover:bg-slate-800 hover:text-slate-200"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="pointer-events-auto min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4 custom-scrollbar">
+          {loadingBets && bets === null ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-16 text-slate-400">
+              <Loader2 className="animate-spin" size={28} />
+              <p className="text-sm">Loading their bets…</p>
+            </div>
+          ) : loadError ? (
+            <p className="py-10 text-center text-sm text-red-300">{loadError}</p>
+          ) : !bets?.length ? (
+            <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/40 py-12 text-center">
+              <Swords className="mx-auto mb-2 text-slate-600" size={32} />
+              <p className="text-sm font-medium text-slate-400">No bets to show</p>
+              <p className="mt-1 px-4 text-xs text-slate-500">
+                They don&apos;t have any slips loaded, or nothing is available to counter yet.
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {bets.map((bet) => {
+                const el = challengeBetEligibility(bet);
+                const selected = bet.id === selectedBetId;
+                const disabled = el.kind === 'disabled';
+                return (
+                  <li key={bet.id}>
+                    <button
+                      type="button"
+                      disabled={disabled}
+                      onClick={() => {
+                        if (!disabled) setSelectedBetId(bet.id);
+                      }}
+                      aria-pressed={!disabled && selected}
+                      className={`relative w-full rounded-xl border px-3 py-3 text-left transition-all sm:px-4 ${
+                        disabled
+                          ? 'cursor-not-allowed border-slate-800/80 bg-slate-950/30 opacity-70'
+                          : selected
+                            ? 'border-red-500/60 bg-red-500/15 ring-2 ring-red-500/40 shadow-[0_0_0_1px_rgba(248,113,113,0.15)]'
+                            : 'cursor-pointer border-slate-700/80 bg-slate-950/40 hover:border-red-500/35 hover:bg-slate-900/70'
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div
+                          className={`mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 ${
+                            disabled
+                              ? 'border-slate-600 bg-slate-900'
+                              : selected
+                                ? 'border-red-400 bg-red-500 text-white'
+                                : 'border-slate-500 bg-slate-900'
+                          }`}
+                          aria-hidden
+                        >
+                          {!disabled && selected ? (
+                            <span className="block h-2 w-2 rounded-full bg-white" />
+                          ) : null}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="font-semibold text-slate-100 line-clamp-2">{bet.marketTitle}</p>
+                          <p className="text-sm text-blue-300">{bet.optionLabel}</p>
+                          <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-slate-500">
+                            <span className="inline-flex items-center gap-1">
+                              <Wallet size={11} /> ${bet.stake.toLocaleString()}
+                            </span>
+                            <span className="inline-flex items-center gap-1">
+                              <Target size={11} /> {bet.odds.toFixed(2)}
+                            </span>
+                            <span className="inline-flex items-center gap-1">
+                              <Clock3 size={11} /> {(bet.status ?? 'PENDING').toLowerCase()}
+                            </span>
+                          </div>
+                          {disabled && (
+                            <p className="mt-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                              {el.reason}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="pointer-events-auto shrink-0 border-t border-slate-800/90 bg-slate-950/50 px-4 py-3 sm:px-5">
+          <button
+            type="button"
+            disabled={!selectedBet || challengeBetEligibility(selectedBet).kind !== 'enabled' || loadingBets}
+            onClick={() => selectedBet && setConfirmBet(selectedBet)}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-red-500/90 py-3 text-sm font-bold uppercase tracking-wide text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            Continue
+            <ChevronRight size={18} />
+          </button>
+          <p className="mt-2 text-center text-[10px] text-slate-500">
+            Withdraw a pending counter from Head-to-Head → Outgoing → Cancel challenge.
+          </p>
+        </div>
+      </div>
+
+      {confirmBet && currentUserId && (
+        <CounterBetModal
+          bet={confirmBet}
+          ownerName={opponentDisplayName}
+          balance={balance}
+          overlayZIndexClass="z-[65]"
+          onConfirm={(originalBetId) => proposeHeadToHead(originalBetId, currentUserId)}
+          onAfterSuccess={onClose}
+          onClose={() => setConfirmBet(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/components/CounterOpponentModal.tsx
+++ b/components/CounterOpponentModal.tsx
@@ -244,7 +244,7 @@ export const CounterOpponentModal: React.FC<CounterOpponentModalProps> = ({
             <ChevronRight size={18} />
           </button>
           <p className="mt-2 text-center text-[10px] text-slate-500">
-            Withdraw a pending counter from Head-to-Head → Outgoing → Cancel challenge.
+            Withdraw a pending counter from Head-to-Head → Their turn → Cancel challenge.
           </p>
         </div>
       </div>

--- a/components/GameChallengeDmCard.tsx
+++ b/components/GameChallengeDmCard.tsx
@@ -18,7 +18,7 @@ interface GameChallengeDmCardProps {
 
 const STATUS_LABEL: Record<GameChallengeStatus, string> = {
   PENDING_ACCEPT: 'Awaiting their accept',
-  ACTIVE: 'Accepted — locks when the game ends',
+  ACTIVE: 'Accepted',
   DECLINED: 'Declined',
   CANCELLED: 'Cancelled',
   EXPIRED: 'Expired — sim ended before accept, or board refreshed',

--- a/components/GameChallengeDmCard.tsx
+++ b/components/GameChallengeDmCard.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import {
+  acceptGameChallenge,
+  cancelGameChallenge,
+  declineGameChallenge,
+  type GameChallengeStatus,
+} from '@/services/gameChallenges';
+
+const COL = 'gameChallenges';
+
+interface GameChallengeDmCardProps {
+  challengeId: string;
+  currentUserId: string;
+}
+
+const STATUS_LABEL: Record<GameChallengeStatus, string> = {
+  PENDING_ACCEPT: 'Awaiting their accept',
+  ACTIVE: 'Accepted — locks when the game ends',
+  DECLINED: 'Declined',
+  CANCELLED: 'Cancelled',
+  COMPLETED_CHALLENGER: 'Challenger won',
+  COMPLETED_OPPONENT: 'Opponent won',
+  PUSH: 'Push — no winner',
+};
+
+export const GameChallengeDmCard: React.FC<GameChallengeDmCardProps> = ({ challengeId, currentUserId }) => {
+  const [status, setStatus] = useState<GameChallengeStatus | null>(null);
+  const [title, setTitle] = useState('');
+  const [challengerName, setChallengerName] = useState('');
+  const [opponentName, setOpponentName] = useState('');
+  const [challengerPick, setChallengerPick] = useState('');
+  const [opponentPick, setOpponentPick] = useState('');
+  const [challengerUid, setChallengerUid] = useState('');
+  const [opponentUid, setOpponentUid] = useState('');
+  const [acting, setActing] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    const r = doc(db, COL, challengeId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) {
+        setStatus(null);
+        return;
+      }
+      const d = snap.data();
+      setStatus((d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT');
+      setTitle(String(d.marketTitle ?? ''));
+      setChallengerName(String(d.challengerName ?? ''));
+      setOpponentName(String(d.opponentName ?? ''));
+      setChallengerPick(String(d.challengerPickLabel ?? ''));
+      setOpponentPick(String(d.opponentPickLabel ?? ''));
+      setChallengerUid(String(d.challengerUid ?? ''));
+      setOpponentUid(String(d.opponentUid ?? ''));
+    });
+    return () => unsub();
+  }, [challengeId]);
+
+  const isChallenger = currentUserId === challengerUid;
+  const isOpponent = currentUserId === opponentUid;
+
+  const run = async (fn: () => Promise<{ success: boolean; error?: string }>) => {
+    setActing(true);
+    setErr(null);
+    const res = await fn();
+    setActing(false);
+    if (!res.success) setErr(res.error ?? 'Failed');
+  };
+
+  if (status === null) {
+    return (
+      <div className="rounded-lg border border-slate-700/60 bg-slate-950/40 px-3 py-2 text-xs text-slate-500">
+        Loading challenge…
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-amber-500/35 bg-amber-500/[0.07] px-3 py-3 text-left">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-amber-400/90">Game challenge</p>
+      <p className="mt-1 text-sm font-bold text-slate-100 line-clamp-2">{title}</p>
+      <div className="mt-2 space-y-1 text-[11px] text-slate-300">
+        <p>
+          <span className="text-slate-500">{challengerName}:</span> {challengerPick}
+        </p>
+        <p>
+          <span className="text-slate-500">{opponentName} (if accepted):</span> {opponentPick}
+        </p>
+      </div>
+      <p className="mt-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">{STATUS_LABEL[status]}</p>
+
+      {err && <p className="mt-2 text-[11px] text-red-300">{err}</p>}
+
+      {status === 'PENDING_ACCEPT' && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {isOpponent && (
+            <>
+              <button
+                type="button"
+                disabled={acting}
+                onClick={() => void run(() => acceptGameChallenge(challengeId, currentUserId))}
+                className="rounded-lg bg-emerald-600/90 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide text-white hover:bg-emerald-500 disabled:opacity-50"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                disabled={acting}
+                onClick={() => void run(() => declineGameChallenge(challengeId, currentUserId))}
+                className="rounded-lg border border-slate-600 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+              >
+                Decline
+              </button>
+            </>
+          )}
+          {isChallenger && (
+            <button
+              type="button"
+              disabled={acting}
+              onClick={() => void run(() => cancelGameChallenge(challengeId, currentUserId))}
+              className="rounded-lg border border-slate-600 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+            >
+              Cancel invite
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/GameChallengeDmCard.tsx
+++ b/components/GameChallengeDmCard.tsx
@@ -5,6 +5,7 @@ import {
   acceptGameChallenge,
   cancelGameChallenge,
   declineGameChallenge,
+  reconcileMockGameChallengeIfNeeded,
   type GameChallengeStatus,
 } from '@/services/gameChallenges';
 
@@ -20,6 +21,7 @@ const STATUS_LABEL: Record<GameChallengeStatus, string> = {
   ACTIVE: 'Accepted — locks when the game ends',
   DECLINED: 'Declined',
   CANCELLED: 'Cancelled',
+  EXPIRED: 'Expired — sim ended before accept, or board refreshed',
   COMPLETED_CHALLENGER: 'Challenger won',
   COMPLETED_OPPONENT: 'Opponent won',
   PUSH: 'Push — no winner',
@@ -53,6 +55,7 @@ export const GameChallengeDmCard: React.FC<GameChallengeDmCardProps> = ({ challe
       setOpponentPick(String(d.opponentPickLabel ?? ''));
       setChallengerUid(String(d.challengerUid ?? ''));
       setOpponentUid(String(d.opponentUid ?? ''));
+      void reconcileMockGameChallengeIfNeeded(challengeId);
     });
     return () => unsub();
   }, [challengeId]);

--- a/components/GameChallengeModal.tsx
+++ b/components/GameChallengeModal.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { X, Loader2, ChevronRight, Trophy } from 'lucide-react';
+import type { Market, MarketOption } from '@/models';
+import { createGameChallengeAndNotify } from '@/services/gameChallenges';
+
+export interface GameChallengeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  markets: Market[];
+  opponentUserId: string;
+  opponentDisplayName: string;
+  opponentAvatarUrl?: string | null;
+  backgroundImageUrl: string;
+  currentUserId: string | null;
+  challengerDisplayName: string;
+  onSent?: () => void;
+}
+
+function h2hPair(market: Market): [MarketOption, MarketOption] | null {
+  const h2h = market.options.filter((o) => (o.marketKey ?? 'h2h') === 'h2h');
+  if (h2h.length !== 2) return null;
+  return [h2h[0], h2h[1]];
+}
+
+/**
+ * Pick an upcoming two-sided moneyline; sends a DM the opponent must accept.
+ */
+export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
+  isOpen,
+  onClose,
+  markets,
+  opponentUserId,
+  opponentDisplayName,
+  opponentAvatarUrl,
+  backgroundImageUrl,
+  currentUserId,
+  challengerDisplayName,
+  onSent,
+}) => {
+  const eligible = useMemo(
+    () =>
+      markets.filter((m) => m.status !== 'CLOSED' && h2hPair(m) !== null),
+    [markets],
+  );
+
+  const [selectedMarket, setSelectedMarket] = useState<Market | null>(null);
+  const [selectedOption, setSelectedOption] = useState<MarketOption | null>(null);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setSelectedMarket(null);
+    setSelectedOption(null);
+    setError(null);
+    setSending(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    reset();
+  }, [isOpen, opponentUserId, reset]);
+
+  const pair = selectedMarket ? h2hPair(selectedMarket) : null;
+
+  const handleSend = async () => {
+    if (!currentUserId || !selectedMarket || !selectedOption) return;
+    setSending(true);
+    setError(null);
+    const res = await createGameChallengeAndNotify({
+      challengerUid: currentUserId,
+      opponentUid: opponentUserId,
+      challengerName: challengerDisplayName,
+      opponentName: opponentDisplayName,
+      market: selectedMarket,
+      chosenOption: selectedOption,
+    });
+    setSending(false);
+    if (res.success) {
+      onSent?.();
+      onClose();
+    } else {
+      setError(res.error ?? 'Could not send');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const safeBg = backgroundImageUrl.replace(/"/g, '\\"');
+
+  return (
+    <div
+      className="fixed inset-0 z-[55] flex items-center justify-center p-3 sm:p-5 animate-in fade-in duration-200"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="game-challenge-title"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 z-0 cursor-default bg-slate-950/80"
+        aria-label="Close"
+        onClick={() => !sending && onClose()}
+      />
+      <div
+        className="pointer-events-none absolute inset-0 z-[1] bg-cover bg-center opacity-[0.22]"
+        style={{ backgroundImage: `url("${safeBg}")` }}
+        aria-hidden
+      />
+      <div className="pointer-events-none absolute inset-0 z-[2] bg-gradient-to-b from-slate-950/88 via-slate-950/78 to-slate-950/92" aria-hidden />
+
+      <div className="pointer-events-auto relative z-10 flex max-h-[min(90vh,760px)] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-amber-700/40 bg-slate-900/95 shadow-2xl backdrop-blur-md animate-in zoom-in-95 duration-200">
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-800/90 px-4 py-3 sm:px-5 sm:py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-amber-600/50 bg-slate-950">
+              {opponentAvatarUrl ? (
+                <img
+                  src={opponentAvatarUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                />
+              ) : (
+                <span className="flex h-full w-full items-center justify-center text-sm font-bold text-amber-100">
+                  {opponentDisplayName.slice(0, 2).toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-500/90">Challenge</p>
+              <h2 id="game-challenge-title" className="truncate text-lg font-black text-white">
+                vs. {opponentDisplayName}
+              </h2>
+              <p className="text-[11px] leading-snug text-slate-400">
+                New pick on a game — they accept in chat. Winner earns a leaderboard challenge win when the game
+                grades.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled={sending}
+            onClick={() => onClose()}
+            className="shrink-0 rounded-lg p-2 text-slate-500 transition-colors hover:bg-slate-800 hover:text-slate-200 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="pointer-events-auto min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4 custom-scrollbar">
+          {!selectedMarket ? (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Choose a game</p>
+              {eligible.length === 0 ? (
+                <p className="py-8 text-center text-sm text-slate-500">
+                  No open two-team moneylines loaded. Open Markets first so games appear here.
+                </p>
+              ) : (
+                eligible.map((m) => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedMarket(m);
+                      setSelectedOption(null);
+                    }}
+                    className="w-full rounded-xl border border-slate-700/80 bg-slate-950/50 px-3 py-3 text-left text-sm text-slate-100 transition-colors hover:border-amber-500/40 hover:bg-slate-900/70"
+                  >
+                    <span className="font-bold line-clamp-2">{m.title}</span>
+                    <span className="mt-1 block text-[11px] uppercase tracking-wider text-slate-500">
+                      {m.sport_key} · {m.status}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedMarket(null);
+                  setSelectedOption(null);
+                }}
+                className="text-xs font-bold uppercase tracking-wider text-amber-400 hover:text-amber-300"
+              >
+                ← Back to games
+              </button>
+              <p className="text-sm font-semibold text-slate-200">{selectedMarket.title}</p>
+              <p className="text-[11px] text-slate-500">Pick your side. They get the other side if they accept.</p>
+              {pair && (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {pair.map((opt) => {
+                    const picked = selectedOption?.id === opt.id;
+                    return (
+                      <button
+                        key={opt.id}
+                        type="button"
+                        onClick={() => setSelectedOption(opt)}
+                        className={`rounded-xl border px-3 py-4 text-center text-sm font-bold transition-all ${
+                          picked
+                            ? 'border-amber-500/70 bg-amber-500/15 ring-2 ring-amber-500/35 text-amber-100'
+                            : 'border-slate-700 bg-slate-950/50 text-slate-100 hover:border-amber-500/40'
+                        }`}
+                      >
+                        {opt.label}
+                        <span className="mt-1 block text-xs font-normal text-slate-400">{opt.odds.toFixed(2)}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+          {error && <p className="mt-3 text-center text-xs text-red-300">{error}</p>}
+        </div>
+
+        <div className="pointer-events-auto shrink-0 border-t border-slate-800/90 bg-slate-950/50 px-4 py-3 sm:px-5">
+          <button
+            type="button"
+            disabled={!selectedMarket || !selectedOption || !currentUserId || sending}
+            onClick={() => void handleSend()}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-amber-600/90 py-3 text-sm font-bold uppercase tracking-wide text-slate-950 transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            {sending ? <Loader2 className="animate-spin" size={18} /> : <Trophy size={18} />}
+            Send to messages
+            <ChevronRight size={18} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/GameChallengeModal.tsx
+++ b/components/GameChallengeModal.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { X, Loader2, ChevronRight, Trophy } from 'lucide-react';
+import { X, Loader2, ChevronRight, Trophy, Search } from 'lucide-react';
 import type { Market, MarketOption } from '@/models';
-import { createGameChallengeAndNotify } from '@/services/gameChallenges';
+import { filterMarketsBySearchQuery } from '@/lib/marketSearch';
+import { createGameChallengeAndNotify, opposingOptionForMarket } from '@/services/gameChallenges';
 
 export interface GameChallengeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  markets: Market[];
+  /** Your three rotating NFL sim games (same source as Markets → NFL mock board). */
+  mockNflMarkets: Market[];
   opponentUserId: string;
   opponentDisplayName: string;
   opponentAvatarUrl?: string | null;
@@ -16,19 +18,31 @@ export interface GameChallengeModalProps {
   onSent?: () => void;
 }
 
-function h2hPair(market: Market): [MarketOption, MarketOption] | null {
-  const h2h = market.options.filter((o) => (o.marketKey ?? 'h2h') === 'h2h');
-  if (h2h.length !== 2) return null;
-  return [h2h[0], h2h[1]];
+function pairedOptionGroups(market: Market): MarketOption[][] {
+  const byKey = new Map<string, MarketOption[]>();
+  for (const o of market.options) {
+    const k = o.marketKey ?? 'h2h';
+    if (!byKey.has(k)) byKey.set(k, []);
+    byKey.get(k)!.push(o);
+  }
+  const out: MarketOption[][] = [];
+  for (const opts of byKey.values()) {
+    if (opts.length === 2) out.push(opts);
+  }
+  return out;
+}
+
+function marketIsSelectable(m: Market): boolean {
+  return m.status !== 'CLOSED' && pairedOptionGroups(m).length > 0;
 }
 
 /**
- * Pick an upcoming two-sided moneyline; sends a DM the opponent must accept.
+ * Search the three NFL sim games, pick ML / spread / total, optional note → DM.
  */
 export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
   isOpen,
   onClose,
-  markets,
+  mockNflMarkets,
   opponentUserId,
   opponentDisplayName,
   opponentAvatarUrl,
@@ -37,20 +51,26 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
   challengerDisplayName,
   onSent,
 }) => {
-  const eligible = useMemo(
-    () =>
-      markets.filter((m) => m.status !== 'CLOSED' && h2hPair(m) !== null),
-    [markets],
-  );
+  const searchPool = useMemo(() => mockNflMarkets.filter(marketIsSelectable), [mockNflMarkets]);
+  const allMockRows = useMemo(() => mockNflMarkets, [mockNflMarkets]);
 
+  const [searchQuery, setSearchQuery] = useState('');
   const [selectedMarket, setSelectedMarket] = useState<Market | null>(null);
   const [selectedOption, setSelectedOption] = useState<MarketOption | null>(null);
+  const [dmNote, setDmNote] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const filteredMarkets = useMemo(() => {
+    const base = searchPool.filter(marketIsSelectable);
+    return filterMarketsBySearchQuery(base, searchQuery);
+  }, [searchPool, searchQuery]);
+
   const reset = useCallback(() => {
+    setSearchQuery('');
     setSelectedMarket(null);
     setSelectedOption(null);
+    setDmNote('');
     setError(null);
     setSending(false);
   }, []);
@@ -60,7 +80,7 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
     reset();
   }, [isOpen, opponentUserId, reset]);
 
-  const pair = selectedMarket ? h2hPair(selectedMarket) : null;
+  const groups = selectedMarket ? pairedOptionGroups(selectedMarket) : [];
 
   const handleSend = async () => {
     if (!currentUserId || !selectedMarket || !selectedOption) return;
@@ -73,19 +93,23 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
       opponentName: opponentDisplayName,
       market: selectedMarket,
       chosenOption: selectedOption,
+      optionalDmNote: dmNote.trim() || undefined,
     });
     setSending(false);
     if (res.success) {
       onSent?.();
       onClose();
     } else {
-      setError(res.error ?? 'Could not send');
+      setError('error' in res ? res.error : 'Could not send');
     }
   };
 
   if (!isOpen) return null;
 
   const safeBg = backgroundImageUrl.replace(/"/g, '\\"');
+  const hasLiveGames = searchPool.length > 0;
+  const endedOnly =
+    allMockRows.length > 0 && searchPool.length === 0 && allMockRows.every((m) => m.status === 'CLOSED');
 
   return (
     <div
@@ -107,7 +131,7 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
       />
       <div className="pointer-events-none absolute inset-0 z-[2] bg-gradient-to-b from-slate-950/88 via-slate-950/78 to-slate-950/92" aria-hidden />
 
-      <div className="pointer-events-auto relative z-10 flex max-h-[min(90vh,760px)] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-amber-700/40 bg-slate-900/95 shadow-2xl backdrop-blur-md animate-in zoom-in-95 duration-200">
+      <div className="pointer-events-auto relative z-10 flex max-h-[min(90vh,820px)] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-amber-700/40 bg-slate-900/95 shadow-2xl backdrop-blur-md animate-in zoom-in-95 duration-200">
         <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-800/90 px-4 py-3 sm:px-5 sm:py-4">
           <div className="flex min-w-0 items-center gap-3">
             <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-amber-600/50 bg-slate-950">
@@ -131,8 +155,7 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
                 vs. {opponentDisplayName}
               </h2>
               <p className="text-[11px] leading-snug text-slate-400">
-                New pick on a game — they accept in chat. Winner earns a leaderboard challenge win when the game
-                grades.
+                NFL Mock Bets: Winner gets a leaderboard challenge win.
               </p>
             </div>
           </div>
@@ -147,16 +170,59 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
           </button>
         </div>
 
+        <div className="pointer-events-auto shrink-0 border-b border-slate-800/60 px-4 py-3 sm:px-5">
+          <label className="sr-only" htmlFor="challenge-game-search">
+            Search NFL sim games
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <input
+              id="challenge-game-search"
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              disabled={!selectedMarket && allMockRows.length === 0}
+              placeholder={
+                allMockRows.length === 0
+                  ? 'Loading your NFL sim board…'
+                  : 'Search teams, spreads, totals, moneylines…'
+              }
+              className="w-full rounded-xl border border-slate-700/80 bg-slate-950/50 py-2.5 pl-10 pr-3 text-sm text-slate-100 outline-none placeholder:text-slate-500 focus:border-amber-500/50 disabled:opacity-50"
+            />
+          </div>
+          <label className="mt-3 block text-[10px] font-bold uppercase tracking-wider text-slate-500" htmlFor="challenge-dm-note">
+            Optional message (sent first in chat)
+          </label>
+          <textarea
+            id="challenge-dm-note"
+            value={dmNote}
+            onChange={(e) => setDmNote(e.target.value)}
+            rows={2}
+            maxLength={500}
+            placeholder="Say hi or add context…"
+            className="mt-1 w-full resize-none rounded-xl border border-slate-700/80 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 outline-none focus:border-amber-500/45"
+          />
+        </div>
+
         <div className="pointer-events-auto min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4 custom-scrollbar">
           {!selectedMarket ? (
             <div className="space-y-2">
               <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Choose a game</p>
-              {eligible.length === 0 ? (
+              {allMockRows.length === 0 ? (
                 <p className="py-8 text-center text-sm text-slate-500">
-                  No open two-team moneylines loaded. Open Markets first so games appear here.
+                  Your sim games are still loading. Stay on the app for a moment or open Markets → Football → NFL.
+                </p>
+              ) : endedOnly ? (
+                <p className="py-8 text-center text-sm text-slate-500">
+                  All three sim games are finished right now. Start a new matchup from the NFL mock board, then open
+                  challenge again.
+                </p>
+              ) : filteredMarkets.length === 0 ? (
+                <p className="py-8 text-center text-sm text-slate-500">
+                  No open games match that search. Try a team name or clear the box to see all live sim games.
                 </p>
               ) : (
-                eligible.map((m) => (
+                filteredMarkets.map((m) => (
                   <button
                     key={m.id}
                     type="button"
@@ -168,14 +234,14 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
                   >
                     <span className="font-bold line-clamp-2">{m.title}</span>
                     <span className="mt-1 block text-[11px] uppercase tracking-wider text-slate-500">
-                      {m.sport_key} · {m.status}
+                      NFL sim · {m.status}
                     </span>
                   </button>
                 ))
               )}
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-4">
               <button
                 type="button"
                 onClick={() => {
@@ -187,44 +253,67 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
                 ← Back to games
               </button>
               <p className="text-sm font-semibold text-slate-200">{selectedMarket.title}</p>
-              <p className="text-[11px] text-slate-500">Pick your side. They get the other side if they accept.</p>
-              {pair && (
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {pair.map((opt) => {
-                    const picked = selectedOption?.id === opt.id;
-                    return (
-                      <button
-                        key={opt.id}
-                        type="button"
-                        onClick={() => setSelectedOption(opt)}
-                        className={`rounded-xl border px-3 py-4 text-center text-sm font-bold transition-all ${
-                          picked
-                            ? 'border-amber-500/70 bg-amber-500/15 ring-2 ring-amber-500/35 text-amber-100'
-                            : 'border-slate-700 bg-slate-950/50 text-slate-100 hover:border-amber-500/40'
-                        }`}
-                      >
-                        {opt.label}
-                        <span className="mt-1 block text-xs font-normal text-slate-400">{opt.odds.toFixed(2)}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
+              <p className="text-[11px] text-slate-500">
+                Pick your side for each line type. They take the opposite number if they accept.
+              </p>
+              {!hasLiveGames && selectedMarket.status === 'CLOSED' ? (
+                <p className="text-sm text-amber-200/90">This sim game already ended — go back and pick an open game.</p>
+              ) : null}
+              {groups.map((pair, idx) => {
+                const key = pair[0]?.marketKey ?? 'h2h';
+                return (
+                  <div key={`${selectedMarket.id}-${key}-${idx}`} className="space-y-2">
+                    <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                      {key === 'h2h' ? 'Moneyline' : key === 'spreads' ? 'Spread' : key === 'totals' ? 'Total' : key}
+                    </p>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {pair.map((opt) => {
+                        const picked = selectedOption?.id === opt.id;
+                        const valid = opposingOptionForMarket(selectedMarket, opt) !== null;
+                        if (!valid) return null;
+                        return (
+                          <button
+                            key={opt.id}
+                            type="button"
+                            onClick={() => setSelectedOption(opt)}
+                            className={`rounded-xl border px-3 py-3 text-center text-sm font-bold transition-all ${
+                              picked
+                                ? 'border-amber-500/70 bg-amber-500/15 ring-2 ring-amber-500/35 text-amber-100'
+                                : 'border-slate-700 bg-slate-950/50 text-slate-100 hover:border-amber-500/40'
+                            }`}
+                          >
+                            <span className="line-clamp-3">{opt.label}</span>
+                            <span className="mt-1 block text-xs font-normal text-slate-400">{opt.odds.toFixed(2)}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           )}
           {error && <p className="mt-3 text-center text-xs text-red-300">{error}</p>}
         </div>
 
-        <div className="pointer-events-auto shrink-0 border-t border-slate-800/90 bg-slate-950/50 px-4 py-3 sm:px-5">
+        <div className="pointer-events-auto flex shrink-0 flex-col gap-2 border-t border-slate-800/90 bg-slate-950/50 px-4 py-3 sm:px-5">
           <button
             type="button"
-            disabled={!selectedMarket || !selectedOption || !currentUserId || sending}
+            disabled={!selectedMarket || !selectedOption || !currentUserId || sending || selectedMarket.status === 'CLOSED'}
             onClick={() => void handleSend()}
             className="flex w-full items-center justify-center gap-2 rounded-xl bg-amber-600/90 py-3 text-sm font-bold uppercase tracking-wide text-slate-950 transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
           >
             {sending ? <Loader2 className="animate-spin" size={18} /> : <Trophy size={18} />}
             Send to messages
             <ChevronRight size={18} />
+          </button>
+          <button
+            type="button"
+            disabled={sending}
+            onClick={() => onClose()}
+            className="w-full rounded-xl border border-slate-600 py-2 text-xs font-bold uppercase tracking-wide text-slate-400 hover:bg-slate-800/60 hover:text-slate-200"
+          >
+            Cancel
           </button>
         </div>
       </div>

--- a/components/GameChallengeModal.tsx
+++ b/components/GameChallengeModal.tsx
@@ -1,13 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { X, Loader2, ChevronRight, Trophy, Search } from 'lucide-react';
+import { X, Loader2, ChevronRight, Trophy } from 'lucide-react';
 import type { Market, MarketOption } from '@/models';
-import { filterMarketsBySearchQuery } from '@/lib/marketSearch';
 import { createGameChallengeAndNotify, opposingOptionForMarket } from '@/services/gameChallenges';
 
 export interface GameChallengeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  /** Your three rotating NFL sim games (same source as Markets → NFL mock board). */
+  /** Global NFL sim games (same board as Markets → NFL for everyone). */
   mockNflMarkets: Market[];
   opponentUserId: string;
   opponentDisplayName: string;
@@ -37,7 +36,7 @@ function marketIsSelectable(m: Market): boolean {
 }
 
 /**
- * Search the three NFL sim games, pick ML / spread / total, optional note → DM.
+ * Pick one of the live global NFL sim games, ML / spread / total, optional note → DM.
  */
 export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
   isOpen,
@@ -51,23 +50,19 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
   challengerDisplayName,
   onSent,
 }) => {
-  const searchPool = useMemo(() => mockNflMarkets.filter(marketIsSelectable), [mockNflMarkets]);
-  const allMockRows = useMemo(() => mockNflMarkets, [mockNflMarkets]);
+  const openGames = useMemo(() => mockNflMarkets.filter(marketIsSelectable), [mockNflMarkets]);
+  const endedOnly =
+    mockNflMarkets.length > 0 &&
+    openGames.length === 0 &&
+    mockNflMarkets.every((m) => m.status === 'CLOSED');
 
-  const [searchQuery, setSearchQuery] = useState('');
   const [selectedMarket, setSelectedMarket] = useState<Market | null>(null);
   const [selectedOption, setSelectedOption] = useState<MarketOption | null>(null);
   const [dmNote, setDmNote] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const filteredMarkets = useMemo(() => {
-    const base = searchPool.filter(marketIsSelectable);
-    return filterMarketsBySearchQuery(base, searchQuery);
-  }, [searchPool, searchQuery]);
-
   const reset = useCallback(() => {
-    setSearchQuery('');
     setSelectedMarket(null);
     setSelectedOption(null);
     setDmNote('');
@@ -107,9 +102,7 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
   if (!isOpen) return null;
 
   const safeBg = backgroundImageUrl.replace(/"/g, '\\"');
-  const hasLiveGames = searchPool.length > 0;
-  const endedOnly =
-    allMockRows.length > 0 && searchPool.length === 0 && allMockRows.every((m) => m.status === 'CLOSED');
+  const hasLiveGames = openGames.length > 0;
 
   return (
     <div
@@ -155,7 +148,8 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
                 vs. {opponentDisplayName}
               </h2>
               <p className="text-[11px] leading-snug text-slate-400">
-                NFL Mock Bets: Winner gets a leaderboard challenge win.
+                Same global NFL sim board for everyone. Winner gets a leaderboard challenge win when the sim game
+                grades.
               </p>
             </div>
           </div>
@@ -170,75 +164,54 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
           </button>
         </div>
 
-        <div className="pointer-events-auto shrink-0 border-b border-slate-800/60 px-4 py-3 sm:px-5">
-          <label className="sr-only" htmlFor="challenge-game-search">
-            Search NFL sim games
-          </label>
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-            <input
-              id="challenge-game-search"
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              disabled={!selectedMarket && allMockRows.length === 0}
-              placeholder={
-                allMockRows.length === 0
-                  ? 'Loading your NFL sim board…'
-                  : 'Search teams, spreads, totals, moneylines…'
-              }
-              className="w-full rounded-xl border border-slate-700/80 bg-slate-950/50 py-2.5 pl-10 pr-3 text-sm text-slate-100 outline-none placeholder:text-slate-500 focus:border-amber-500/50 disabled:opacity-50"
-            />
-          </div>
-          <label className="mt-3 block text-[10px] font-bold uppercase tracking-wider text-slate-500" htmlFor="challenge-dm-note">
-            Optional message (sent first in chat)
-          </label>
-          <textarea
-            id="challenge-dm-note"
-            value={dmNote}
-            onChange={(e) => setDmNote(e.target.value)}
-            rows={2}
-            maxLength={500}
-            placeholder="Say hi or add context…"
-            className="mt-1 w-full resize-none rounded-xl border border-slate-700/80 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 outline-none focus:border-amber-500/45"
-          />
-        </div>
-
         <div className="pointer-events-auto min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4 custom-scrollbar">
           {!selectedMarket ? (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Choose a game</p>
-              {allMockRows.length === 0 ? (
-                <p className="py-8 text-center text-sm text-slate-500">
-                  Your sim games are still loading. Stay on the app for a moment or open Markets → Football → NFL.
-                </p>
-              ) : endedOnly ? (
-                <p className="py-8 text-center text-sm text-slate-500">
-                  All three sim games are finished right now. Start a new matchup from the NFL mock board, then open
-                  challenge again.
-                </p>
-              ) : filteredMarkets.length === 0 ? (
-                <p className="py-8 text-center text-sm text-slate-500">
-                  No open games match that search. Try a team name or clear the box to see all live sim games.
-                </p>
-              ) : (
-                filteredMarkets.map((m) => (
-                  <button
-                    key={m.id}
-                    type="button"
-                    onClick={() => {
-                      setSelectedMarket(m);
-                      setSelectedOption(null);
-                    }}
-                    className="w-full rounded-xl border border-slate-700/80 bg-slate-950/50 px-3 py-3 text-left text-sm text-slate-100 transition-colors hover:border-amber-500/40 hover:bg-slate-900/70"
-                  >
-                    <span className="font-bold line-clamp-2">{m.title}</span>
-                    <span className="mt-1 block text-[11px] uppercase tracking-wider text-slate-500">
-                      NFL sim · {m.status}
-                    </span>
-                  </button>
-                ))
-              )}
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Choose a game</p>
+                {mockNflMarkets.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-slate-500">
+                    Loading the global NFL sim board… Open Markets → Football → NFL if this stays empty.
+                  </p>
+                ) : endedOnly ? (
+                  <p className="py-6 text-center text-sm text-slate-500">
+                    All five sim games are finished right now. Spin up new games from the NFL mock board, then try
+                    again.
+                  </p>
+                ) : (
+                  openGames.map((m) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedMarket(m);
+                        setSelectedOption(null);
+                      }}
+                      className="w-full rounded-xl border border-slate-700/80 bg-slate-950/50 px-3 py-3 text-left text-sm text-slate-100 transition-colors hover:border-amber-500/40 hover:bg-slate-900/70"
+                    >
+                      <span className="font-bold line-clamp-2">{m.title}</span>
+                      <span className="mt-1 block text-[11px] uppercase tracking-wider text-slate-500">
+                        NFL sim · {m.status}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+
+              <div>
+                <label className="block text-[10px] font-bold uppercase tracking-wider text-slate-500" htmlFor="challenge-dm-note">
+                  Optional message (sent first in chat)
+                </label>
+                <textarea
+                  id="challenge-dm-note"
+                  value={dmNote}
+                  onChange={(e) => setDmNote(e.target.value)}
+                  rows={2}
+                  maxLength={500}
+                  placeholder="Say hi or add context…"
+                  className="mt-1 w-full resize-none rounded-xl border border-slate-700/80 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 outline-none focus:border-amber-500/45"
+                />
+              </div>
             </div>
           ) : (
             <div className="space-y-4">
@@ -304,7 +277,7 @@ export const GameChallengeModal: React.FC<GameChallengeModalProps> = ({
             className="flex w-full items-center justify-center gap-2 rounded-xl bg-amber-600/90 py-3 text-sm font-bold uppercase tracking-wide text-slate-950 transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
           >
             {sending ? <Loader2 className="animate-spin" size={18} /> : <Trophy size={18} />}
-            Send to messages
+            Send
             <ChevronRight size={18} />
           </button>
           <button

--- a/components/GameChallengeSettlementDmCard.tsx
+++ b/components/GameChallengeSettlementDmCard.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import { useNavigate } from 'react-router-dom';
+import { Skull, Sparkles, Trophy, Swords } from 'lucide-react';
+import type { GameChallengeStatus } from '@/services/gameChallenges';
+
+const COL = 'gameChallenges';
+
+interface GameChallengeSettlementDmCardProps {
+  challengeId: string;
+  currentUserId: string;
+  onOpenFull?: () => void;
+}
+
+function outcomeForViewer(
+  status: GameChallengeStatus,
+  uid: string,
+  chUid: string,
+  opUid: string,
+): 'win' | 'loss' | 'push' | 'pending' {
+  if (status === 'PUSH') return 'push';
+  if (status === 'COMPLETED_CHALLENGER') {
+    if (uid === chUid) return 'win';
+    if (uid === opUid) return 'loss';
+  }
+  if (status === 'COMPLETED_OPPONENT') {
+    if (uid === opUid) return 'win';
+    if (uid === chUid) return 'loss';
+  }
+  return 'pending';
+}
+
+/** DM bubble when a game challenge settles — gold win / red loss; tap header for full-screen recap. */
+export const GameChallengeSettlementDmCard: React.FC<GameChallengeSettlementDmCardProps> = ({
+  challengeId,
+  currentUserId,
+  onOpenFull,
+}) => {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<GameChallengeStatus | null>(null);
+  const [title, setTitle] = useState('');
+  const [chPick, setChPick] = useState('');
+  const [opPick, setOpPick] = useState('');
+  const [chUid, setChUid] = useState('');
+  const [opUid, setOpUid] = useState('');
+
+  useEffect(() => {
+    const r = doc(db, COL, challengeId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) {
+        setStatus(null);
+        return;
+      }
+      const d = snap.data();
+      setStatus((d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT');
+      setTitle(String(d.marketTitle ?? ''));
+      setChPick(String(d.challengerPickLabel ?? ''));
+      setOpPick(String(d.opponentPickLabel ?? ''));
+      setChUid(String(d.challengerUid ?? ''));
+      setOpUid(String(d.opponentUid ?? ''));
+    });
+    return () => unsub();
+  }, [challengeId]);
+
+  if (status === null) {
+    return (
+      <div className="rounded-xl border border-slate-700/60 bg-slate-950/50 px-3 py-2 text-xs text-slate-500">
+        Loading challenge result…
+      </div>
+    );
+  }
+
+  const viewer = outcomeForViewer(status, currentUserId, chUid, opUid);
+  const opponentUid = currentUserId === chUid ? opUid : chUid;
+  const yourPick = currentUserId === chUid ? chPick : opPick;
+
+  const shell =
+    viewer === 'win'
+      ? 'border-amber-400/50 bg-gradient-to-br from-amber-500/20 via-yellow-500/10 to-orange-600/15 shadow-[0_0_28px_rgba(251,191,36,0.38)]'
+      : viewer === 'loss'
+        ? 'border-rose-500/45 bg-gradient-to-br from-rose-950/80 via-orange-950/50 to-slate-950/90 shadow-[0_0_22px_rgba(244,63,94,0.28)]'
+        : viewer === 'push'
+          ? 'border-slate-500/40 bg-slate-900/80 shadow-[0_0_16px_rgba(148,163,184,0.2)]'
+          : 'border-slate-600/50 bg-slate-950/60';
+
+  const headline =
+    viewer === 'win' ? 'You ran the table' : viewer === 'loss' ? 'They edged you' : viewer === 'push' ? 'Dead heat' : 'Challenge update';
+
+  const sub =
+    viewer === 'win'
+      ? 'Your side hit — bragging rights earned.'
+      : viewer === 'loss'
+        ? 'Their pick was the right one this time.'
+        : viewer === 'push'
+          ? 'Push — nobody walks away crowned.'
+          : 'Still updating…';
+
+  return (
+    <div className={`rounded-2xl border px-3.5 py-3.5 text-left ${shell}`}>
+      <div
+        role={onOpenFull ? 'button' : undefined}
+        tabIndex={onOpenFull ? 0 : undefined}
+        className={onOpenFull ? 'cursor-pointer rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50' : undefined}
+        onClick={() => onOpenFull?.()}
+        onKeyDown={(e) => {
+          if (!onOpenFull) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onOpenFull();
+          }
+        }}
+      >
+        <div className="flex items-start gap-2">
+          {viewer === 'win' ? (
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/40">
+              <Trophy className="h-5 w-5 drop-shadow-[0_0_8px_rgba(251,191,36,0.9)]" />
+            </div>
+          ) : viewer === 'loss' ? (
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/35">
+              <Skull className="h-5 w-5" />
+            </div>
+          ) : (
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-600/30 text-slate-200">
+              <Sparkles className="h-4 w-4" />
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <p
+              className={`text-[10px] font-black uppercase tracking-[0.2em] ${
+                viewer === 'win' ? 'text-amber-200/90' : viewer === 'loss' ? 'text-rose-200/85' : 'text-slate-400'
+              }`}
+            >
+              Challenge settled
+            </p>
+            <h4
+              className={`mt-1 text-lg font-black tracking-tight ${
+                viewer === 'win'
+                  ? 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 drop-shadow-[0_0_12px_rgba(253,224,71,0.45)]'
+                  : viewer === 'loss'
+                    ? 'text-transparent bg-clip-text bg-gradient-to-r from-rose-200 via-orange-200 to-amber-900/80'
+                    : 'text-slate-100'
+              }`}
+            >
+              {headline}
+            </h4>
+            <p className="mt-1 text-[12px] leading-snug text-slate-300">{sub}</p>
+            <p className="mt-2 text-sm font-bold text-slate-100 line-clamp-2">{title}</p>
+            <p className="mt-1 text-[11px] text-slate-400">
+              Your side: <span className="text-emerald-300">{yourPick}</span>
+            </p>
+            {onOpenFull ? (
+              <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">Tap for full-screen recap</p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      {opponentUid && viewer !== 'pending' ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/profile/${opponentUid}`, { state: { openGameChallenge: true } });
+            }}
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-amber-500/40 bg-amber-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-amber-100 hover:bg-amber-500/20"
+          >
+            <Trophy size={14} />
+            Challenge
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/profile/${opponentUid}`, { state: { openCounter: true } });
+            }}
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-red-500/40 bg-red-500/10 py-2 text-[11px] font-black uppercase tracking-wide text-red-100 hover:bg-red-500/20"
+          >
+            <Swords size={14} />
+            Counter
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/components/GameChallengeSettlementDmCard.tsx
+++ b/components/GameChallengeSettlementDmCard.tsx
@@ -89,7 +89,7 @@ export const GameChallengeSettlementDmCard: React.FC<GameChallengeSettlementDmCa
 
   const sub =
     viewer === 'win'
-      ? 'Your side hit — bragging rights earned.'
+      ? 'Your side hit!'
       : viewer === 'loss'
         ? 'Their pick was the right one this time.'
         : viewer === 'push'
@@ -150,7 +150,7 @@ export const GameChallengeSettlementDmCard: React.FC<GameChallengeSettlementDmCa
               Your side: <span className="text-emerald-300">{yourPick}</span>
             </p>
             {onOpenFull ? (
-              <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">Tap for full-screen recap</p>
+              <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-slate-500">View Recap:</p>
             ) : null}
           </div>
         </div>

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -10,7 +10,7 @@ interface LeaderboardProps {
   entries: LeaderboardEntry[];
 }
 
-type SortKey = 'rank' | 'user' | 'netWorth' | 'winRate' | 'trend';
+type SortKey = 'rank' | 'user' | 'netWorth' | 'winRate' | 'challengeWins' | 'trend';
 type SortDir = 'asc' | 'desc';
 
 function trendScore(e: LeaderboardEntry): number {
@@ -43,6 +43,8 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
           return (a.netWorth - b.netWorth) * dir;
         case 'winRate':
           return (a.winRate - b.winRate) * dir;
+        case 'challengeWins':
+          return ((a.challengeWins ?? 0) - (b.challengeWins ?? 0)) * dir;
         case 'trend':
           return (trendScore(a) - trendScore(b)) * dir;
         default:
@@ -101,13 +103,14 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
               <SortHeader label="User" colKey="user" />
               <SortHeader label="Net Worth" colKey="netWorth" />
               <SortHeader label="Win Rate" colKey="winRate" />
+              <SortHeader label="Challenges" colKey="challengeWins" align="right" />
               <SortHeader label="Trend" colKey="trend" align="right" />
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/50">
             {entries.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-6 py-16 text-center">
+                <td colSpan={6} className="px-6 py-16 text-center">
                   <Trophy className="mx-auto text-slate-600 mb-3" size={40} />
                   <p className="text-slate-300 font-bold text-lg mb-1">No players on the board yet</p>
                   <p className="text-slate-500 text-sm max-w-md mx-auto">
@@ -165,6 +168,9 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ entries }) => {
                     </div>
                     <span className="text-xs font-bold text-slate-400">{entry.winRate}%</span>
                   </div>
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <span className="font-black text-amber-200/90 tabular-nums">{entry.challengeWins ?? 0}</span>
                 </td>
                 <td className="px-6 py-4 text-right">
                   <TrendingUp className="inline text-green-400" size={16} />

--- a/components/PeerSettleDetailModal.tsx
+++ b/components/PeerSettleDetailModal.tsx
@@ -263,7 +263,7 @@ export const PeerSettleDetailModal: React.FC<PeerSettleDetailModalProps> = ({
     const v = gcViewerOutcome(gcStatus, currentUserId, gcChUid, gcOpUid);
     const shell = v === 'win' ? shellWin : v === 'loss' ? shellLoss : v === 'push' ? shellPush : 'border-slate-600 bg-slate-950/90';
     const title =
-      v === 'win' ? 'You won the challenge' : v === 'loss' ? 'You lost the challenge' : v === 'push' ? 'Challenge pushed' : 'Game challenge';
+      v === 'win' ? 'You won the challenge.' : v === 'loss' ? 'You lost the challenge.' : v === 'push' ? 'Challenge pushed.' : 'Game challenge.';
     const yourPick = currentUserId === gcChUid ? gcChPick : gcOpPick;
     const theirPick = currentUserId === gcChUid ? gcOpPick : gcChPick;
 

--- a/components/PeerSettleDetailModal.tsx
+++ b/components/PeerSettleDetailModal.tsx
@@ -1,0 +1,332 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import { X, Skull, Sparkles, Trophy } from 'lucide-react';
+import type { Bet, HeadToHeadStatus, ParlayLeg } from '@/models';
+import type { GameChallengeStatus } from '@/services/gameChallenges';
+import { getGameChallenge } from '@/services/gameChallenges';
+
+const H2H = 'headToHead';
+
+export type PeerSettleKind = 'h2h' | 'gc';
+
+export interface PeerSettleDetailModalProps {
+  open: boolean;
+  kind: PeerSettleKind | null;
+  docId: string | null;
+  currentUserId: string;
+  onClose: () => void;
+}
+
+function h2hViewerOutcome(
+  status: HeadToHeadStatus,
+  uid: string,
+  orig: string,
+  chall: string,
+): 'win' | 'loss' | 'push' | 'pending' {
+  if (status === 'PUSH') return 'push';
+  if (status === 'WON_BY_ORIGINAL') {
+    if (uid === orig) return 'win';
+    if (uid === chall) return 'loss';
+  }
+  if (status === 'WON_BY_CHALLENGER') {
+    if (uid === chall) return 'win';
+    if (uid === orig) return 'loss';
+  }
+  return 'pending';
+}
+
+function gcViewerOutcome(
+  status: GameChallengeStatus,
+  uid: string,
+  ch: string,
+  op: string,
+): 'win' | 'loss' | 'push' | 'pending' {
+  if (status === 'PUSH') return 'push';
+  if (status === 'COMPLETED_CHALLENGER') {
+    if (uid === ch) return 'win';
+    if (uid === op) return 'loss';
+  }
+  if (status === 'COMPLETED_OPPONENT') {
+    if (uid === op) return 'win';
+    if (uid === ch) return 'loss';
+  }
+  return 'pending';
+}
+
+/**
+ * Full-screen win / loss / push recap for a settled counter-bet or game challenge (opened from DM).
+ */
+export const PeerSettleDetailModal: React.FC<PeerSettleDetailModalProps> = ({
+  open,
+  kind,
+  docId,
+  currentUserId,
+  onClose,
+}) => {
+  const [h2hStatus, setH2hStatus] = useState<HeadToHeadStatus | null>(null);
+  const [marketTitle, setMarketTitle] = useState('');
+  const [originalSide, setOriginalSide] = useState('');
+  const [originalStake, setOriginalStake] = useState(0);
+  const [challengerStake, setChallengerStake] = useState(0);
+  const [originalUid, setOriginalUid] = useState('');
+  const [challengerUid, setChallengerUid] = useState('');
+  const [originalBetId, setOriginalBetId] = useState('');
+  const [linkedBet, setLinkedBet] = useState<Bet | null>(null);
+
+  const [gcStatus, setGcStatus] = useState<GameChallengeStatus | null>(null);
+  const [gcTitle, setGcTitle] = useState('');
+  const [gcChPick, setGcChPick] = useState('');
+  const [gcOpPick, setGcOpPick] = useState('');
+  const [gcChUid, setGcChUid] = useState('');
+  const [gcOpUid, setGcOpUid] = useState('');
+
+  useEffect(() => {
+    if (!open || kind !== 'h2h' || !docId) return;
+    const r = doc(db, H2H, docId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) {
+        setH2hStatus(null);
+        return;
+      }
+      const d = snap.data();
+      setH2hStatus((d.status as HeadToHeadStatus) ?? 'PENDING_ACCEPT');
+      setMarketTitle(String(d.marketTitle ?? ''));
+      setOriginalSide(String(d.originalSide ?? ''));
+      setOriginalStake(Number(d.originalStake) || 0);
+      setChallengerStake(Number(d.challengerStake) || 0);
+      setOriginalUid(String(d.originalUserId ?? ''));
+      setChallengerUid(String(d.challengerUserId ?? ''));
+      setOriginalBetId(String(d.originalBetId ?? ''));
+    });
+    return () => unsub();
+  }, [open, kind, docId]);
+
+  useEffect(() => {
+    if (!open || kind !== 'h2h' || !originalBetId) return;
+    let cancelled = false;
+    void getDoc(doc(db, 'bets', originalBetId)).then((snap) => {
+      if (cancelled || !snap.exists()) return;
+      const data = snap.data();
+      const legs: ParlayLeg[] = Array.isArray(data.parlayLegs)
+        ? data.parlayLegs.map((leg: Record<string, unknown>): ParlayLeg => ({
+            marketId: String(leg.marketId ?? ''),
+            marketTitle: String(leg.marketTitle ?? ''),
+            sportKey: String(leg.sportKey ?? ''),
+            optionId: String(leg.optionId ?? ''),
+            optionLabel: String(leg.optionLabel ?? ''),
+            odds: Number(leg.odds) || 0,
+            marketKey: (leg.marketKey as ParlayLeg['marketKey']) ?? 'h2h',
+            result: (leg.result as ParlayLeg['result']) ?? 'PENDING',
+          }))
+        : [];
+      setLinkedBet({
+        id: snap.id,
+        userID: String(data.userID ?? ''),
+        marketId: String(data.marketId ?? ''),
+        marketTitle: String(data.marketTitle ?? ''),
+        optionLabel: String(data.optionLabel ?? ''),
+        betType: data.betType === 'parlay' ? 'parlay' : 'single',
+        stake: Number(data.stake) || 0,
+        odds: Number(data.odds) || 0,
+        potentialPayout: Number(data.potentialPayout) || 0,
+        placedAt: data.placedAt?.toDate?.() ?? new Date(),
+        legCount: Number(data.legCount) ?? 1,
+        parlayLegs: legs,
+        status: (data.status ?? 'PENDING') as Bet['status'],
+        settledAt: data.settledAt?.toDate?.(),
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, kind, originalBetId]);
+
+  useEffect(() => {
+    if (!open || kind !== 'gc' || !docId) return;
+    let cancelled = false;
+    void getGameChallenge(docId).then((gc) => {
+      if (cancelled || !gc) return;
+      setGcStatus(gc.status);
+      setGcTitle(gc.marketTitle);
+      setGcChPick(gc.challengerPickLabel);
+      setGcOpPick(gc.opponentPickLabel);
+      setGcChUid(gc.challengerUid);
+      setGcOpUid(gc.opponentUid);
+    });
+    const r = doc(db, 'gameChallenges', docId);
+    const unsub = onSnapshot(r, (snap) => {
+      if (!snap.exists()) return;
+      const d = snap.data();
+      setGcStatus((d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT');
+      setGcTitle(String(d.marketTitle ?? ''));
+      setGcChPick(String(d.challengerPickLabel ?? ''));
+      setGcOpPick(String(d.opponentPickLabel ?? ''));
+      setGcChUid(String(d.challengerUid ?? ''));
+      setGcOpUid(String(d.opponentUid ?? ''));
+    });
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, [open, kind, docId]);
+
+  if (!open || !kind || !docId) return null;
+
+  const shellWin =
+    'border-amber-400/50 bg-gradient-to-br from-amber-500/25 via-yellow-500/15 to-orange-600/20 shadow-[0_0_60px_rgba(251,191,36,0.45)]';
+  const shellLoss =
+    'border-rose-500/50 bg-gradient-to-br from-rose-950/90 via-orange-950/60 to-slate-950/95 shadow-[0_0_48px_rgba(244,63,94,0.35)]';
+  const shellPush = 'border-slate-500/40 bg-slate-900/90 shadow-[0_0_28px_rgba(148,163,184,0.25)]';
+
+  if (kind === 'h2h' && h2hStatus) {
+    const v = h2hViewerOutcome(h2hStatus, currentUserId, originalUid, challengerUid);
+    const shell = v === 'win' ? shellWin : v === 'loss' ? shellLoss : v === 'push' ? shellPush : 'border-slate-600 bg-slate-950/90';
+    const title =
+      v === 'win' ? 'You won the counter' : v === 'loss' ? 'You lost the counter' : v === 'push' ? 'Counter pushed' : 'Counter-bet';
+    const sub =
+      v === 'win'
+        ? h2hStatus === 'WON_BY_ORIGINAL'
+          ? 'Your pick held — you took the escrow.'
+          : 'The fade hit — you cleared the pot.'
+        : v === 'loss'
+          ? h2hStatus === 'WON_BY_ORIGINAL'
+            ? 'Their pick stood — they took the escrow.'
+            : 'Their fade cashed against your pick.'
+          : v === 'push'
+            ? 'Both escrows were returned.'
+            : '';
+
+    return (
+      <div
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/75 backdrop-blur-md px-4"
+        onClick={onClose}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          className={`relative w-full max-w-lg rounded-2xl border p-6 ${shell}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-3 top-3 rounded-full border border-slate-600 bg-slate-950/60 p-1.5 text-slate-300 hover:text-white"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+          <div className="flex items-center gap-2">
+            {v === 'win' ? (
+              <Trophy className="h-8 w-8 text-amber-200 drop-shadow-[0_0_12px_rgba(253,224,71,0.8)]" />
+            ) : v === 'loss' ? (
+              <Skull className="h-8 w-8 text-rose-200" />
+            ) : (
+              <Sparkles className="h-7 w-7 text-slate-300" />
+            )}
+            <h2
+              className={`text-2xl font-black tracking-tight ${
+                v === 'win'
+                  ? 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200'
+                  : v === 'loss'
+                    ? 'text-transparent bg-clip-text bg-gradient-to-r from-rose-200 to-orange-200'
+                    : 'text-slate-100'
+              }`}
+            >
+              {title}
+            </h2>
+          </div>
+          <p className="mt-2 text-sm text-slate-300">{sub}</p>
+          <p className="mt-4 text-base font-bold text-slate-50">{marketTitle}</p>
+          <p className="mt-1 text-sm text-slate-400">
+            Contested pick: <span className="text-sky-300">{originalSide}</span>
+          </p>
+          <p className="mt-2 text-sm text-slate-400">
+            Escrow pot <span className="font-mono text-slate-100">${(originalStake + challengerStake).toFixed(2)}</span>
+          </p>
+          {linkedBet ? (
+            <div className="mt-5 rounded-xl border border-slate-700/80 bg-slate-950/60 p-4 text-sm">
+              <p className="text-[10px] font-bold uppercase text-slate-500">Original ticket</p>
+              <p className="mt-1 font-semibold text-slate-100">{linkedBet.optionLabel}</p>
+              <p className="text-xs text-slate-500">{linkedBet.marketTitle}</p>
+              <p className="mt-2 text-xs text-slate-400">
+                Stake ${linkedBet.stake.toFixed(2)} · Odds {linkedBet.odds.toFixed(2)} · {linkedBet.status}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (kind === 'gc' && gcStatus) {
+    const v = gcViewerOutcome(gcStatus, currentUserId, gcChUid, gcOpUid);
+    const shell = v === 'win' ? shellWin : v === 'loss' ? shellLoss : v === 'push' ? shellPush : 'border-slate-600 bg-slate-950/90';
+    const title =
+      v === 'win' ? 'You won the challenge' : v === 'loss' ? 'You lost the challenge' : v === 'push' ? 'Challenge pushed' : 'Game challenge';
+    const yourPick = currentUserId === gcChUid ? gcChPick : gcOpPick;
+    const theirPick = currentUserId === gcChUid ? gcOpPick : gcChPick;
+
+    return (
+      <div
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/75 backdrop-blur-md px-4"
+        onClick={onClose}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          className={`relative w-full max-w-lg rounded-2xl border p-6 ${shell}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-3 top-3 rounded-full border border-slate-600 bg-slate-950/60 p-1.5 text-slate-300 hover:text-white"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+          <div className="flex items-center gap-2">
+            {v === 'win' ? (
+              <Trophy className="h-8 w-8 text-amber-200 drop-shadow-[0_0_12px_rgba(253,224,71,0.8)]" />
+            ) : v === 'loss' ? (
+              <Skull className="h-8 w-8 text-rose-200" />
+            ) : (
+              <Sparkles className="h-7 w-7 text-slate-300" />
+            )}
+            <h2
+              className={`text-2xl font-black tracking-tight ${
+                v === 'win'
+                  ? 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200'
+                  : v === 'loss'
+                    ? 'text-transparent bg-clip-text bg-gradient-to-r from-rose-200 to-orange-200'
+                    : 'text-slate-100'
+              }`}
+            >
+              {title}
+            </h2>
+          </div>
+          <p className="mt-4 text-base font-bold text-slate-50">{gcTitle}</p>
+          <div className="mt-4 grid gap-2 rounded-xl border border-slate-700/70 bg-slate-950/50 p-4 text-sm">
+            <p>
+              <span className="text-slate-500">Your side:</span>{' '}
+              <span className="font-semibold text-emerald-300">{yourPick}</span>
+            </p>
+            <p>
+              <span className="text-slate-500">Their side:</span>{' '}
+              <span className="font-semibold text-sky-300">{theirPick}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/70 px-4" onClick={onClose}>
+      <div className="rounded-xl border border-slate-700 bg-slate-900 p-6 text-slate-400" onClick={(e) => e.stopPropagation()}>
+        Loading…
+      </div>
+    </div>
+  );
+};

--- a/components/SocialMessagingView.tsx
+++ b/components/SocialMessagingView.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import type { Bet, Friend, SocialActivity } from '../models';
 import { Eye, Swords, Search, UserPlus2, UserPlus } from 'lucide-react';
 import { ChatPane, type ChatMessage } from './chat/ChatPane';
+import { PeerSettleDetailModal, type PeerSettleKind } from './PeerSettleDetailModal';
 import { UserAvatar } from './UserAvatar';
 import { ANONYMOUS_PROFILE_AVATAR_PATH, defaultAvatarForUid } from '@/models/defaultProfileAvatars';
 import {
@@ -47,6 +48,7 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showAllActivity, setShowAllActivity] = useState(false);
   const [privacy, togglePrivacy] = useState(userPrivacy);
+  const [peerSettleOpen, setPeerSettleOpen] = useState<{ kind: PeerSettleKind; id: string } | null>(null);
 
   const location = useLocation();
 
@@ -552,7 +554,7 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
 
             <div className="glass-card rounded-2xl overflow-hidden border-slate-800/80 bg-slate-950/30">
               <ChatPane
-                currentUserId={currentUid}
+                currentUserId={currentUid!}
                 currentUserName={currentUserName}
                 otherUser={activeFriend}
                 messages={activeThreadMessages}
@@ -562,6 +564,7 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                 onDeleteMessage={handleDeleteMessage}
                 onOpenProfile={(userId) => navigate(`/profile/${userId}`)}
                 onClose={() => setActiveChatUserId(null)}
+                onPeerSettleOpen={(p) => setPeerSettleOpen(p)}
               />
             </div>
           </>
@@ -588,25 +591,43 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
         <div className="space-y-4 max-h-[72vh] overflow-y-auto custom-scrollbar pr-1">
           {visibleActivities?.map((activity) => {
                 const expandedBet = expandedBetForActivity(activity);
+                const isPeer =
+                  activity.activityKind === 'peer_counter' || activity.activityKind === 'peer_challenge';
                 const placedAt =
                   expandedBet?.placedAt instanceof Date
                     ? expandedBet.placedAt
                     : expandedBet
                       ? new Date(expandedBet.placedAt as unknown as string)
                       : null;
+                const peerAvatarSrc =
+                  activity.peerUserAvatarUrl ??
+                  (activity.peerUserId && activity.peerUserName
+                    ? `/bethub/${defaultAvatarForUid(activity.peerUserId, activity.peerUserName)}`
+                    : undefined);
 
             return (
               <div
                 key={activity.id}
                 className="glass-card rounded-2xl p-4 flex gap-4 border-slate-800 hover:bg-slate-800/20 transition-all"
               >
-                <UserAvatar
-                  initials={activity.userAvatar}
-                  imageUrl={activityAvatarUrl(activity)}
-                  alt={`${activity.userName}'s avatar`}
-                  className="w-10 h-10 rounded-xl flex-shrink-0"
-                  textClassName="text-slate-400"
-                />
+                <div className="relative h-10 w-10 flex-shrink-0">
+                  <UserAvatar
+                    initials={activity.userAvatar}
+                    imageUrl={activityAvatarUrl(activity)}
+                    alt={`${activity.userName}'s avatar`}
+                    className="h-10 w-10 rounded-xl"
+                    textClassName="text-slate-400"
+                  />
+                  {activity.peerUserId ? (
+                    <UserAvatar
+                      initials={activity.peerUserAvatar ?? '??'}
+                      imageUrl={peerAvatarSrc}
+                      alt={`${activity.peerUserName ?? 'Opponent'}'s avatar`}
+                      className="absolute -bottom-1 -right-2 h-7 w-7 rounded-lg border-2 border-slate-900"
+                      textClassName="text-[9px] text-violet-200"
+                    />
+                  ) : null}
+                </div>
                 <div className="flex-1">
                   <div className="flex justify-between items-start gap-3">
                     <p className="text-sm min-w-0">
@@ -618,6 +639,18 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                       </NavLink>{' '}
                       <span className="text-slate-400">{activity.action}</span>{' '}
                       <span className="font-bold text-blue-400" title={activity.target}>{truncateTarget(activity.target)}</span>
+                      {activity.peerUserId ? (
+                        <>
+                          {' '}
+                          <span className="text-slate-500">vs</span>{' '}
+                          <NavLink
+                            to={`/profile/${activity.peerUserId}`}
+                            className="font-bold text-amber-200/95 hover:text-amber-100 transition-colors"
+                          >
+                            {activity.peerUserName ?? 'Opponent'}
+                          </NavLink>
+                        </>
+                      ) : null}
                     </p>
                     <span className="text-[10px] text-slate-600 font-bold uppercase shrink-0">
                       {activity.timestamp}
@@ -625,13 +658,23 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                   </div>
 
                   <div className="mt-3 flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => toggleDetails(activity.id)}
-                      className="text-[10px] font-bold text-slate-500 hover:text-slate-300 flex items-center gap-1 uppercase tracking-tighter"
-                    >
-                      <Eye size={12} /> View Bet
-                    </button>
+                    {!isPeer ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleDetails(activity.id)}
+                        className="text-[10px] font-bold text-slate-500 hover:text-slate-300 flex items-center gap-1 uppercase tracking-tighter"
+                      >
+                        <Eye size={12} /> View Bet
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => toggleDetails(activity.id)}
+                        className="text-[10px] font-bold text-slate-500 hover:text-slate-300 flex items-center gap-1 uppercase tracking-tighter"
+                      >
+                        <Eye size={12} /> Details
+                      </button>
+                    )}
 
                     <button
                       type="button"
@@ -640,9 +683,28 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                     >
                       <Swords size={12} /> Message
                     </button>
+                    {activity.peerUserId ? (
+                      <button
+                        type="button"
+                        onClick={() => setActiveChatUserId(activity.peerUserId)}
+                        className="text-[10px] font-bold text-amber-400/90 hover:text-amber-300 flex items-center gap-1 uppercase tracking-tighter"
+                      >
+                        <UserPlus size={12} /> Opponent
+                      </button>
+                    ) : null}
                   </div>
 
-                  {expandedId === activity.id && expandedBet ? (
+                  {expandedId === activity.id && isPeer ? (
+                    <div className="mt-3 p-4 rounded-2xl bg-slate-500/5 border border-slate-500/10 text-sm text-slate-300">
+                      <p className="font-semibold text-slate-200">
+                        {activity.activityKind === 'peer_counter' ? 'Head-to-head counter' : 'Game challenge'}
+                      </p>
+                      <p className="mt-2 text-slate-400">
+                        {activity.userName} {activity.action}{' '}
+                        <span className="text-slate-200">{truncateTarget(activity.target, 120)}</span>
+                      </p>
+                    </div>
+                  ) : expandedId === activity.id && expandedBet ? (
                     <div className="mt-3 p-4 rounded-2xl bg-slate-500/5 border border-slate-500/10">
                       <div className="text-sm">
                         <span className="font-bold text-slate-100">Stake: </span>
@@ -663,7 +725,7 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                         </span>
                       </div>
                     </div>
-                  ) : expandedId === activity.id && !expandedBet ? (
+                  ) : expandedId === activity.id && !expandedBet && !isPeer ? (
                     <div className="mt-3 p-4 rounded-2xl bg-slate-500/5 border border-slate-500/10 text-sm text-slate-400">
                       Bet details unavailable.
                     </div>
@@ -675,6 +737,15 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
           </div>
       </div>
 
+      {currentUid && peerSettleOpen ? (
+        <PeerSettleDetailModal
+          open
+          kind={peerSettleOpen.kind}
+          docId={peerSettleOpen.id}
+          currentUserId={currentUid}
+          onClose={() => setPeerSettleOpen(null)}
+        />
+      ) : null}
     </div>
   );
 };

--- a/components/SocialMessagingView.tsx
+++ b/components/SocialMessagingView.tsx
@@ -418,7 +418,7 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
                     onChallenge(friend);
                   }}
                   className="p-2 rounded-lg bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 items-center justify-center gap-1 text-[10px] font-bold uppercase pointer-events-auto"
-                  aria-label={`Challenge ${friend.name}`}
+                  aria-label={`Counter ${friend.name}`}
                 >
                   <Swords size={14} />
                 </button>

--- a/components/SocialMessagingView.tsx
+++ b/components/SocialMessagingView.tsx
@@ -262,6 +262,40 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
     return m;
   }, [friendsForRail, currentUid]);
 
+  const isActiveChatNonFriend = useMemo(
+    () =>
+      Boolean(activeChatUserId && !friendsForRail.some((f) => f.id === activeChatUserId)),
+    [activeChatUserId, friendsForRail],
+  );
+
+  const pinnedSearchUser: UserSearchResult | null = useMemo(() => {
+    if (!isActiveChatNonFriend || !activeChatUserId || !activeFriend || activeFriend.name === 'Unknown') return null;
+    return {
+      uid: activeChatUserId,
+      name: activeFriend.name,
+      privacyEnabled: activeFriend.privacyEnabled,
+      avatarUrl: activeFriend.avatarUrl,
+      profileBackgroundUrl: activeFriend.profileBackgroundUrl,
+    };
+  }, [isActiveChatNonFriend, activeChatUserId, activeFriend]);
+
+  const combinedSearchRows = useMemo(() => {
+    const out: UserSearchResult[] = [];
+    if (pinnedSearchUser) out.push(pinnedSearchUser);
+    for (const r of searchResults) {
+      if (pinnedSearchUser && r.uid === pinnedSearchUser.uid) continue;
+      out.push(r);
+    }
+    return out;
+  }, [pinnedSearchUser, searchResults]);
+
+  useEffect(() => {
+    if (!isActiveChatNonFriend || !activeChatUserId) return;
+    const name = activeFriend?.name?.trim();
+    if (!name || name === 'Unknown') return;
+    onSearchChange(name);
+  }, [isActiveChatNonFriend, activeChatUserId, activeFriend?.name]);
+
   useEffect(() => {
     togglePrivacy(userPrivacy);
   }, [userPrivacy]);
@@ -435,15 +469,18 @@ export const SocialMessagingView: React.FC<SocialMessagingViewProps> = ({
               onChange={(e) => onSearchChange(e.target.value)}
               className="w-full bg-slate-900 border border-slate-800 rounded-xl py-2.5 pl-10 pr-3 outline-none focus:border-blue-500 transition-all text-sm"
             />
-            {(searchLoading || searchResults.length > 0 || searchQuery.trim().length > 0) && (
+            {(searchLoading ||
+              combinedSearchRows.length > 0 ||
+              searchQuery.trim().length > 0 ||
+              (isActiveChatNonFriend && Boolean(activeFriend?.name && activeFriend.name !== 'Unknown'))) && (
               <div className="mt-2 rounded-xl border border-slate-800 bg-slate-950/80 p-1.5 max-h-56 overflow-y-auto custom-scrollbar">
                 {searchLoading ? (
                   <p className="px-3 py-2 text-xs text-slate-500">Searching…</p>
-                ) : searchResults.length === 0 ? (
+                ) : combinedSearchRows.length === 0 ? (
                   <p className="px-3 py-2 text-xs text-slate-500">No users found.</p>
                 ) : (
                   <div className="space-y-1">
-                    {searchResults.map((u) => {
+                    {combinedSearchRows.map((u) => {
                       const alreadyFriend = friendsForRail.some((f) => f.id === u.uid);
                       const alreadyRequested = requestedUserIds.has(u.uid);
                       return (

--- a/components/SocialView.tsx
+++ b/components/SocialView.tsx
@@ -168,7 +168,7 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
                 onClick={() => onChallenge(friend)}
                 className="p-2 rounded-lg bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-all opacity-0 group-hover:opacity-100 flex items-center gap-1 text-[10px] font-bold uppercase"
               >
-                <Swords size={14} /> Challenge
+                <Swords size={14} /> Counter
               </button>
             </div>
           ))}

--- a/components/SocialView.tsx
+++ b/components/SocialView.tsx
@@ -65,6 +65,7 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
     | { kind: 'enabled'; bet: Bet };
 
   const fadeEligibilityFor = (activity: SocialActivity): FadeEligibility => {
+    if (activity.activityKind && activity.activityKind !== 'bet') return { kind: 'hidden' };
     if (currentUid && activity.userId === currentUid) return { kind: 'hidden' };
     const bet = betList.find((b) => b.id === activity.id);
     if (!bet)                          return { kind: 'disabled', reason: 'Bet details unavailable.' };
@@ -272,16 +273,34 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
         </div>
 
         <div className="space-y-4">
-          {activities?.map(activity => (
-
+          {activities?.map((activity) => {
+            const isPeer =
+              activity.activityKind === 'peer_counter' || activity.activityKind === 'peer_challenge';
+            const peerAvatarSrc =
+              activity.peerUserAvatarUrl ??
+              (activity.peerUserId && activity.peerUserName
+                ? `/bethub/${defaultAvatarForUid(activity.peerUserId, activity.peerUserName)}`
+                : undefined);
+            return (
             <div key={activity.id} className="glass-card rounded-2xl p-4 flex gap-4 border-slate-800 hover:bg-slate-800/20 transition-all">
-              <UserAvatar
-                initials={activity.userAvatar}
-                imageUrl={activityAvatarUrl(activity)}
-                alt={`${activity.userName}'s avatar`}
-                className="w-10 h-10 rounded-xl flex-shrink-0"
-                textClassName="text-slate-400"
-              />
+              <div className="relative h-10 w-10 flex-shrink-0">
+                <UserAvatar
+                  initials={activity.userAvatar}
+                  imageUrl={activityAvatarUrl(activity)}
+                  alt={`${activity.userName}'s avatar`}
+                  className="h-10 w-10 rounded-xl"
+                  textClassName="text-slate-400"
+                />
+                {activity.peerUserId ? (
+                  <UserAvatar
+                    initials={activity.peerUserAvatar ?? '??'}
+                    imageUrl={peerAvatarSrc}
+                    alt={`${activity.peerUserName ?? 'Opponent'}'s avatar`}
+                    className="absolute -bottom-1 -right-2 h-7 w-7 rounded-lg border-2 border-slate-900"
+                    textClassName="text-[9px] text-violet-200"
+                  />
+                ) : null}
+              </div>
               <div className="flex-1">
                 <div className="flex justify-between items-start">
                   <p className="text-sm">
@@ -290,6 +309,18 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
                     </NavLink>{' '}
                     <span className="text-slate-400">{activity.action}</span>{' '}
                     <span className="font-bold text-blue-400">{activity.target}</span>
+                    {activity.peerUserId ? (
+                      <>
+                        {' '}
+                        <span className="text-slate-500">vs</span>{' '}
+                        <NavLink
+                          to={`/profile/${activity.peerUserId}`}
+                          className="font-bold text-amber-200/95 hover:text-amber-100 transition-colors"
+                        >
+                          {activity.peerUserName ?? 'Opponent'}
+                        </NavLink>
+                      </>
+                    ) : null}
                   </p>
                   <span className="text-[10px] text-slate-600 font-bold uppercase">{activity.timestamp}</span>
                 </div>
@@ -297,7 +328,7 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
                   <button
                       onClick={() => toggleDetails(activity.id)}
                       className="text-[10px] font-bold text-slate-500 hover:text-slate-300 flex items-center gap-1 uppercase tracking-tighter">
-                    <Eye size={12} /> View Bet
+                    <Eye size={12} /> {isPeer ? 'Details' : 'View Bet'}
                   </button>
 
                   {(() => {
@@ -327,13 +358,16 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
                     );
                   })()}
                 </div>
-                {expandedId === activity.id && (() => {
-                  // Resolve the bet once instead of running .find() four
-                  // times and crashing if the row is missing from betList
-                  // (e.g. a freshly-streamed bet whose author doc was
-                  // dropped). placedAt is already a Date by the time it
-                  // reaches us — render it directly instead of calling
-                  // .toDate() on a Date.
+                {expandedId === activity.id && isPeer ? (
+                  <div className="mt-3 p-4 rounded-2xl bg-slate-500/5 border border-slate-500/10 text-sm text-slate-300">
+                    <p className="font-semibold text-slate-200">
+                      {activity.activityKind === 'peer_counter' ? 'Head-to-head counter' : 'Game challenge'}
+                    </p>
+                    <p className="mt-2 text-slate-400">
+                      {activity.userName} {activity.action} <span className="text-slate-200">{activity.target}</span>
+                    </p>
+                  </div>
+                ) : expandedId === activity.id ? (() => {
                   const expandedBet = betList.find(obj => obj.id === activity.id);
                   if (!expandedBet) {
                     return (
@@ -369,10 +403,11 @@ export const SocialView: React.FC<SocialViewProps> = ({ friends, friendRequests,
                       </div>
                     </div>
                   );
-                })()}
+                })() : null}
                 </div>
             </div>
-          ))}
+            );
+          })}
         </div>
       </div>
       {counterBetTarget && currentUid && (

--- a/components/WinCelebrationModal.tsx
+++ b/components/WinCelebrationModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, Sparkles, Trophy, Flame } from 'lucide-react';
+import { X, Sparkles, Trophy, Flame, Scale, Skull } from 'lucide-react';
 import type { Bet } from '../models';
 import { computeParlayRollup } from '@/services/parlayRollup';
 
@@ -15,10 +15,33 @@ export type WinCelebrationPayload =
       originalBetId?: string;
     }
   | {
+      kind: 'h2h_loss';
+      opponentUid: string;
+      marketTitle: string;
+      /** Short label for the user’s head-to-head side (original pick or fade context). */
+      yourSideLabel: string;
+    }
+  | {
+      kind: 'h2h_push';
+      opponentUid: string;
+      marketTitle: string;
+    }
+  | {
       kind: 'gc_win';
       opponentUid: string;
       marketTitle: string;
       yourPick: string;
+    }
+  | {
+      kind: 'gc_loss';
+      opponentUid: string;
+      marketTitle: string;
+      yourPick: string;
+    }
+  | {
+      kind: 'gc_push';
+      opponentUid: string;
+      marketTitle: string;
     };
 
 export interface WinCelebrationModalProps {
@@ -42,6 +65,13 @@ const resolvedPayout = (bet: Bet) => {
   return bet.potentialPayout;
 };
 
+type PeerOutcomeKind = WinCelebrationPayload['kind'];
+
+const isWinKind = (k: PeerOutcomeKind) =>
+  k === 'bet' || k === 'h2h_win' || k === 'gc_win';
+const isLossKind = (k: PeerOutcomeKind) => k === 'h2h_loss' || k === 'gc_loss';
+const isPushKind = (k: PeerOutcomeKind) => k === 'h2h_push' || k === 'gc_push';
+
 export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payload, open, onClose }) => {
   const [banter, setBanter] = useState('');
 
@@ -56,24 +86,60 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
     else onClose();
   };
 
-  const shell =
-    payload.kind === 'bet'
-      ? 'border-violet-300/35 bg-[#120d24]/95 shadow-[0_0_80px_rgba(249,115,22,0.35)]'
-      : 'border-amber-400/45 bg-[#1a1208]/95 shadow-[0_0_72px_rgba(251,191,36,0.38)]';
+  const shell = (() => {
+    if (payload.kind === 'bet') {
+      return 'border-violet-300/35 bg-[#120d24]/95 shadow-[0_0_80px_rgba(249,115,22,0.35)]';
+    }
+    if (isLossKind(payload.kind)) {
+      return 'border-rose-500/40 bg-[#1a0a10]/95 shadow-[0_0_72px_rgba(244,63,94,0.28)]';
+    }
+    if (isPushKind(payload.kind)) {
+      return 'border-slate-500/40 bg-[#0f1419]/95 shadow-[0_0_56px_rgba(148,163,184,0.22)]';
+    }
+    return 'border-amber-400/45 bg-[#1a1208]/95 shadow-[0_0_72px_rgba(251,191,36,0.38)]';
+  })();
 
-  const title =
-    payload.kind === 'bet'
-      ? 'You won!'
-      : payload.kind === 'h2h_win'
-        ? 'Counter cashed for you'
-        : 'Challenge crushed';
+  const title = (() => {
+    switch (payload.kind) {
+      case 'bet':
+        return 'You won!';
+      case 'h2h_win':
+        return 'Counter cashed for you';
+      case 'h2h_loss':
+        return 'Counter did not cash';
+      case 'h2h_push':
+        return 'Head-to-head push';
+      case 'gc_win':
+        return 'Challenge crushed';
+      case 'gc_loss':
+        return 'Challenge settled';
+      case 'gc_push':
+        return 'Challenge push';
+      default:
+        return 'Result';
+    }
+  })();
 
-  const subtitle =
-    payload.kind === 'bet'
-      ? 'Your bet has settled as a winner.'
-      : payload.kind === 'h2h_win'
-        ? 'You cleared the head-to-head counter — the escrow is yours.'
-        : 'Your game challenge pick hit — flex if you want.';
+  const subtitle = (() => {
+    switch (payload.kind) {
+      case 'bet':
+        return 'Your bet has settled as a winner.';
+      case 'h2h_win':
+        return 'You cleared the head-to-head counter — the escrow is yours.';
+      case 'h2h_loss':
+        return 'This head-to-head is final — your side did not take the pot.';
+      case 'h2h_push':
+        return 'No winner on the counter — both escrows were returned.';
+      case 'gc_win':
+        return 'Your game challenge pick hit — flex if you want.';
+      case 'gc_loss':
+        return 'The game challenge is final — their side graded ahead of yours.';
+      case 'gc_push':
+        return "Neither side took the bragging rights — it's a push.";
+      default:
+        return '';
+    }
+  })();
 
   return (
     <div
@@ -81,14 +147,18 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
       onClick={handleClose}
       role="dialog"
       aria-modal="true"
-      aria-label="Win celebration"
+      aria-label="Bet outcome"
     >
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
         <div
           className={`h-[26rem] w-[26rem] rounded-full blur-3xl animate-pulse ${
             payload.kind === 'bet'
               ? 'bg-[radial-gradient(circle,_rgba(139,92,246,0.45)_0%,_rgba(16,185,129,0.35)_45%,_rgba(251,146,60,0.3)_75%,_rgba(2,6,23,0)_100%)]'
-              : 'bg-[radial-gradient(circle,_rgba(251,191,36,0.5)_0%,_rgba(245,158,11,0.35)_40%,_rgba(234,88,12,0.25)_70%,_rgba(2,6,23,0)_100%)]'
+              : isLossKind(payload.kind)
+                ? 'bg-[radial-gradient(circle,_rgba(244,63,94,0.4)_0%,_rgba(127,29,29,0.35)_45%,_rgba(15,23,42,0.2)_75%,_rgba(2,6,23,0)_100%)]'
+                : isPushKind(payload.kind)
+                  ? 'bg-[radial-gradient(circle,_rgba(148,163,184,0.45)_0%,_rgba(71,85,105,0.3)_50%,_rgba(2,6,23,0)_100%)]'
+                  : 'bg-[radial-gradient(circle,_rgba(251,191,36,0.5)_0%,_rgba(245,158,11,0.35)_40%,_rgba(234,88,12,0.25)_70%,_rgba(2,6,23,0)_100%)]'
           }`}
         />
       </div>
@@ -101,7 +171,7 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
           type="button"
           onClick={handleClose}
           className="absolute right-3 top-3 rounded-full border border-slate-700/80 bg-slate-900/70 p-1.5 text-slate-300 transition-colors hover:text-white"
-          aria-label="Close win message"
+          aria-label="Close outcome message"
         >
           <X size={15} />
         </button>
@@ -110,7 +180,11 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
           className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${
             payload.kind === 'bet'
               ? 'border-emerald-300/40 bg-emerald-400/15 text-emerald-200'
-              : 'border-amber-300/50 bg-amber-400/20 text-amber-100'
+              : isLossKind(payload.kind)
+                ? 'border-rose-400/45 bg-rose-500/15 text-rose-100'
+                : isPushKind(payload.kind)
+                  ? 'border-slate-500/50 bg-slate-600/20 text-slate-200'
+                  : 'border-amber-300/50 bg-amber-400/20 text-amber-100'
           }`}
         >
           {payload.kind === 'bet' ? (
@@ -123,10 +197,30 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
               <Flame size={12} />
               Counter-bet win
             </>
-          ) : (
+          ) : payload.kind === 'h2h_loss' ? (
+            <>
+              <Skull size={12} />
+              Counter-bet loss
+            </>
+          ) : payload.kind === 'h2h_push' ? (
+            <>
+              <Scale size={12} />
+              Counter-bet push
+            </>
+          ) : payload.kind === 'gc_win' ? (
             <>
               <Trophy size={12} />
               Challenge win
+            </>
+          ) : payload.kind === 'gc_loss' ? (
+            <>
+              <Skull size={12} />
+              Challenge loss
+            </>
+          ) : (
+            <>
+              <Scale size={12} />
+              Challenge push
             </>
           )}
         </div>
@@ -135,7 +229,11 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
           className={`mt-3 text-3xl font-black tracking-tight ${
             payload.kind === 'bet'
               ? 'text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-emerald-300 to-orange-300'
-              : 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 drop-shadow-[0_0_14px_rgba(253,224,71,0.45)]'
+              : isLossKind(payload.kind)
+                ? 'text-transparent bg-clip-text bg-gradient-to-r from-rose-200 via-rose-100 to-slate-200 drop-shadow-[0_0_14px_rgba(251,113,133,0.35)]'
+                : isPushKind(payload.kind)
+                  ? 'text-transparent bg-clip-text bg-gradient-to-r from-slate-200 via-slate-300 to-slate-400'
+                  : 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 drop-shadow-[0_0_14px_rgba(253,224,71,0.45)]'
           }`}
         >
           {title}
@@ -154,13 +252,39 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
             <p className="mt-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Escrow you collected</p>
             <p className="mt-0.5 text-2xl font-black text-amber-200">${payload.totalEscrow.toFixed(2)}</p>
           </div>
-        ) : (
+        ) : payload.kind === 'h2h_loss' ? (
+          <div className="mt-4 rounded-xl border border-rose-500/30 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-rose-200/80">Counter-bet</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
+            <p className="mt-1 text-xs text-slate-400">
+              Your side: <span className="text-rose-200">{payload.yourSideLabel}</span>
+            </p>
+          </div>
+        ) : payload.kind === 'h2h_push' ? (
+          <div className="mt-4 rounded-xl border border-slate-600/50 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">Counter-bet</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
+          </div>
+        ) : payload.kind === 'gc_win' ? (
           <div className="mt-4 rounded-xl border border-amber-500/30 bg-slate-950/60 p-3.5">
             <p className="text-xs font-semibold uppercase tracking-wider text-amber-200/80">Game challenge</p>
             <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
             <p className="mt-1 text-xs text-slate-400">
               Your side: <span className="text-emerald-300">{payload.yourPick}</span>
             </p>
+          </div>
+        ) : payload.kind === 'gc_loss' ? (
+          <div className="mt-4 rounded-xl border border-rose-500/30 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-rose-200/80">Game challenge</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
+            <p className="mt-1 text-xs text-slate-400">
+              Your side: <span className="text-rose-200">{payload.yourPick}</span>
+            </p>
+          </div>
+        ) : (
+          <div className="mt-4 rounded-xl border border-slate-600/50 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">Game challenge</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
           </div>
         )}
 
@@ -182,9 +306,25 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
           </div>
         ) : null}
 
-        <div className="mt-4 flex items-center gap-1.5 text-[11px] font-semibold text-orange-200/90">
+        <div
+          className={`mt-4 flex items-center gap-1.5 text-[11px] font-semibold ${
+            isWinKind(payload.kind) && payload.kind !== 'bet'
+              ? 'text-orange-200/90'
+              : isLossKind(payload.kind)
+                ? 'text-rose-200/80'
+                : isPushKind(payload.kind)
+                  ? 'text-slate-400'
+                  : 'text-orange-200/90'
+          }`}
+        >
           <Sparkles size={12} />
-          {payload.kind === 'bet' ? 'May the odds be ever in your favor.' : 'Congratulations on your win!'}
+          {payload.kind === 'bet'
+            ? 'May the odds be ever in your favor.'
+            : isWinKind(payload.kind)
+              ? 'Congratulations on your win!'
+              : isLossKind(payload.kind)
+                ? "Tough loss."
+                : 'All even — no winner this time.'}
         </div>
       </div>
     </div>

--- a/components/WinCelebrationModal.tsx
+++ b/components/WinCelebrationModal.tsx
@@ -1,18 +1,31 @@
-import React from 'react';
-import { X, Sparkles, Trophy } from 'lucide-react';
+import React, { useState } from 'react';
+import { X, Sparkles, Trophy, Flame } from 'lucide-react';
 import type { Bet } from '../models';
 import { computeParlayRollup } from '@/services/parlayRollup';
 
-/* props for the win celebration modal */
-/* bet: the bet that was won */
-/* open: whether the modal is open */
-/* onClose: function to close the modal
-- aidan o'halloran at 1:45 am on may 8th 2026 */
+export type WinCelebrationPayload =
+  | { kind: 'bet'; bet: Bet }
+  | {
+      kind: 'h2h_win';
+      opponentUid: string;
+      marketTitle: string;
+      pickLabel: string;
+      totalEscrow: number;
+      /** Original ticket (optional; used for “your side” copy). */
+      originalBetId?: string;
+    }
+  | {
+      kind: 'gc_win';
+      opponentUid: string;
+      marketTitle: string;
+      yourPick: string;
+    };
 
-interface WinCelebrationModalProps { 
-  bet: Bet | null;
+export interface WinCelebrationModalProps {
+  payload: WinCelebrationPayload | null;
   open: boolean;
-  onClose: () => void;
+  /** Called with optional banter for H2H / game-challenge wins (sent to DM thread). */
+  onClose: (opts?: { banter?: string }) => void;
 }
 
 const isReducedParlay = (bet: Bet) => {
@@ -29,79 +42,184 @@ const resolvedPayout = (bet: Bet) => {
   return bet.potentialPayout;
 };
 
-export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ bet, open, onClose }) => {
-  if (!open || !bet) return null;
+export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payload, open, onClose }) => {
+  const [banter, setBanter] = useState('');
 
-  const payout = resolvedPayout(bet);
-  const reducedParlay = isReducedParlay(bet);
-  const settledAtLabel = bet.settledAt?.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  if (!open || !payload) return null;
+
+  const showBanter = payload.kind === 'h2h_win' || payload.kind === 'gc_win';
+
+  const handleClose = () => {
+    const trimmed = banter.trim();
+    setBanter('');
+    if (showBanter && trimmed) onClose({ banter: trimmed });
+    else onClose();
+  };
+
+  const shell =
+    payload.kind === 'bet'
+      ? 'border-violet-300/35 bg-[#120d24]/95 shadow-[0_0_80px_rgba(249,115,22,0.35)]'
+      : 'border-amber-400/45 bg-[#1a1208]/95 shadow-[0_0_72px_rgba(251,191,36,0.38)]';
+
+  const title =
+    payload.kind === 'bet'
+      ? 'You won!'
+      : payload.kind === 'h2h_win'
+        ? 'Counter cashed for you'
+        : 'Challenge crushed';
+
+  const subtitle =
+    payload.kind === 'bet'
+      ? 'Your bet has settled as a winner.'
+      : payload.kind === 'h2h_win'
+        ? 'You cleared the head-to-head counter — the escrow is yours.'
+        : 'Your game challenge pick hit — flex if you want.';
 
   return (
     <div
       className="fixed inset-0 z-[120] flex items-center justify-center bg-slate-950/65 backdrop-blur-sm px-4"
-      onClick={onClose}
+      onClick={handleClose}
       role="dialog"
       aria-modal="true"
-      aria-label="Winning bet celebration"
+      aria-label="Win celebration"
     >
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-        <div className="h-[26rem] w-[26rem] rounded-full bg-[radial-gradient(circle,_rgba(139,92,246,0.45)_0%,_rgba(16,185,129,0.35)_45%,_rgba(251,146,60,0.3)_75%,_rgba(2,6,23,0)_100%)] blur-3xl animate-pulse" />
+        <div
+          className={`h-[26rem] w-[26rem] rounded-full blur-3xl animate-pulse ${
+            payload.kind === 'bet'
+              ? 'bg-[radial-gradient(circle,_rgba(139,92,246,0.45)_0%,_rgba(16,185,129,0.35)_45%,_rgba(251,146,60,0.3)_75%,_rgba(2,6,23,0)_100%)]'
+              : 'bg-[radial-gradient(circle,_rgba(251,191,36,0.5)_0%,_rgba(245,158,11,0.35)_40%,_rgba(234,88,12,0.25)_70%,_rgba(2,6,23,0)_100%)]'
+          }`}
+        />
       </div>
 
       <div
-        className="relative z-10 w-full max-w-md rounded-2xl border border-violet-300/35 bg-[#120d24]/95 p-5 shadow-[0_0_80px_rgba(249,115,22,0.35)] backdrop-blur-md animate-in fade-in zoom-in-95 duration-300"
+        className={`relative z-10 w-full max-w-md rounded-2xl border p-5 backdrop-blur-md animate-in fade-in zoom-in-95 duration-300 ${shell}`}
         onClick={(event) => event.stopPropagation()}
       >
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           className="absolute right-3 top-3 rounded-full border border-slate-700/80 bg-slate-900/70 p-1.5 text-slate-300 transition-colors hover:text-white"
           aria-label="Close win message"
         >
           <X size={15} />
         </button>
 
-        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-300/40 bg-emerald-400/15 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-emerald-200">
-          <Trophy size={12} />
-          Winning Ticket
-        </div>
-
-        <h3 className="mt-3 text-3xl font-black tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-emerald-300 to-orange-300">
-          You won!
-        </h3>
-        <p className="mt-1 text-sm text-slate-300">Your bet has settled as a winner.</p>
-
-        <div className="mt-4 rounded-xl border border-slate-700/80 bg-slate-950/70 p-3.5">
-          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Bet Details</p>
-          <p className="mt-2 text-sm font-semibold text-slate-100">{bet.optionLabel}</p>
-          <p className="mt-1 text-xs text-slate-400">{bet.marketTitle}</p>
-
-          <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
-            <div>
-              <p className="font-semibold uppercase tracking-wider text-slate-500">Stake</p>
-              <p className="mt-0.5 text-slate-200">${bet.stake.toFixed(2)}</p>
-            </div>
-            <div>
-              <p className="font-semibold uppercase tracking-wider text-slate-500">Payout</p>
-              <p className="mt-0.5 font-bold text-emerald-300">${payout.toFixed(2)}</p>
-            </div>
-          </div>
-
-          {bet.betType === 'parlay' && (
-            <p className="mt-2 text-[11px] text-violet-200/90">
-              {bet.parlayLegs?.length ?? 0}-leg parlay
-              {reducedParlay ? ' (reduced after pushed/voided leg)' : ''}
-            </p>
+        <div
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-bold uppercase tracking-wider ${
+            payload.kind === 'bet'
+              ? 'border-emerald-300/40 bg-emerald-400/15 text-emerald-200'
+              : 'border-amber-300/50 bg-amber-400/20 text-amber-100'
+          }`}
+        >
+          {payload.kind === 'bet' ? (
+            <>
+              <Trophy size={12} />
+              Winning ticket
+            </>
+          ) : payload.kind === 'h2h_win' ? (
+            <>
+              <Flame size={12} />
+              Counter-bet win
+            </>
+          ) : (
+            <>
+              <Trophy size={12} />
+              Challenge win
+            </>
           )}
-          {settledAtLabel ? (
-            <p className="mt-1 text-[11px] text-slate-500">Settled at {settledAtLabel}</p>
-          ) : null}
         </div>
 
-        <div className="mt-4 inline-flex items-center gap-1.5 text-[11px] font-semibold text-orange-200">
-          May the odds be ever in your favor.
+        <h3
+          className={`mt-3 text-3xl font-black tracking-tight ${
+            payload.kind === 'bet'
+              ? 'text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-emerald-300 to-orange-300'
+              : 'text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 drop-shadow-[0_0_14px_rgba(253,224,71,0.45)]'
+          }`}
+        >
+          {title}
+        </h3>
+        <p className="mt-1 text-sm text-slate-300">{subtitle}</p>
+
+        {payload.kind === 'bet' ? (
+          <BetWinBody bet={payload.bet} />
+        ) : payload.kind === 'h2h_win' ? (
+          <div className="mt-4 rounded-xl border border-amber-500/30 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-200/80">Counter-bet</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
+            <p className="mt-1 text-xs text-slate-400">
+              Ticket side: <span className="text-sky-300">{payload.pickLabel}</span>
+            </p>
+            <p className="mt-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Escrow you collected</p>
+            <p className="mt-0.5 text-2xl font-black text-amber-200">${payload.totalEscrow.toFixed(2)}</p>
+          </div>
+        ) : (
+          <div className="mt-4 rounded-xl border border-amber-500/30 bg-slate-950/60 p-3.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-200/80">Game challenge</p>
+            <p className="mt-2 text-sm font-semibold text-slate-100 line-clamp-2">{payload.marketTitle}</p>
+            <p className="mt-1 text-xs text-slate-400">
+              Your side: <span className="text-emerald-300">{payload.yourPick}</span>
+            </p>
+          </div>
+        )}
+
+        {showBanter ? (
+          <div className="mt-4">
+            <label htmlFor="winBanter" className="text-[11px] font-bold uppercase tracking-wide text-slate-400">
+              Victory lap (optional) — drops in your DM with them
+            </label>
+            <textarea
+              id="winBanter"
+              value={banter}
+              onChange={(e) => setBanter(e.target.value)}
+              rows={2}
+              maxLength={280}
+              placeholder="Talk your talk…"
+              className="mt-1.5 w-full resize-none rounded-xl border border-slate-600/70 bg-slate-950/50 px-3 py-2 text-sm text-slate-100 outline-none placeholder:text-slate-600 focus:border-amber-500/50"
+            />
+            <p className="mt-1 text-right text-[10px] text-slate-500">{banter.length}/280</p>
+          </div>
+        ) : null}
+
+        <div className="mt-4 flex items-center gap-1.5 text-[11px] font-semibold text-orange-200/90">
+          <Sparkles size={12} />
+          {payload.kind === 'bet' ? 'May the odds be ever in your favor.' : 'Ship the smoke respectfully — or not.'}
         </div>
       </div>
+    </div>
+  );
+};
+
+const BetWinBody: React.FC<{ bet: Bet }> = ({ bet }) => {
+  const payout = resolvedPayout(bet);
+  const reducedParlay = isReducedParlay(bet);
+  const settledAtLabel = bet.settledAt?.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+
+  return (
+    <div className="mt-4 rounded-xl border border-slate-700/80 bg-slate-950/70 p-3.5">
+      <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Bet details</p>
+      <p className="mt-2 text-sm font-semibold text-slate-100">{bet.optionLabel}</p>
+      <p className="mt-1 text-xs text-slate-400">{bet.marketTitle}</p>
+
+      <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
+        <div>
+          <p className="font-semibold uppercase tracking-wider text-slate-500">Stake</p>
+          <p className="mt-0.5 text-slate-200">${bet.stake.toFixed(2)}</p>
+        </div>
+        <div>
+          <p className="font-semibold uppercase tracking-wider text-slate-500">Payout</p>
+          <p className="mt-0.5 font-bold text-emerald-300">${payout.toFixed(2)}</p>
+        </div>
+      </div>
+
+      {bet.betType === 'parlay' && (
+        <p className="mt-2 text-[11px] text-violet-200/90">
+          {bet.parlayLegs?.length ?? 0}-leg parlay
+          {reducedParlay ? ' (reduced after pushed/voided leg)' : ''}
+        </p>
+      )}
+      {settledAtLabel ? <p className="mt-1 text-[11px] text-slate-500">Settled at {settledAtLabel}</p> : null}
     </div>
   );
 };

--- a/components/WinCelebrationModal.tsx
+++ b/components/WinCelebrationModal.tsx
@@ -184,7 +184,7 @@ export const WinCelebrationModal: React.FC<WinCelebrationModalProps> = ({ payloa
 
         <div className="mt-4 flex items-center gap-1.5 text-[11px] font-semibold text-orange-200/90">
           <Sparkles size={12} />
-          {payload.kind === 'bet' ? 'May the odds be ever in your favor.' : 'Ship the smoke respectfully — or not.'}
+          {payload.kind === 'bet' ? 'May the odds be ever in your favor.' : 'Congratulations on your win!'}
         </div>
       </div>
     </div>

--- a/components/chat/ChatPane.tsx
+++ b/components/chat/ChatPane.tsx
@@ -4,7 +4,12 @@ import { Send, Trash2, X } from 'lucide-react';
 import { UserAvatar } from '../UserAvatar';
 import { GameChallengeDmCard } from '../GameChallengeDmCard';
 import { CounterBetDmCard } from '../CounterBetDmCard';
-import { isGameChallengeMessageText, parseGameChallengeIdFromMessage } from '@/services/gameChallenges';
+import {
+  isGameChallengeMessageText,
+  isGcSettleMessageText,
+  parseGameChallengeIdFromMessage,
+  parseGcSettleChallengeIdFromMessage,
+} from '@/services/gameChallenges';
 import {
   isCounterBetInviteMessageText,
   isCounterBetSettlementMessageText,
@@ -12,6 +17,7 @@ import {
   parseCounterBetSettlementH2hIdFromMessage,
 } from '@/services/dbOps';
 import { CounterBetSettlementDmCard } from '../CounterBetSettlementDmCard';
+import { GameChallengeSettlementDmCard } from '../GameChallengeSettlementDmCard';
 
 export type ChatMessage = {
   id: string;
@@ -33,6 +39,8 @@ interface ChatPaneProps {
   onDeleteMessage?: (messageId: string) => void;
   onOpenProfile?: (userId: string) => void;
   onClose?: () => void;
+  /** Open full-screen settle recap for counter-bet or game challenge. */
+  onPeerSettleOpen?: (payload: { kind: 'h2h' | 'gc'; id: string }) => void;
 }
 
 const formatTime = (ms: number) => {
@@ -51,6 +59,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   onDeleteMessage,
   onOpenProfile,
   onClose,
+  onPeerSettleOpen,
 }) => {
   const listRef = useRef<HTMLDivElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
@@ -140,11 +149,14 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
             {messages.map((m) => {
               const isSelf = m.fromUserId === currentUserId;
               const gcId = isGameChallengeMessageText(m.text) ? parseGameChallengeIdFromMessage(m.text) : null;
+              const settleGcId = isGcSettleMessageText(m.text) ? parseGcSettleChallengeIdFromMessage(m.text) : null;
               const settleH2hId = isCounterBetSettlementMessageText(m.text)
                 ? parseCounterBetSettlementH2hIdFromMessage(m.text)
                 : null;
               const counterH2hId =
-                !settleH2hId && isCounterBetInviteMessageText(m.text)
+                !settleH2hId &&
+                !settleGcId &&
+                isCounterBetInviteMessageText(m.text)
                   ? parseCounterBetInviteIdFromMessage(m.text)
                   : null;
               return (
@@ -175,14 +187,24 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                         <div className="flex items-start justify-between gap-2">
                           {gcId ? (
                             <GameChallengeDmCard challengeId={gcId} currentUserId={currentUserId} />
+                          ) : settleGcId ? (
+                            <GameChallengeSettlementDmCard
+                              challengeId={settleGcId}
+                              currentUserId={currentUserId}
+                              onOpenFull={() => onPeerSettleOpen?.({ kind: 'gc', id: settleGcId })}
+                            />
                           ) : settleH2hId ? (
-                            <CounterBetSettlementDmCard h2hId={settleH2hId} currentUserId={currentUserId} />
+                            <CounterBetSettlementDmCard
+                              h2hId={settleH2hId}
+                              currentUserId={currentUserId}
+                              onOpenFull={() => onPeerSettleOpen?.({ kind: 'h2h', id: settleH2hId })}
+                            />
                           ) : counterH2hId ? (
                             <CounterBetDmCard h2hId={counterH2hId} currentUserId={currentUserId} />
                           ) : (
                             <p className="text-sm chat-bubble-text whitespace-pre-wrap text-slate-100">{m.text}</p>
                           )}
-                          {isSelf && onDeleteMessage && !gcId && !counterH2hId && !settleH2hId ? (
+                          {isSelf && onDeleteMessage && !gcId && !counterH2hId && !settleH2hId && !settleGcId ? (
                             <button
                               type="button"
                               onClick={() => onDeleteMessage(m.id)}

--- a/components/chat/ChatPane.tsx
+++ b/components/chat/ChatPane.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import type { Friend } from '../../models';
 import { Send, Trash2, X } from 'lucide-react';
 import { UserAvatar } from '../UserAvatar';
+import { GameChallengeDmCard } from '../GameChallengeDmCard';
+import { isGameChallengeMessageText, parseGameChallengeIdFromMessage } from '@/services/gameChallenges';
 
 export type ChatMessage = {
   id: string;
@@ -129,13 +131,14 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
           <div className="space-y-3">
             {messages.map((m) => {
               const isSelf = m.fromUserId === currentUserId;
+              const gcId = isGameChallengeMessageText(m.text) ? parseGameChallengeIdFromMessage(m.text) : null;
               return (
                 <div
                   key={m.id}
                   className={`group flex ${isSelf ? 'justify-end' : 'justify-start'}`}
                 >
                   <div
-                    className={`chat-bubble max-w-[80%] rounded-2xl border px-3 py-2.5 ${
+                    className={`chat-bubble max-w-[min(92%,420px)] rounded-2xl border px-3 py-2.5 ${
                       isSelf
                         ? 'chat-bubble-self bg-blue-600/15 border-blue-400/30'
                         : 'chat-bubble-other bg-slate-950/20 border-slate-700/60'
@@ -153,10 +156,14 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                           />
                         </div>
                       )}
-                      <div>
+                      <div className="min-w-0 flex-1">
                         <div className="flex items-start justify-between gap-2">
-                          <p className="text-sm chat-bubble-text whitespace-pre-wrap text-slate-100">{m.text}</p>
-                          {isSelf && onDeleteMessage ? (
+                          {gcId ? (
+                            <GameChallengeDmCard challengeId={gcId} currentUserId={currentUserId} />
+                          ) : (
+                            <p className="text-sm chat-bubble-text whitespace-pre-wrap text-slate-100">{m.text}</p>
+                          )}
+                          {isSelf && onDeleteMessage && !gcId ? (
                             <button
                               type="button"
                               onClick={() => onDeleteMessage(m.id)}

--- a/components/chat/ChatPane.tsx
+++ b/components/chat/ChatPane.tsx
@@ -7,8 +7,11 @@ import { CounterBetDmCard } from '../CounterBetDmCard';
 import { isGameChallengeMessageText, parseGameChallengeIdFromMessage } from '@/services/gameChallenges';
 import {
   isCounterBetInviteMessageText,
+  isCounterBetSettlementMessageText,
   parseCounterBetInviteIdFromMessage,
+  parseCounterBetSettlementH2hIdFromMessage,
 } from '@/services/dbOps';
+import { CounterBetSettlementDmCard } from '../CounterBetSettlementDmCard';
 
 export type ChatMessage = {
   id: string;
@@ -137,9 +140,13 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
             {messages.map((m) => {
               const isSelf = m.fromUserId === currentUserId;
               const gcId = isGameChallengeMessageText(m.text) ? parseGameChallengeIdFromMessage(m.text) : null;
-              const counterH2hId = isCounterBetInviteMessageText(m.text)
-                ? parseCounterBetInviteIdFromMessage(m.text)
+              const settleH2hId = isCounterBetSettlementMessageText(m.text)
+                ? parseCounterBetSettlementH2hIdFromMessage(m.text)
                 : null;
+              const counterH2hId =
+                !settleH2hId && isCounterBetInviteMessageText(m.text)
+                  ? parseCounterBetInviteIdFromMessage(m.text)
+                  : null;
               return (
                 <div
                   key={m.id}
@@ -168,12 +175,14 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                         <div className="flex items-start justify-between gap-2">
                           {gcId ? (
                             <GameChallengeDmCard challengeId={gcId} currentUserId={currentUserId} />
+                          ) : settleH2hId ? (
+                            <CounterBetSettlementDmCard h2hId={settleH2hId} currentUserId={currentUserId} />
                           ) : counterH2hId ? (
                             <CounterBetDmCard h2hId={counterH2hId} currentUserId={currentUserId} />
                           ) : (
                             <p className="text-sm chat-bubble-text whitespace-pre-wrap text-slate-100">{m.text}</p>
                           )}
-                          {isSelf && onDeleteMessage && !gcId && !counterH2hId ? (
+                          {isSelf && onDeleteMessage && !gcId && !counterH2hId && !settleH2hId ? (
                             <button
                               type="button"
                               onClick={() => onDeleteMessage(m.id)}

--- a/components/chat/ChatPane.tsx
+++ b/components/chat/ChatPane.tsx
@@ -3,7 +3,12 @@ import type { Friend } from '../../models';
 import { Send, Trash2, X } from 'lucide-react';
 import { UserAvatar } from '../UserAvatar';
 import { GameChallengeDmCard } from '../GameChallengeDmCard';
+import { CounterBetDmCard } from '../CounterBetDmCard';
 import { isGameChallengeMessageText, parseGameChallengeIdFromMessage } from '@/services/gameChallenges';
+import {
+  isCounterBetInviteMessageText,
+  parseCounterBetInviteIdFromMessage,
+} from '@/services/dbOps';
 
 export type ChatMessage = {
   id: string;
@@ -132,6 +137,9 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
             {messages.map((m) => {
               const isSelf = m.fromUserId === currentUserId;
               const gcId = isGameChallengeMessageText(m.text) ? parseGameChallengeIdFromMessage(m.text) : null;
+              const counterH2hId = isCounterBetInviteMessageText(m.text)
+                ? parseCounterBetInviteIdFromMessage(m.text)
+                : null;
               return (
                 <div
                   key={m.id}
@@ -160,10 +168,12 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                         <div className="flex items-start justify-between gap-2">
                           {gcId ? (
                             <GameChallengeDmCard challengeId={gcId} currentUserId={currentUserId} />
+                          ) : counterH2hId ? (
+                            <CounterBetDmCard h2hId={counterH2hId} currentUserId={currentUserId} />
                           ) : (
                             <p className="text-sm chat-bubble-text whitespace-pre-wrap text-slate-100">{m.text}</p>
                           )}
-                          {isSelf && onDeleteMessage && !gcId ? (
+                          {isSelf && onDeleteMessage && !gcId && !counterH2hId ? (
                             <button
                               type="button"
                               onClick={() => onDeleteMessage(m.id)}

--- a/devGlobals.ts
+++ b/devGlobals.ts
@@ -1,0 +1,19 @@
+import { cancelPendingMockNflBetsForUser } from '@/services/dbOps';
+
+declare global {
+  interface Window {
+    /**
+     * Dev only: cancels all pending mock-NFL-only slips for `localStorage.uid`
+     * (refunds stakes). Run in the console while signed in.
+     */
+    bethubCancelMockPending?: () => Promise<{ cancelledIds: string[] }>;
+  }
+}
+
+if (import.meta.env.DEV) {
+  window.bethubCancelMockPending = async () => {
+    const uid = localStorage.getItem('uid');
+    if (!uid) throw new Error('Not signed in — localStorage.uid is missing.');
+    return cancelPendingMockNflBetsForUser(uid);
+  };
+}

--- a/index.css
+++ b/index.css
@@ -5,6 +5,17 @@
   box-sizing: border-box;
 }
 
+/* Hide scrollbars while keeping overflow scroll (e.g. bet slip lists) */
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 #root {
   min-height: 100vh;
 }

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
+if (import.meta.env.DEV) {
+  void import('./devGlobals');
+}
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error("Could not find root element to mount to");

--- a/lib/challengeBetEligibility.ts
+++ b/lib/challengeBetEligibility.ts
@@ -1,0 +1,26 @@
+import type { Bet, BetStatus } from '@/models';
+
+export type ChallengeBetEligibility =
+  | { kind: 'enabled' }
+  | { kind: 'disabled'; reason: string };
+
+/** Whether another user can propose a head-to-head fade on this bet. */
+export function challengeBetEligibility(bet: Bet): ChallengeBetEligibility {
+  const status = (bet.status ?? 'PENDING') as BetStatus;
+  if (status !== 'PENDING') {
+    return { kind: 'disabled', reason: `This bet is already ${status.toLowerCase()}.` };
+  }
+  if (bet.betType === 'parlay') {
+    return { kind: 'disabled', reason: "Parlays can't be faded yet." };
+  }
+  if (!bet.eventId || !bet.sportKey) {
+    return { kind: 'disabled', reason: 'This bet is missing event info — too old to auto-settle a fade.' };
+  }
+  if (bet.odds <= 1) {
+    return { kind: 'disabled', reason: "Invalid odds — can't compute a fair fade." };
+  }
+  if (bet.eventStartsAt && bet.eventStartsAt.getTime() <= Date.now()) {
+    return { kind: 'disabled', reason: 'Game has already started — too late to fade.' };
+  }
+  return { kind: 'enabled' };
+}

--- a/lib/challengeBetEligibility.ts
+++ b/lib/challengeBetEligibility.ts
@@ -4,6 +4,10 @@ export type ChallengeBetEligibility =
   | { kind: 'enabled' }
   | { kind: 'disabled'; reason: string };
 
+export function isMockBetSlip(bet: Bet): boolean {
+  return (bet.marketId ?? '').startsWith('mock-');
+}
+
 /** Whether another user can propose a head-to-head fade on this bet. */
 export function challengeBetEligibility(bet: Bet): ChallengeBetEligibility {
   const status = (bet.status ?? 'PENDING') as BetStatus;
@@ -19,7 +23,8 @@ export function challengeBetEligibility(bet: Bet): ChallengeBetEligibility {
   if (bet.odds <= 1) {
     return { kind: 'disabled', reason: "Invalid odds — can't compute a fair fade." };
   }
-  if (bet.eventStartsAt && bet.eventStartsAt.getTime() <= Date.now()) {
+  // Simulated mock NFL uses synthetic kickoff times; don't block on Odds-API-style eventStartsAt.
+  if (!isMockBetSlip(bet) && bet.eventStartsAt && bet.eventStartsAt.getTime() <= Date.now()) {
     return { kind: 'disabled', reason: 'Game has already started — too late to fade.' };
   }
   return { kind: 'enabled' };

--- a/lib/globalMockNflBoard.ts
+++ b/lib/globalMockNflBoard.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared random NFL sim game rows (same schedule for every account).
+ */
+
+import { MOCK_NFL_TEAM_POOL } from '@/models/constants';
+import type { MockNflGameState } from '@/models';
+import {
+  mlDecimalsForFavorite,
+  randomSpreadMagnitudeHalf,
+  randomTotalLineHalf,
+  spreadSideDecimals,
+  totalSideDecimals,
+} from '@/lib/mockNflGameGenerator';
+
+const pickRandom = <T,>(items: readonly T[]) => items[Math.floor(Math.random() * items.length)];
+const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+const randomWeek = () => Math.floor(randomBetween(1, 19));
+
+export const MOCK_NFL_BOARD_TARGET_COUNT = 5;
+
+export function createRandomMockNflGameState(idPrefix: string, previous?: MockNflGameState): MockNflGameState {
+  const teamPool = MOCK_NFL_TEAM_POOL;
+  const shouldFlip = Boolean(previous) && Math.random() < 0.5;
+  const awayTeam = shouldFlip && previous ? previous.homeTeam : pickRandom(teamPool);
+  let homeTeam = shouldFlip && previous ? previous.awayTeam : pickRandom(teamPool);
+  let guard = 0;
+  while (homeTeam === awayTeam && guard < 10) {
+    homeTeam = pickRandom(teamPool);
+    guard += 1;
+  }
+
+  const spreadMag = randomSpreadMagnitudeHalf();
+  const awayFavored = Math.random() < 0.5;
+  const spreadLine = awayFavored ? -spreadMag : spreadMag;
+  const ml = mlDecimalsForFavorite(awayFavored);
+  const sp = spreadSideDecimals();
+  const tot = totalSideDecimals();
+  return {
+    id: `${idPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    week: randomWeek(),
+    awayTeam,
+    homeTeam,
+    awayOdds: ml.away,
+    homeOdds: ml.home,
+    spreadAwayOdds: sp.away,
+    spreadHomeOdds: sp.home,
+    totalOverOdds: tot.over,
+    totalUnderOdds: tot.under,
+    spreadLine,
+    totalLine: randomTotalLineHalf(),
+    status: 'UPCOMING',
+    awayScore: null,
+    homeScore: null,
+    winner: null,
+    updatedAtMs: Date.now(),
+  };
+}
+
+/** Keeps FINAL rows, pads with new UPCOMING games until `count` total rows. */
+export function ensureMockBoardUpToCount(existing: MockNflGameState[], count: number): MockNflGameState[] {
+  const upcoming = existing.filter((g) => g.status !== 'FINAL');
+  const seeded = [...upcoming];
+  while (seeded.length < count) {
+    seeded.push(createRandomMockNflGameState('mock-nfl', seeded[seeded.length - 1]));
+  }
+  return seeded.slice(0, count);
+}

--- a/lib/historyBetPeerMap.ts
+++ b/lib/historyBetPeerMap.ts
@@ -1,0 +1,105 @@
+import type { Bet } from '@/models';
+
+export type HistoryBetPeerKind = 'counter' | 'challenge';
+
+/** Links a settled/open ticket to the other participant (counter-bet or game challenge). */
+export interface HistoryBetPeerInfo {
+  kind: HistoryBetPeerKind;
+  opponentUid: string;
+  sourceId: string;
+}
+
+export type HeadToHeadDocRow = { id: string; data: Record<string, unknown> };
+export type GameChallengeDocRow = { id: string; data: Record<string, unknown> };
+
+const H2H_EXCLUDED = new Set(['DECLINED', 'CANCELLED']);
+const GC_EXCLUDED = new Set(['DECLINED', 'CANCELLED', 'EXPIRED']);
+
+/** Prefer explicit event id; fall back to mock NFL market id (`mock-*`). */
+export function eventKeyForBet(bet: Bet): string | null {
+  if (bet.eventId && String(bet.eventId).trim()) return String(bet.eventId).trim();
+  if (bet.marketId?.startsWith('mock-')) return bet.marketId;
+  return null;
+}
+
+function pickMatchesChallenge(
+  uid: string,
+  d: Record<string, unknown>,
+  optionLabel: string,
+): boolean {
+  const ch = String(d.challengerUid ?? '');
+  const op = String(d.opponentUid ?? '');
+  const label = optionLabel.trim();
+  if (uid === ch && label === String(d.challengerPickLabel ?? '').trim()) return true;
+  if (uid === op && label === String(d.opponentPickLabel ?? '').trim()) return true;
+  return false;
+}
+
+function betTouchesChallenge(bet: Bet, uid: string, d: Record<string, unknown>): boolean {
+  const eventId = String(d.eventId ?? '');
+  const ek = eventKeyForBet(bet);
+  if (!ek || ek !== eventId) return false;
+  const ch = String(d.challengerUid ?? '');
+  const op = String(d.opponentUid ?? '');
+  if (uid !== ch && uid !== op) return false;
+
+  if (bet.betType === 'parlay' && bet.parlayLegs?.length) {
+    return bet.parlayLegs.some(
+      (leg) => leg.marketId === eventId && pickMatchesChallenge(uid, d, leg.optionLabel),
+    );
+  }
+  return pickMatchesChallenge(uid, d, bet.optionLabel);
+}
+
+function gcCreatedMs(d: Record<string, unknown>): number {
+  const c = d.createdAt as { toMillis?: () => number } | undefined;
+  return typeof c?.toMillis === 'function' ? c.toMillis() : 0;
+}
+
+/**
+ * Build betId → peer info. Counter-bet (same ticket) wins over a game-challenge match
+ * when both could apply.
+ */
+export function compileHistoryBetPeers(
+  uid: string,
+  h2hRows: HeadToHeadDocRow[],
+  gcRows: GameChallengeDocRow[],
+  bets: Bet[],
+): Record<string, HistoryBetPeerInfo> {
+  const out: Record<string, HistoryBetPeerInfo> = {};
+
+  for (const row of h2hRows) {
+    const d = row.data;
+    const status = String(d.status ?? '');
+    if (H2H_EXCLUDED.has(status)) continue;
+    const bid = String(d.originalBetId ?? '');
+    if (!bid) continue;
+    const orig = String(d.originalUserId ?? '');
+    const chall = String(d.challengerUserId ?? '');
+    const opponent = uid === orig ? chall : orig;
+    if (!opponent) continue;
+    out[bid] = { kind: 'counter', opponentUid: opponent, sourceId: row.id };
+  }
+
+  const sortedGc = [...gcRows].sort((a, b) => gcCreatedMs(b.data) - gcCreatedMs(a.data));
+
+  for (const bet of bets) {
+    if (out[bet.id]?.kind === 'counter') continue;
+    const betUid = String(bet.userID ?? uid);
+    if (betUid !== uid) continue;
+
+    for (const row of sortedGc) {
+      const d = row.data;
+      const st = String(d.status ?? '');
+      if (GC_EXCLUDED.has(st)) continue;
+      if (!betTouchesChallenge(bet, uid, d)) continue;
+      const ch = String(d.challengerUid ?? '');
+      const op = String(d.opponentUid ?? '');
+      const opponent = uid === ch ? op : ch;
+      out[bet.id] = { kind: 'challenge', opponentUid: opponent, sourceId: row.id };
+      break;
+    }
+  }
+
+  return out;
+}

--- a/lib/marketSearch.ts
+++ b/lib/marketSearch.ts
@@ -1,0 +1,26 @@
+import type { Market } from '@/models';
+
+/** Text used for substring search (teams often appear only on spread/h2h option labels). */
+export function marketSearchHaystack(m: Market): string {
+  const parts = [
+    m.title,
+    m.subtitle,
+    m.category,
+    m.sport_key ?? '',
+    ...m.options.map((o) => o.label),
+  ];
+  return parts.join(' ').toLowerCase().replace(/@/g, ' ');
+}
+
+export function queryMatchesHaystack(haystack: string, rawQuery: string): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+  const tokens = q.split(/\s+/).filter(Boolean);
+  return tokens.every((t) => haystack.includes(t));
+}
+
+export function filterMarketsBySearchQuery(markets: readonly Market[], rawQuery: string): Market[] {
+  const q = rawQuery.trim();
+  if (!q) return [...markets];
+  return markets.filter((m) => queryMatchesHaystack(marketSearchHaystack(m), rawQuery));
+}

--- a/lib/mergeActivityFeeds.ts
+++ b/lib/mergeActivityFeeds.ts
@@ -1,0 +1,12 @@
+import type { SocialActivity } from '@/models';
+
+/** Merge bet-based community rows with peer competition rows, newest first. */
+export function mergeActivityFeeds(
+  betRows: SocialActivity[],
+  peerRows: SocialActivity[],
+  cap = 60,
+): SocialActivity[] {
+  const merged = [...betRows, ...peerRows];
+  merged.sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0));
+  return merged.slice(0, cap);
+}

--- a/lib/mockNflChallengeGrade.ts
+++ b/lib/mockNflChallengeGrade.ts
@@ -1,0 +1,52 @@
+import type { MockNflGameState } from '@/services/dbOps';
+
+function normalizeSpreadLine(line: number) {
+  return line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1);
+}
+
+/** Grades a pick label after the mock game is FINAL (same rules as bet settlement). */
+export function gradeMockNflPickAfterFinal(
+  game: MockNflGameState,
+  optionLabel: string,
+): 'WON' | 'LOST' | 'PUSH' | 'VOID' | null {
+  if (game.status !== 'FINAL' || game.awayScore == null || game.homeScore == null) return null;
+
+  const awayTeam = game.awayTeam;
+  const homeTeam = game.homeTeam;
+  const awaySpreadLabel = `${awayTeam} ${normalizeSpreadLine(game.spreadLine)}`;
+  const homeSpread = -game.spreadLine;
+  const homeSpreadLabel = `${homeTeam} ${normalizeSpreadLine(homeSpread)}`;
+  const overLabel = `Over ${game.totalLine.toFixed(1)}`;
+  const underLabel = `Under ${game.totalLine.toFixed(1)}`;
+  const margin = game.awayScore - game.homeScore;
+  const totalScore = game.awayScore + game.homeScore;
+  const selected = optionLabel.trim();
+
+  if (selected === awayTeam) {
+    if (game.awayScore === game.homeScore) return 'PUSH';
+    return game.awayScore > game.homeScore ? 'WON' : 'LOST';
+  }
+  if (selected === homeTeam) {
+    if (game.awayScore === game.homeScore) return 'PUSH';
+    return game.homeScore > game.awayScore ? 'WON' : 'LOST';
+  }
+  if (selected === awaySpreadLabel) {
+    const spreadResult = margin + game.spreadLine;
+    if (spreadResult === 0) return 'PUSH';
+    return spreadResult > 0 ? 'WON' : 'LOST';
+  }
+  if (selected === homeSpreadLabel) {
+    const spreadResult = -margin - game.spreadLine;
+    if (spreadResult === 0) return 'PUSH';
+    return spreadResult > 0 ? 'WON' : 'LOST';
+  }
+  if (selected === overLabel) {
+    if (totalScore === game.totalLine) return 'PUSH';
+    return totalScore > game.totalLine ? 'WON' : 'LOST';
+  }
+  if (selected === underLabel) {
+    if (totalScore === game.totalLine) return 'PUSH';
+    return totalScore < game.totalLine ? 'WON' : 'LOST';
+  }
+  return 'VOID';
+}

--- a/lib/mockNflChallengeGrade.ts
+++ b/lib/mockNflChallengeGrade.ts
@@ -1,4 +1,4 @@
-import type { MockNflGameState } from '@/services/dbOps';
+import type { MockNflGameState } from '@/models';
 
 function normalizeSpreadLine(line: number) {
   return line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1);

--- a/lib/mockNflGameGenerator.ts
+++ b/lib/mockNflGameGenerator.ts
@@ -1,0 +1,56 @@
+/**
+ * Realistic mock NFL lines: half-point spreads, standard negative juice on
+ * spread/total sides (no duplicate +108 / +108 mirrors), ML correlated with favorite.
+ */
+
+import { americanToDecimal } from './oddsAmericanFormat';
+
+/** Typical main-market juice (both sides usually negative near -110). */
+const SPREAD_OR_TOTAL_JUICE = [-125, -122, -120, -118, -115, -112, -110, -108, -105] as const;
+
+function pickDistinctSpreadTotalJuices(): [number, number] {
+  const pick = () =>
+    SPREAD_OR_TOTAL_JUICE[Math.floor(Math.random() * SPREAD_OR_TOTAL_JUICE.length)];
+  let a = pick();
+  let b = pick();
+  for (let i = 0; i < 24 && a === b; i++) b = pick();
+  return [americanToDecimal(a), americanToDecimal(b)];
+}
+
+function shufflePair(pair: [number, number]): [number, number] {
+  return Math.random() < 0.5 ? pair : [pair[1], pair[0]];
+}
+
+/** 0.5 through 15.5 in 0.5 steps (e.g. -7.5 favorite). */
+export function randomSpreadMagnitudeHalf(): number {
+  const k = Math.floor(Math.random() * 31) + 1;
+  return k * 0.5;
+}
+
+/** Total line 39.5–53.5 in half-point steps. */
+export function randomTotalLineHalf(): number {
+  const low = 79;
+  const high = 107;
+  const idx = Math.floor(Math.random() * (high - low + 1)) + low;
+  return idx * 0.5;
+}
+
+/** Favorite = shorter ML; underdog = plus-money. */
+export function mlDecimalsForFavorite(favoriteIsAway: boolean): { away: number; home: number } {
+  const favAm = -Math.round(135 + Math.random() * 105);
+  const dogAm = Math.round(125 + Math.random() * 105);
+  const fav = americanToDecimal(favAm);
+  const dog = americanToDecimal(dogAm);
+  if (favoriteIsAway) return { away: fav, home: dog };
+  return { away: dog, home: fav };
+}
+
+export function spreadSideDecimals(): { away: number; home: number } {
+  const [d1, d2] = shufflePair(pickDistinctSpreadTotalJuices());
+  return { away: d1, home: d2 };
+}
+
+export function totalSideDecimals(): { over: number; under: number } {
+  const [d1, d2] = shufflePair(pickDistinctSpreadTotalJuices());
+  return { over: d1, under: d2 };
+}

--- a/lib/mockNflMarketFromState.ts
+++ b/lib/mockNflMarketFromState.ts
@@ -1,0 +1,48 @@
+import { MarketType, type Market } from '@/models';
+import type { MockNflGameState } from '@/services/dbOps';
+
+export function normalizeMockSpreadLine(line: number) {
+  return line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1);
+}
+
+/** Builds the same synthetic market object the Markets NFL mock board uses. */
+export function buildMockNflMarketFromGameState(game: MockNflGameState): Market {
+  return {
+    id: `mock-${game.id}`,
+    sport_key: 'football_nfl_mock',
+    title: `${game.awayTeam} @ ${game.homeTeam}`,
+    subtitle: 'NFL (sim)',
+    category: 'Football',
+    type: MarketType.SPORTS,
+    startTime: new Date(game.updatedAtMs).toISOString(),
+    status: game.status === 'FINAL' ? 'CLOSED' : 'UPCOMING',
+    options: [
+      {
+        id: `${game.id}-spread-away`,
+        label: `${game.awayTeam} ${normalizeMockSpreadLine(game.spreadLine)}`,
+        odds: game.spreadAwayOdds ?? game.awayOdds,
+        marketKey: 'spreads',
+      },
+      {
+        id: `${game.id}-spread-home`,
+        label: `${game.homeTeam} ${normalizeMockSpreadLine(-game.spreadLine)}`,
+        odds: game.spreadHomeOdds ?? game.homeOdds,
+        marketKey: 'spreads',
+      },
+      {
+        id: `${game.id}-total-over`,
+        label: `Over ${game.totalLine.toFixed(1)}`,
+        odds: game.totalOverOdds,
+        marketKey: 'totals',
+      },
+      {
+        id: `${game.id}-total-under`,
+        label: `Under ${game.totalLine.toFixed(1)}`,
+        odds: game.totalUnderOdds,
+        marketKey: 'totals',
+      },
+      { id: `${game.id}-ml-away`, label: game.awayTeam, odds: game.awayOdds, marketKey: 'h2h' },
+      { id: `${game.id}-ml-home`, label: game.homeTeam, odds: game.homeOdds, marketKey: 'h2h' },
+    ],
+  };
+}

--- a/lib/mockNflMarketFromState.ts
+++ b/lib/mockNflMarketFromState.ts
@@ -1,5 +1,5 @@
 import { MarketType, type Market } from '@/models';
-import type { MockNflGameState } from '@/services/dbOps';
+import type { MockNflGameState } from '@/models';
 
 export function normalizeMockSpreadLine(line: number) {
   return line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1);

--- a/lib/oddsAmericanFormat.ts
+++ b/lib/oddsAmericanFormat.ts
@@ -1,0 +1,25 @@
+/**
+ * Display helpers: the app stores and computes payouts using decimal odds
+ * (e.g. 1.91). US-style boards show American / moneyline (+120, -110).
+ */
+
+export function decimalOddsToAmerican(decimalOdds: number): number {
+  if (!Number.isFinite(decimalOdds) || decimalOdds <= 1) return 0;
+  if (decimalOdds >= 2) return Math.round((decimalOdds - 1) * 100);
+  return Math.round(-100 / (decimalOdds - 1));
+}
+
+/** e.g. 1.91 → "-110", 2.5 → "+150" */
+export function formatAmericanOddsLine(decimalOdds: number): string {
+  const american = decimalOddsToAmerican(decimalOdds);
+  if (american === 0) return '—';
+  return american > 0 ? `+${american}` : `${american}`;
+}
+
+/** American moneyline (e.g. -110, +150) → decimal for stake math. */
+export function americanToDecimal(american: number): number {
+  if (!Number.isFinite(american)) return 1.91;
+  if (american >= 100) return Number((1 + american / 100).toFixed(2));
+  if (american <= -100) return Number((1 + 100 / Math.abs(american)).toFixed(2));
+  return 1.91;
+}

--- a/models/index.ts
+++ b/models/index.ts
@@ -55,6 +55,8 @@ export interface Bet {
   status?: BetStatus;           // ← ADDED: undefined on old bets = treat as PENDING
   eventId?: string;             // ← ADDED: Odds API event ID (singles only)
   sportKey?: string;            // ← ADDED: e.g. "basketball_nba" (singles only)
+  /** Singles: line type at placement (h2h / spreads / totals). Used for API score settlement. */
+  pickedMarketKey?: MarketOption['marketKey'];
   eventStartsAt?: Date;         // ← ADDED: kickoff time (singles only) — used by H2H lock
   settledAt?: Date;             // ← ADDED
   // Optional metadata persisted alongside bets in Firestore. Declared here so

--- a/models/index.ts
+++ b/models/index.ts
@@ -113,6 +113,29 @@ export interface Challenge {
   status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'COMPLETED';
 }
 
+// ── Global NFL sim board (shared mock games) ─────────────────────
+export type MockNflWinner = 'HOME' | 'AWAY' | null;
+
+export interface MockNflGameState {
+  id: string;
+  week: number;
+  awayTeam: string;
+  homeTeam: string;
+  awayOdds: number;
+  homeOdds: number;
+  spreadAwayOdds: number;
+  spreadHomeOdds: number;
+  totalOverOdds: number;
+  totalUnderOdds: number;
+  spreadLine: number;
+  totalLine: number;
+  status: 'UPCOMING' | 'FINAL';
+  awayScore: number | null;
+  homeScore: number | null;
+  winner: MockNflWinner;
+  updatedAtMs: number;
+}
+
 // ── Head-to-Head (peer-to-peer side wager) ───────────────────────
 //
 // A challenger picks a pending bet placed by another user and proposes to

--- a/models/index.ts
+++ b/models/index.ts
@@ -74,6 +74,8 @@ export interface LeaderboardEntry {
   profileBackgroundUrl?: string;
   netWorth: number;
   winRate: number;
+  /** Accepted peer game challenges won (settled). */
+  challengeWins: number;
   rank: number;
   isCurrentUser?: boolean;
 }

--- a/models/index.ts
+++ b/models/index.ts
@@ -80,6 +80,9 @@ export interface LeaderboardEntry {
   isCurrentUser?: boolean;
 }
 
+/** `bet` = legacy slip row; peer rows come from head-to-head or game-challenge feeds. */
+export type SocialActivityKind = 'bet' | 'peer_counter' | 'peer_challenge';
+
 export interface SocialActivity {
   id: string;
   userId: string;
@@ -90,6 +93,16 @@ export interface SocialActivity {
   action: string;
   target: string;
   timestamp: string;
+  /** Merge sort with peer feed (epoch ms). Bet rows set from placedAt. */
+  sortKey?: number;
+  activityKind?: SocialActivityKind;
+  /** Other participant in a counter or challenge row. */
+  peerUserId?: string;
+  peerUserName?: string;
+  peerUserAvatar?: string;
+  peerUserAvatarUrl?: string;
+  peerH2hId?: string;
+  peerChallengeId?: string;
 }
 
 export interface Friend {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "dotenv": "^17.3.1",
         "express": "^4.21.0",
-        "firebase": "^12.9.0",
+        "firebase": "^12.11.0",
         "firebase-admin": "^13.8.0",
         "lucide-react": "^0.563.0",
         "react": "^19.2.4",
@@ -757,15 +757,15 @@
       "license": "MIT"
     },
     "node_modules/@firebase/ai": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.8.0.tgz",
-      "integrity": "sha512-grWYGFPsSo+pt+6CYeKR0kWnUfoLLS3xgWPvNrhAS5EPxl6xWq7+HjDZqX24yLneETyl45AVgDsTbVgxeWeRfg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+      "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -777,15 +777,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.19",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.19.tgz",
-      "integrity": "sha512-3wU676fh60gaiVYQEEXsbGS4HbF2XsiBphyvvqDbtC1U4/dO4coshbYktcCHq+HFaGIK07iHOh4pME0hEq1fcg==",
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -793,15 +793,15 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.25.tgz",
-      "integrity": "sha512-fdzoaG0BEKbqksRDhmf4JoyZf16Wosrl0Y7tbZtJyVDOOwziE0vrFjmZuTdviL0yhak+Nco6rMsUUbkbD+qb6Q==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.19",
-        "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -809,20 +809,20 @@
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
-      "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+      "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -831,14 +831,14 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
-      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+      "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -849,16 +849,16 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
-      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+      "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.11.0",
-        "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -869,27 +869,27 @@
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
-      "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+      "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.14.8",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app": "0.14.12",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -897,20 +897,23 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.0.tgz",
-      "integrity": "sha512-zkvLpsrxynWHk07qGrUDfCSqKf4AvfZGEqJ7mVCtYGjNNDbGE71k0Yn84rg8QEZu4hQw1BC0qDEHzpNVBcSVmA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+      "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -918,7 +921,7 @@
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^2.2.0"
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -927,15 +930,15 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.2.tgz",
-      "integrity": "sha512-8UhCzF6pav9bw/eXA8Zy1QAKssPRYEYXaWagie1ewLTwHkXv6bKp/j6/IwzSYQP67sy/BMFXIFaCCsoXzFLr7A==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+      "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.12.0",
-        "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -946,15 +949,15 @@
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
-      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -962,12 +965,12 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
-      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -975,15 +978,15 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.12.tgz",
-      "integrity": "sha512-baPddcoNLj/+vYo+HSJidJUdr5W4OkhT109c5qhR8T1dJoZcyJpkv/dFpYlw/VJ3dV66vI8GHQFrmAZw/xUS4g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+      "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -991,16 +994,16 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
-      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -1009,16 +1012,16 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
-      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-types": "1.0.16",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1026,25 +1029,25 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
-      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.13.0"
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.11.0.tgz",
-      "integrity": "sha512-Zb88s8rssBd0J2Tt+NUXMPt2sf+Dq7meatKiJf5t9oto1kZ8w9gK59Koe1uPVbaKfdgBp++N/z0I4G/HamyEhg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
-        "@firebase/webchannel-wrapper": "1.0.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
         "tslib": "^2.1.0"
@@ -1057,15 +1060,15 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.5.tgz",
-      "integrity": "sha512-yVX1CkVvqBI4qbA56uZo42xFA4TNU0ICQ+9AFDvYq9U9Xu6iAx9lFDAk/tN+NGereQQXXCSnpISwc/oxsQqPLA==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+      "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/firestore": "4.11.0",
-        "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1076,9 +1079,9 @@
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
-      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -1086,16 +1089,16 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
-      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+      "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1106,15 +1109,15 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
-      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+      "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/functions": "0.13.1",
-        "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1125,19 +1128,19 @@
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
-      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1146,15 +1149,15 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
-      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1162,18 +1165,18 @@
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
-      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
-      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1183,15 +1186,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
-      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "version": "0.12.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+      "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1200,14 +1203,14 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
-      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+      "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1215,21 +1218,21 @@
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+      "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
-      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -1238,16 +1241,16 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
-      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/performance": "0.7.9",
-        "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1255,21 +1258,21 @@
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.0.tgz",
-      "integrity": "sha512-sJz7C2VACeE257Z/3kY9Ap2WXbFsgsDLfaGfZmmToKAK39ipXxFan+vzB9CSbF6mP7bzjyzEnqPcMXhAnYE6fQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+      "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1277,16 +1280,16 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.21.tgz",
-      "integrity": "sha512-9+lm0eUycxbu8GO25JfJe4s6R2xlDqlVt0CR6CvN9E6B4AFArEV4qfLoDVRgIEB7nHKwvH2nYRocPWfmjRQTnw==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+      "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/remote-config": "0.8.0",
-        "@firebase/remote-config-types": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1294,19 +1297,19 @@
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
-      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
-      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1317,15 +1320,15 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
-      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/storage": "0.14.0",
-        "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1336,9 +1339,9 @@
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
-      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -1346,9 +1349,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
-      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1359,9 +1362,9 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
-      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@google-cloud/firestore": {
@@ -3147,39 +3150,39 @@
       "license": "MIT"
     },
     "node_modules/firebase": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.9.0.tgz",
-      "integrity": "sha512-CwwTYoqZg6KxygPOaaJqIc4aoLvo0RCRrXoln9GoxLE8QyAwTydBaSLGVlR4WPcuOgN3OEL0tJLT1H4IU/dv7w==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+      "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.8.0",
-        "@firebase/analytics": "0.10.19",
-        "@firebase/analytics-compat": "0.2.25",
-        "@firebase/app": "0.14.8",
-        "@firebase/app-check": "0.11.0",
-        "@firebase/app-check-compat": "0.4.0",
-        "@firebase/app-compat": "0.5.8",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.12.0",
-        "@firebase/auth-compat": "0.6.2",
-        "@firebase/data-connect": "0.3.12",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-compat": "2.1.0",
-        "@firebase/firestore": "4.11.0",
-        "@firebase/firestore-compat": "0.4.5",
-        "@firebase/functions": "0.13.1",
-        "@firebase/functions-compat": "0.4.1",
-        "@firebase/installations": "0.6.19",
-        "@firebase/installations-compat": "0.2.19",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/messaging-compat": "0.2.23",
-        "@firebase/performance": "0.7.9",
-        "@firebase/performance-compat": "0.2.22",
-        "@firebase/remote-config": "0.8.0",
-        "@firebase/remote-config-compat": "0.2.21",
-        "@firebase/storage": "0.14.0",
-        "@firebase/storage-compat": "0.4.0",
-        "@firebase/util": "1.13.0"
+        "@firebase/ai": "2.12.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.12",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-compat": "0.4.3",
+        "@firebase/app-compat": "0.5.12",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-compat": "0.6.6",
+        "@firebase/data-connect": "0.7.0",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-compat": "0.4.9",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-compat": "0.4.4",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/messaging-compat": "0.2.26",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-compat": "0.2.24",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/firebase-admin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "start": "node server/index.js",
     "seed:achievements": "node scripts/seed-achievement-definitions.js",
-    "test:parlay": "node --experimental-strip-types --no-warnings --test services/__tests__/parlayRollup.test.ts services/__tests__/parlayRules.test.ts"
+    "test:parlay": "node --experimental-strip-types --no-warnings --test services/__tests__/parlayRollup.test.ts services/__tests__/parlayRules.test.ts services/__tests__/apiOddsGrading.test.ts"
   },
   "dependencies": {
     "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "start": "node server/index.js",
     "seed:achievements": "node scripts/seed-achievement-definitions.js",
+    "cancel:mock-nfl-bets": "node scripts/cancel-mock-nfl-pending-bets.mjs",
     "test:parlay": "node --experimental-strip-types --no-warnings --test services/__tests__/parlayRollup.test.ts services/__tests__/parlayRules.test.ts services/__tests__/apiOddsGrading.test.ts"
   },
   "dependencies": {

--- a/scripts/cancel-mock-nfl-pending-bets.mjs
+++ b/scripts/cancel-mock-nfl-pending-bets.mjs
@@ -1,0 +1,152 @@
+/**
+ * Cancels all PENDING bets for one user that are exclusively mock NFL markets
+ * (same rules as `cancelPendingMockNflBetsForUser` in services/dbOps.ts):
+ * singles with marketId prefix `mock-`, parlays whose every leg has mock- marketId.
+ *
+ * For each slip: status → CANCELLED, stake refunded to userInfo.money (unless isFree),
+ * then pending head-to-head proposals on that slip are declined and challenger escrow refunded.
+ *
+ * Usage:
+ *   FIREBASE_SERVICE_ACCOUNT_PATH=./path-to.json node scripts/cancel-mock-nfl-pending-bets.mjs <uid>
+ *   node scripts/cancel-mock-nfl-pending-bets.mjs <uid> --dry-run
+ *
+ * @author maintenance script
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import admin from 'firebase-admin';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const serviceAccountPath =
+  process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+
+const args = process.argv.slice(2).filter((a) => a !== '--dry-run');
+const dryRun = process.argv.includes('--dry-run');
+const uid = args[0]?.trim();
+
+if (!uid) {
+  console.error('Usage: node scripts/cancel-mock-nfl-pending-bets.mjs <firebaseAuthUid> [--dry-run]');
+  process.exit(1);
+}
+
+if (!serviceAccountPath) {
+  console.error(
+    'Set GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_PATH to your service account JSON.',
+  );
+  process.exit(1);
+}
+
+const resolvedServiceAccountPath = path.isAbsolute(serviceAccountPath)
+  ? serviceAccountPath
+  : path.resolve(repoRoot, serviceAccountPath);
+
+if (!fs.existsSync(resolvedServiceAccountPath)) {
+  console.error(`Service account file not found: ${resolvedServiceAccountPath}`);
+  process.exit(1);
+}
+
+const serviceAccount = JSON.parse(fs.readFileSync(resolvedServiceAccountPath, 'utf8'));
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  });
+}
+
+const db = admin.firestore();
+const FieldValue = admin.firestore.FieldValue;
+const H2H_COLLECTION = 'headToHead';
+
+function isMockNflOnlyBet(data) {
+  const betType = data.betType === 'parlay' ? 'parlay' : 'single';
+  if (betType === 'parlay') {
+    const legs = Array.isArray(data.parlayLegs) ? data.parlayLegs : [];
+    return legs.length > 0 && legs.every((leg) => String(leg.marketId ?? '').startsWith('mock-'));
+  }
+  return String(data.marketId ?? '').startsWith('mock-');
+}
+
+async function closePendingHeadToHeadsForOriginalBet(originalBetId) {
+  const snap = await db.collection(H2H_COLLECTION).where('originalBetId', '==', originalBetId).get();
+  for (const d of snap.docs) {
+    const row = d.data();
+    if (row.status !== 'PENDING_ACCEPT') continue;
+    if (dryRun) {
+      console.log(`  [dry-run] would decline H2H ${d.id} (refund challenger escrow)`);
+      continue;
+    }
+    await db.runTransaction(async (tx) => {
+      const ref = d.ref;
+      const s = await tx.get(ref);
+      if (!s.exists) return;
+      if (s.data().status !== 'PENDING_ACCEPT') return;
+      const challengerStake = Number(s.data().challengerStake) || 0;
+      const challengerUserId = String(s.data().challengerUserId ?? '');
+      if (challengerUserId && challengerStake > 0) {
+        tx.update(db.collection('userInfo').doc(challengerUserId), { money: FieldValue.increment(challengerStake) });
+      }
+      tx.update(ref, { status: 'DECLINED', settledAt: FieldValue.serverTimestamp() });
+    });
+  }
+}
+
+async function main() {
+  // Query by userID only (same as the app) so we do not require a composite index on (userID, status).
+  const q = await db.collection('bets').where('userID', '==', uid).get();
+
+  const targets = [];
+  q.forEach((doc) => {
+    const data = doc.data();
+    if ((data.status ?? 'PENDING') !== 'PENDING') return;
+    if (isMockNflOnlyBet(data)) targets.push({ id: doc.id, data });
+  });
+
+  if (targets.length === 0) {
+    console.log(`No pending mock-NFL-only bets for uid ${uid}.`);
+    return;
+  }
+
+  console.log(`${dryRun ? '[dry-run] ' : ''}Found ${targets.length} pending mock-NFL-only bet(s) for ${uid}:`);
+  for (const { id, data } of targets) {
+    console.log(`  - ${id}: ${data.marketTitle ?? ''} / ${data.optionLabel ?? ''} stake=${data.stake}`);
+  }
+
+  if (dryRun) {
+    for (const { id } of targets) await closePendingHeadToHeadsForOriginalBet(id);
+    return;
+  }
+
+  for (const { id, data } of targets) {
+    const stake = Number(data.stake) || 0;
+    const isFree = data.isFree === true;
+    const userId = String(data.userID ?? uid);
+
+    const batch = db.batch();
+    const betRef = db.collection('bets').doc(id);
+    batch.update(betRef, {
+      status: 'CANCELLED',
+      settledAt: FieldValue.serverTimestamp(),
+    });
+    if (!isFree && stake > 0) {
+      batch.update(db.collection('userInfo').doc(userId), { money: FieldValue.increment(stake) });
+    }
+    await batch.commit();
+
+    const marketId = String(data.marketId ?? '');
+    if (marketId.startsWith('mock-')) {
+      await closePendingHeadToHeadsForOriginalBet(id);
+    }
+    console.log(`Cancelled ${id}`);
+  }
+
+  console.log('Done.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -2,22 +2,10 @@
  * Express backend for BetHub
  * Handles auth and proxies Odds API requests (keeps API key server-side)
  *
- * TODO(settlement): The original `settleOpenBets` cron was wired up here but
- * its implementation file (`server/settlement.js`) was never committed to any
- * branch — git log -S 'settleOpenBets' shows the import landed in 55b3095
- * without the file. As a result `npm run server` has been crash-on-boot since
- * that commit. Today only the in-app `settleUserMockNflGameBets` path runs
- * (called from the frontend when a mock NFL game finalizes); API-game
- * settlement does not run anywhere. When somebody resurrects automatic API
- * settlement, plug it back in here:
- *   1. create `server/settlement.js` exporting `settleOpenBets()`
- *   2. uncomment the import + cron block below
- *   3. swap the 503 stub on POST /api/settle-bets for the real call
- *      The shared building blocks (`getPendingBets`, `settleBet`,
- *      `recordParlayLegResult`, `settleParlayBetIfReady`,
- *      `getAcceptedHeadToHead`, `settleHeadToHead`) already exist in
- *      services/dbOps.ts.
- *   - 5.8.2026 Aidan O'Halloran
+ * API game settlement: the client calls `settlePendingApiOddsBetsForUser` in
+ * services/settleApiOddsBets.ts (scores via GET /api/scores/:sportKey below).
+ * Mock NFL still uses `settleUserMockNflGameBets` when a mock game finalizes.
+ * POST /api/settle-bets remains a stub if you later add a server cron.
  */
 import dotenv from 'dotenv';
 import express from 'express';
@@ -132,6 +120,30 @@ app.get('/api/odds', async (req, res) => {
 app.get('/api/odds/:sportKey', async (req, res) => {
   try { await proxyOddsApiJson(res, req.params.sportKey, req.query); }
   catch (err) { res.status(500).json({ message: err.message }); }
+});
+
+/** Odds API scores — same event ids as /odds; used to settle API singles/parlays. */
+app.get('/api/scores/:sportKey', async (req, res) => {
+  try {
+    if (!ODDS_API_KEY) {
+      return res.status(503).json({
+        message: 'Server has no ODDS_API_KEY. Set ODDS_API_KEY in .env or .env.local and restart the API.',
+      });
+    }
+    const u = new URL(
+      `https://api.the-odds-api.com/v4/sports/${encodeURIComponent(req.params.sportKey)}/scores`,
+    );
+    for (const [k, raw] of Object.entries(req.query)) {
+      if (k === 'apiKey') continue;
+      u.searchParams.set(k, Array.isArray(raw) ? raw.join(',') : String(raw));
+    }
+    u.searchParams.set('apiKey', ODDS_API_KEY);
+    const response = await fetch(u);
+    const data = await response.json().catch(() => []);
+    return res.status(response.status).json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
 });
 
 app.get('/api/sports', async (req, res) => {

--- a/services/__tests__/apiOddsGrading.test.ts
+++ b/services/__tests__/apiOddsGrading.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Run with: npm run test:parlay
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { gradeOddsApiSelection } from '../apiOddsGrading.ts';
+import type { OddsApiScoreEvent } from '../oddsApiScores.ts';
+
+const nbaFinal: OddsApiScoreEvent = {
+  id: 'evt1',
+  sport_key: 'basketball_nba',
+  completed: true,
+  home_team: 'Sacramento Kings',
+  away_team: 'Oklahoma City Thunder',
+  scores: [
+    { name: 'Sacramento Kings', score: '113' },
+    { name: 'Oklahoma City Thunder', score: '103' },
+  ],
+};
+
+test('h2h home wins', () => {
+  const g = gradeOddsApiSelection(
+    { label: 'Sacramento Kings', marketKey: 'h2h' },
+    nbaFinal,
+  );
+  assert.equal(g, 'WON');
+});
+
+test('h2h away loses', () => {
+  const g = gradeOddsApiSelection(
+    { label: 'Oklahoma City Thunder', marketKey: 'h2h' },
+    nbaFinal,
+  );
+  assert.equal(g, 'LOST');
+});
+
+test('totals over wins', () => {
+  const g = gradeOddsApiSelection({ label: 'Over 210.5', marketKey: 'totals' }, nbaFinal);
+  assert.equal(g, 'WON');
+});
+
+test('totals under loses', () => {
+  const g = gradeOddsApiSelection({ label: 'Under 210.5', marketKey: 'totals' }, nbaFinal);
+  assert.equal(g, 'LOST');
+});
+
+test('spread away +7 loses when down 10', () => {
+  // home 113 away 103 -> margin away = -10, +7 => -3 LOST
+  const g = gradeOddsApiSelection(
+    { label: 'Oklahoma City Thunder +7', marketKey: 'spreads' },
+    nbaFinal,
+  );
+  assert.equal(g, 'LOST');
+});
+
+test('spread away +7 wins when losing by 6', () => {
+  const e: OddsApiScoreEvent = {
+    ...nbaFinal,
+    scores: [
+      { name: 'Sacramento Kings', score: '100' },
+      { name: 'Oklahoma City Thunder', score: '94' },
+    ],
+  };
+  const g = gradeOddsApiSelection(
+    { label: 'Oklahoma City Thunder +7', marketKey: 'spreads' },
+    e,
+  );
+  assert.equal(g, 'WON');
+});
+
+test('incomplete event -> null', () => {
+  const g = gradeOddsApiSelection(
+    { label: 'Sacramento Kings', marketKey: 'h2h' },
+    { ...nbaFinal, completed: false },
+  );
+  assert.equal(g, null);
+});

--- a/services/apiOddsGrading.ts
+++ b/services/apiOddsGrading.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure grading for bets placed against Odds API events, using the /scores payload.
+ * See: https://the-odds-api.com/liveapi/guides/v4/#get-scores
+ */
+
+import type { MarketOption } from '@/models';
+import type { OddsApiScoreEvent } from './oddsApiScores';
+
+export type ApiGrade = 'WON' | 'LOST' | 'PUSH' | 'VOID';
+
+function parseScores(event: OddsApiScoreEvent): { home: number; away: number } | null {
+  const homeName = event.home_team?.trim() ?? '';
+  const awayName = event.away_team?.trim() ?? '';
+  if (!homeName || !awayName || !event.scores?.length) return null;
+  let home = 0;
+  let away = 0;
+  for (const row of event.scores) {
+    if (row.name === homeName) home = parseInt(row.score, 10) || 0;
+    else if (row.name === awayName) away = parseInt(row.score, 10) || 0;
+  }
+  return { home, away };
+}
+
+function inferMarketKey(
+  label: string,
+  event: OddsApiScoreEvent,
+): 'h2h' | 'spreads' | 'totals' | 'outrights' {
+  const t = label.trim();
+  if (/^(over|under)\s+/i.test(t)) return 'totals';
+  const home = event.home_team?.trim() ?? '';
+  const away = event.away_team?.trim() ?? '';
+  if (t === home || t === away) return 'h2h';
+  const drawish = /^(draw|tie)$/i.test(t);
+  if (drawish) return 'h2h';
+  return 'spreads';
+}
+
+/**
+ * @returns null if the game is not ready to grade (not completed or missing scores).
+ */
+export function gradeOddsApiSelection(
+  pick: { label: string; marketKey?: MarketOption['marketKey'] },
+  event: OddsApiScoreEvent,
+): ApiGrade | null {
+  if (!event.completed) return null;
+  const parsed = parseScores(event);
+  if (!parsed) return null;
+
+  const { home: homeScore, away: awayScore } = parsed;
+  const home = event.home_team?.trim() ?? '';
+  const away = event.away_team?.trim() ?? '';
+  const label = pick.label.trim();
+  const mk = pick.marketKey ?? inferMarketKey(label, event);
+
+  if (mk === 'h2h' || mk === 'outrights') {
+    if (/^(draw|tie)$/i.test(label)) {
+      if (homeScore === awayScore) return 'WON';
+      return 'LOST';
+    }
+    if (label === home) {
+      if (homeScore === awayScore) return 'PUSH';
+      return homeScore > awayScore ? 'WON' : 'LOST';
+    }
+    if (label === away) {
+      if (homeScore === awayScore) return 'PUSH';
+      return awayScore > homeScore ? 'WON' : 'LOST';
+    }
+    return 'VOID';
+  }
+
+  if (mk === 'totals') {
+    const m = label.match(/^(Over|Under)\s+(\d+(?:\.\d+)?)\s*$/i);
+    if (!m) return 'VOID';
+    const line = parseFloat(m[2]);
+    if (!Number.isFinite(line)) return 'VOID';
+    const total = homeScore + awayScore;
+    const side = m[1].toLowerCase();
+    if (side === 'over') {
+      if (total === line) return 'PUSH';
+      return total > line ? 'WON' : 'LOST';
+    }
+    if (total === line) return 'PUSH';
+    return total < line ? 'WON' : 'LOST';
+  }
+
+  if (mk === 'spreads') {
+    const sides = [
+      { which: 'home' as const, name: home },
+      { which: 'away' as const, name: away },
+    ].sort((a, b) => b.name.length - a.name.length);
+
+    let picked: 'home' | 'away' | null = null;
+    let spreadStr: string | null = null;
+    for (const { which, name } of sides) {
+      if (!name) continue;
+      if (label.startsWith(name)) {
+        const rest = label.slice(name.length).trim();
+        if (/^[+-]?\d+(?:\.\d+)?$/.test(rest)) {
+          picked = which;
+          spreadStr = rest;
+          break;
+        }
+      }
+    }
+    if (!picked || spreadStr == null) {
+      const rm = label.match(/^(.+?)\s+([+-]?\d+(?:\.\d+)?)\s*$/);
+      if (!rm) return 'VOID';
+      const teamName = rm[1].trim();
+      if (teamName === home) picked = 'home';
+      else if (teamName === away) picked = 'away';
+      else return 'VOID';
+      spreadStr = rm[2];
+    }
+
+    const spread = parseFloat(spreadStr);
+    if (!Number.isFinite(spread)) return 'VOID';
+
+    const pickedMargin =
+      picked === 'home' ? homeScore - awayScore : awayScore - homeScore;
+    const adjusted = pickedMargin + spread;
+    if (adjusted > 0) return 'WON';
+    if (adjusted < 0) return 'LOST';
+    return 'PUSH';
+  }
+
+  return 'VOID';
+}

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -712,29 +712,35 @@ export async function settleUserMockNflGameBets(
     );
     if (pending.length === 0) return;
 
-    await Promise.all(
-        pending.map(async (bet) => {
-            if (bet.betType === "parlay") {
-                const legs = bet.parlayLegs ?? [];
-                for (let idx = 0; idx < legs.length; idx++) {
-                    const leg = legs[idx];
-                    if (leg.marketId !== marketId) continue;
-                    if (leg.result && leg.result !== "PENDING") continue; // already decided
-                    const result = outcomeForParlayLeg(leg);
-                    // A parlay leg that we can't recognize for this market is
-                    // recorded as VOID — `computeParlayRollup` treats that the
-                    // same as PUSH (drops the leg from the payout).
-                    await recordParlayLegResult(bet.id, idx, result);
-                }
-                return;
+    // Serialize parlay updates per bet so two legs on the same ticket never
+    // race in separate Firestore transactions (one could read stale legs and
+    // skip the roll-up LOST settle).
+    for (const bet of pending) {
+        if (bet.betType === "parlay") {
+            const legs = bet.parlayLegs ?? [];
+            let wroteAnyLeg = false;
+            for (let idx = 0; idx < legs.length; idx++) {
+                const leg = legs[idx];
+                if (leg.marketId !== marketId) continue;
+                if (leg.result && leg.result !== "PENDING") continue; // already decided
+                const result = outcomeForParlayLeg(leg);
+                // A parlay leg that we can't recognize for this market is
+                // recorded as VOID — `computeParlayRollup` treats that the
+                // same as PUSH (drops the leg from the payout).
+                await recordParlayLegResult(bet.id, idx, result);
+                wroteAnyLeg = true;
             }
+            if (wroteAnyLeg) {
+                await settleParlayBetIfReady(bet.id);
+            }
+            continue;
+        }
 
-            // Single bet on this exact mock market.
-            if (bet.marketId === marketId) {
-                await settleBet(bet, outcomeFor(bet.optionLabel));
-            }
-        }),
-    );
+        // Single bet on this exact mock market.
+        if (bet.marketId === marketId) {
+            await settleBet(bet, outcomeFor(bet.optionLabel));
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -1,6 +1,6 @@
 import { setDoc, doc, getDoc, getDocs, onSnapshot, collection, deleteDoc, Timestamp, runTransaction, deleteField, query, where, orderBy, limit, writeBatch, increment, QueryDocumentSnapshot, DocumentData, DocumentReference, addDoc } from "firebase/firestore";
 import { db } from "@/models/constants.ts";
-import {Bet, LeaderboardEntry, ParlayLeg, BetStatus, Friend, SocialActivity, HeadToHead, HeadToHeadStatus} from "@/models";
+import {Bet, LeaderboardEntry, ParlayLeg, BetStatus, Friend, SocialActivity, HeadToHead, HeadToHeadStatus, type MockNflGameState} from "@/models";
 import { PROFILE_BACKGROUND_URLS, profileBackgroundForUid } from "@/models/profileBackgrounds";
 import {
     ANONYMOUS_PROFILE_AVATAR_PATH,
@@ -11,6 +11,7 @@ import {
     MODE_TEST_DEFAULT_AVATAR_PATH,
 } from "@/models/defaultProfileAvatars";
 import {randomInt} from "node:crypto";
+import { ensureMockBoardUpToCount, MOCK_NFL_BOARD_TARGET_COUNT } from "@/lib/globalMockNflBoard";
 
 export var currBets = new Array<Bet>;
 
@@ -517,40 +518,21 @@ export async function setSpendingLimits(
 
 
 // ─────────────────────────────────────────────────────────────────
-//  MOCK NFL GAMES (PER USER)
+//  MOCK NFL GAMES (GLOBAL — one board for every signed-in user)
+//  Stored at: mockNflBoard/global
 // ─────────────────────────────────────────────────────────────────
 
-export type MockNflWinner = "HOME" | "AWAY" | null;
+export type { MockNflGameState, MockNflWinner } from "@/models";
 
-export interface MockNflGameState {
-    id: string;
-    week: number;
-    awayTeam: string;
-    homeTeam: string;
-    awayOdds: number;
-    homeOdds: number;
-    /** Spread leg prices (decimal); separate from moneyline. */
-    spreadAwayOdds: number;
-    spreadHomeOdds: number;
-    totalOverOdds: number;
-    totalUnderOdds: number;
-    spreadLine: number;
-    totalLine: number;
-    status: "UPCOMING" | "FINAL";
-    awayScore: number | null;
-    homeScore: number | null;
-    winner: MockNflWinner;
-    updatedAtMs: number;
+const MOCK_NFL_GLOBAL_COLLECTION = "mockNflBoard";
+const MOCK_NFL_GLOBAL_DOC_ID = "global";
+
+function mockNflGlobalDoc() {
+    return doc(db, MOCK_NFL_GLOBAL_COLLECTION, MOCK_NFL_GLOBAL_DOC_ID);
 }
 
-export async function getUserMockNflGames(uid: string): Promise<MockNflGameState[]> {
-    if (!uid) return [];
-    const snap = await getDoc(doc(db, "userInfo", uid));
-    if (!snap.exists()) return [];
-    const data = snap.data();
-    const raw = data["mockNflGames"];
+export function parseMockNflGamesFromFirestore(raw: unknown): MockNflGameState[] {
     if (!Array.isArray(raw)) return [];
-
     return raw
         .map((row: any): MockNflGameState | null => {
             if (!row || typeof row !== "object") return null;
@@ -581,12 +563,83 @@ export async function getUserMockNflGames(uid: string): Promise<MockNflGameState
         .filter((row: MockNflGameState | null): row is MockNflGameState => row !== null);
 }
 
-export async function saveUserMockNflGames(uid: string, games: MockNflGameState[]): Promise<void> {
-    if (!uid) return;
-    await setDoc(doc(db, "userInfo", uid), {
-        mockNflGames: games,
-        mockNflUpdatedAt: Timestamp.now(),
-    }, { merge: true });
+export async function getGlobalMockNflGames(): Promise<MockNflGameState[]> {
+    const snap = await getDoc(mockNflGlobalDoc());
+    if (!snap.exists()) return [];
+    return parseMockNflGamesFromFirestore(snap.data()?.["games"]);
+}
+
+export async function saveGlobalMockNflGames(games: MockNflGameState[]): Promise<void> {
+    await setDoc(
+        mockNflGlobalDoc(),
+        { games, updatedAt: Timestamp.now() },
+        { merge: true },
+    );
+}
+
+export function subscribeToGlobalMockNflGames(
+    onUpdate: (games: MockNflGameState[]) => void,
+    onError?: (err: Error) => void,
+): () => void {
+    return onSnapshot(
+        mockNflGlobalDoc(),
+        (snap) => {
+            const games = snap.exists() ? parseMockNflGamesFromFirestore(snap.data()?.["games"]) : [];
+            onUpdate(games);
+        },
+        (err) => {
+            if (onError) onError(err as Error);
+            else console.error("subscribeToGlobalMockNflGames failed", err);
+        },
+    );
+}
+
+/** Ensures the global doc has five rows (pads with random UPCOMING games). Safe to call from any client. */
+export async function ensureGlobalMockNflBoardSeeded(): Promise<MockNflGameState[]> {
+    const ref = mockNflGlobalDoc();
+    const out = await runTransaction(db, async (tx) => {
+        const s = await tx.get(ref);
+        const parsed = s.exists() ? parseMockNflGamesFromFirestore(s.data()?.["games"]) : [];
+        const next = ensureMockBoardUpToCount(parsed, MOCK_NFL_BOARD_TARGET_COUNT);
+        tx.set(ref, { games: next, updatedAt: Timestamp.now() }, { merge: true });
+        return next;
+    });
+    return out;
+}
+
+/**
+ * When a global mock game is FINAL, settle every user's singles + parlays touching that market,
+ * then settle any accepted head-to-heads on those bet ids.
+ */
+export async function settleAllUsersForMockNflGame(game: MockNflGameState): Promise<void> {
+    if (game.status !== "FINAL") return;
+    if (game.awayScore == null || game.homeScore == null) return;
+    const marketId = `mock-${game.id}`;
+    const userIds = new Set<string>();
+
+    const singleSnap = await getDocs(
+        query(collection(db, "bets"), where("marketId", "==", marketId), where("status", "==", "PENDING")),
+    );
+    singleSnap.forEach((d) => {
+        const uid = String(d.data()?.["userID"] ?? "");
+        if (uid) userIds.add(uid);
+    });
+
+    const parlaySnap = await getDocs(
+        query(collection(db, "bets"), where("betType", "==", "parlay"), where("status", "==", "PENDING"), limit(400)),
+    );
+    parlaySnap.forEach((d) => {
+        const legs = Array.isArray(d.data()?.["parlayLegs"]) ? d.data()?.["parlayLegs"] : [];
+        const hit = legs.some((L: any) => String(L?.marketId ?? "") === marketId);
+        if (hit) {
+            const uid = String(d.data()?.["userID"] ?? "");
+            if (uid) userIds.add(uid);
+        }
+    });
+
+    for (const uid of userIds) {
+        await settleUserMockNflGameBets(uid, game);
+    }
 }
 
 /**
@@ -1145,6 +1198,40 @@ export async function settleBet(
     }
 
     await batch.commit();
+    await runMockBetFollowUpsAfterBetSettled(bet, result);
+}
+
+/**
+ * Singles on the mock NFL board use `marketId` values prefixed with `mock-`.
+ * Parlays store top-level `marketId` like `parlay:mock-…|mock-…` but each leg’s
+ * `marketId` is still a `mock-…` id.
+ */
+export function isMockNflOnlyBet(bet: Pick<Bet, "betType" | "marketId" | "parlayLegs">): boolean {
+    if (bet.betType === "parlay") {
+        const legs = bet.parlayLegs ?? [];
+        return legs.length > 0 && legs.every((leg) => String(leg.marketId).startsWith("mock-"));
+    }
+    return String(bet.marketId ?? "").startsWith("mock-");
+}
+
+/**
+ * Cancels every still-pending slip that is exclusively mock NFL markets: sets
+ * status to CANCELLED and refunds stake via {@link settleBet}. Real Odds API
+ * tickets (non-`mock-` markets) are left unchanged.
+ */
+export async function cancelPendingMockNflBetsForUser(uid: string): Promise<{ cancelledIds: string[] }> {
+    const trimmed = uid.trim();
+    if (!trimmed) return { cancelledIds: [] };
+    const all = await getBets(trimmed);
+    const targets = all.filter(
+        (b) => (b.status ?? "PENDING") === "PENDING" && isMockNflOnlyBet(b),
+    );
+    const cancelledIds: string[] = [];
+    for (const bet of targets) {
+        await settleBet(bet, "CANCELLED");
+        cancelledIds.push(bet.id);
+    }
+    return { cancelledIds };
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -2449,6 +2536,8 @@ export async function sendDirectMessage(input: SendDirectMessageInput): Promise<
 }
 
 const COUNTER_BET_DM_PREFIX = "COUNTER_BET:";
+/** Machine-readable counter settlement line → render rich card in chat. */
+const H2H_SETTLE_DM_PREFIX = "H2H_SETTLE:";
 
 export function makeDmThreadId(uidA: string, uidB: string): string {
     const [a, b] = [uidA, uidB].sort((x, y) => x.localeCompare(y));
@@ -2463,6 +2552,17 @@ export function parseCounterBetInviteIdFromMessage(text: string): string | null 
     const t = text.trim();
     if (!t.startsWith(COUNTER_BET_DM_PREFIX)) return null;
     const id = t.slice(COUNTER_BET_DM_PREFIX.length).trim();
+    return id.length > 0 ? id : null;
+}
+
+export function isCounterBetSettlementMessageText(text: string): boolean {
+    return text.trimStart().startsWith(H2H_SETTLE_DM_PREFIX);
+}
+
+export function parseCounterBetSettlementH2hIdFromMessage(text: string): string | null {
+    const t = text.trim();
+    if (!t.startsWith(H2H_SETTLE_DM_PREFIX)) return null;
+    const id = t.slice(H2H_SETTLE_DM_PREFIX.length).trim();
     return id.length > 0 ? id : null;
 }
 
@@ -3025,5 +3125,73 @@ export async function settleHeadToHead(
     } catch (error) {
         const msg = error instanceof Error ? error.message : "UNKNOWN";
         return { success: false, error: msg };
+    }
+}
+
+/** Refunds challenger escrow for any still-pending counter on this bet (bet already graded). */
+async function closePendingHeadToHeadsForOriginalBet(originalBetId: string): Promise<void> {
+    const q = query(collection(db, H2H_COLLECTION), where("originalBetId", "==", originalBetId));
+    const snap = await getDocs(q);
+    for (const d of snap.docs) {
+        const data = d.data();
+        if ((data.status as string) !== "PENDING_ACCEPT") continue;
+        const h2hRef = doc(db, H2H_COLLECTION, d.id);
+        try {
+            await runTransaction(db, async (transaction) => {
+                const s = await transaction.get(h2hRef);
+                if (!s.exists()) return;
+                if ((s.data().status as string) !== "PENDING_ACCEPT") return;
+                const challengerStake = Number(s.data().challengerStake) || 0;
+                const challengerUserId = String(s.data().challengerUserId ?? "");
+                const challengerRef = doc(db, "userInfo", challengerUserId);
+                transaction.update(challengerRef, { money: increment(challengerStake) });
+                transaction.update(h2hRef, { status: "DECLINED", settledAt: Timestamp.now() });
+            });
+        } catch (e) {
+            console.warn("closePendingHeadToHeadsForOriginalBet", d.id, e);
+        }
+    }
+}
+
+/** Settles accepted counter-bets tied to this slip and posts a DM summary. */
+async function settleAcceptedHeadToHeadsForOriginalBet(
+    originalBetId: string,
+    underlyingResult: "WON" | "LOST" | "PUSH" | "CANCELLED",
+): Promise<void> {
+    const q = query(collection(db, H2H_COLLECTION), where("originalBetId", "==", originalBetId));
+    const snap = await getDocs(q);
+    for (const d of snap.docs) {
+        const data = d.data();
+        if ((data.status as string) !== "ACCEPTED") continue;
+        const h2hId = d.id;
+        const originalUserId = String(data.originalUserId ?? "");
+        const challengerUserId = String(data.challengerUserId ?? "");
+        const res = await settleHeadToHead(h2hId, underlyingResult);
+        if (!res.success) continue;
+        const text = `${H2H_SETTLE_DM_PREFIX}${h2hId}`;
+        const base = Date.now();
+        const threadId = makeDmThreadId(originalUserId, challengerUserId);
+        const dm = await sendDirectMessage({
+            threadId,
+            messageId: `h2h_settle_${h2hId}_${base}`,
+            fromUserId: originalUserId,
+            toUserId: challengerUserId,
+            text,
+            createdAtMs: base,
+        });
+        if (!dm.success) console.warn("settleAcceptedHeadToHeadsForOriginalBet DM failed", dm);
+    }
+}
+
+async function runMockBetFollowUpsAfterBetSettled(
+    bet: Bet,
+    result: "WON" | "LOST" | "PUSH" | "VOID" | "CANCELLED",
+): Promise<void> {
+    if (!bet.marketId?.startsWith("mock-")) return;
+    await closePendingHeadToHeadsForOriginalBet(bet.id);
+    const underlying: "WON" | "LOST" | "PUSH" | "CANCELLED" =
+        result === "VOID" ? "PUSH" : result;
+    if (underlying === "WON" || underlying === "LOST" || underlying === "PUSH" || underlying === "CANCELLED") {
+        await settleAcceptedHeadToHeadsForOriginalBet(bet.id, underlying);
     }
 }

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -529,6 +529,9 @@ export interface MockNflGameState {
     homeTeam: string;
     awayOdds: number;
     homeOdds: number;
+    /** Spread leg prices (decimal); separate from moneyline. */
+    spreadAwayOdds: number;
+    spreadHomeOdds: number;
     totalOverOdds: number;
     totalUnderOdds: number;
     spreadLine: number;
@@ -562,6 +565,8 @@ export async function getUserMockNflGames(uid: string): Promise<MockNflGameState
                 homeTeam,
                 awayOdds: Number(row.awayOdds) || 1.91,
                 homeOdds: Number(row.homeOdds) || 1.91,
+                spreadAwayOdds: Number(row.spreadAwayOdds) || Number(row.awayOdds) || 1.91,
+                spreadHomeOdds: Number(row.spreadHomeOdds) || Number(row.homeOdds) || 1.91,
                 totalOverOdds: Number(row.totalOverOdds) || 1.91,
                 totalUnderOdds: Number(row.totalUnderOdds) || 1.91,
                 spreadLine: Number(row.spreadLine) || 0,
@@ -667,6 +672,41 @@ export async function settleUserMockNflGameBets(
         return "VOID";
     };
 
+    // Parlay legs carry stable option ids (e.g. "...-total-over"), which are
+    // safer than labels when mock lines get regenerated. Prefer id-based
+    // grading so totals/spreads don't get incorrectly VOIDed and reduced.
+    const outcomeForParlayLeg = (leg: ParlayLeg): "WON" | "LOST" | "PUSH" | "VOID" => {
+        const optionId = String(leg.optionId ?? "");
+        if (optionId.endsWith("-ml-away")) {
+            if (game.awayScore === game.homeScore) return "PUSH";
+            return game.awayScore > game.homeScore ? "WON" : "LOST";
+        }
+        if (optionId.endsWith("-ml-home")) {
+            if (game.awayScore === game.homeScore) return "PUSH";
+            return game.homeScore > game.awayScore ? "WON" : "LOST";
+        }
+        if (optionId.endsWith("-spread-away")) {
+            const result = margin + game.spreadLine;
+            if (result === 0) return "PUSH";
+            return result > 0 ? "WON" : "LOST";
+        }
+        if (optionId.endsWith("-spread-home")) {
+            const result = -margin - game.spreadLine;
+            if (result === 0) return "PUSH";
+            return result > 0 ? "WON" : "LOST";
+        }
+        if (optionId.endsWith("-total-over")) {
+            if (totalScore === game.totalLine) return "PUSH";
+            return totalScore > game.totalLine ? "WON" : "LOST";
+        }
+        if (optionId.endsWith("-total-under")) {
+            if (totalScore === game.totalLine) return "PUSH";
+            return totalScore < game.totalLine ? "WON" : "LOST";
+        }
+        // Legacy/fallback bets may not have optionId in expected format.
+        return outcomeFor(leg.optionLabel);
+    };
+
     const pending = (await getBets(uid)).filter(
         (b) => (b.status ?? "PENDING") === "PENDING",
     );
@@ -680,7 +720,7 @@ export async function settleUserMockNflGameBets(
                     const leg = legs[idx];
                     if (leg.marketId !== marketId) continue;
                     if (leg.result && leg.result !== "PENDING") continue; // already decided
-                    const result = outcomeFor(leg.optionLabel);
+                    const result = outcomeForParlayLeg(leg);
                     // A parlay leg that we can't recognize for this market is
                     // recorded as VOID — `computeParlayRollup` treats that the
                     // same as PUSH (drops the leg from the payout).
@@ -724,6 +764,7 @@ export async function addBet(uid: string, bet: Bet) {
         status:          "PENDING",
         eventId:         bet.eventId  ?? bet.marketId,
         sportKey:        bet.sportKey ?? "",
+        pickedMarketKey: bet.pickedMarketKey ?? null,
         // ──────────────────────────────────────────────────────
     });
     currBets.push(bet);
@@ -817,6 +858,7 @@ export async function placeSingleBet(uid: string, bet: Bet, boost: BoostType | n
                 status:          "PENDING",
                 eventId:         bet.eventId  ?? bet.marketId,
                 sportKey:        bet.sportKey ?? "",
+                pickedMarketKey: bet.pickedMarketKey ?? null,
                 eventStartsAt:   bet.eventStartsAt ? Timestamp.fromDate(bet.eventStartsAt) : null,
                 isFree:          false,
                 boostApplied:    boost ?? null,
@@ -892,6 +934,7 @@ export async function getBets(uid: string): Promise<Bet[]> {
             status:        (data.status   ?? "PENDING") as BetStatus,
             eventId:       data.eventId,
             sportKey:      data.sportKey,
+            pickedMarketKey: data.pickedMarketKey ?? undefined,
             eventStartsAt: data.eventStartsAt?.toDate?.(),
             settledAt:     data.settledAt?.toDate?.(),
             isFree:        data.isFree ?? false,
@@ -955,6 +998,7 @@ export function subscribeToUserBets(
                     status:        (data.status   ?? "PENDING") as BetStatus,
                     eventId:       data.eventId,
                     sportKey:      data.sportKey,
+                    pickedMarketKey: data.pickedMarketKey ?? undefined,
                     eventStartsAt: data.eventStartsAt?.toDate?.(),
                     settledAt:     data.settledAt?.toDate?.(),
                 };
@@ -1008,6 +1052,7 @@ export async function getPendingBets(): Promise<Bet[]> {
             status:   "PENDING",
             eventId:  data.eventId,
             sportKey: data.sportKey,
+            pickedMarketKey: data.pickedMarketKey ?? undefined,
             isFree:   data.isFree ?? false,
         });
     });

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -3021,7 +3021,7 @@ async function refundChallengerAndClose(
 }
 
 /** Convert a Firestore document into a typed HeadToHead object. */
-function mapHeadToHead(id: string, data: DocumentData): HeadToHead {
+export function mapHeadToHead(id: string, data: DocumentData): HeadToHead {
     const eventStartsAtRaw = data.eventStartsAt as Timestamp | undefined;
     const createdAtRaw     = data.createdAt     as Timestamp | undefined;
     const acceptedAtRaw    = data.acceptedAt    as Timestamp | undefined;

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -1483,6 +1483,8 @@ export async function getTopUsers(): Promise<LeaderboardEntry[]> {
 
         const money = typeof data.money === "number" ? data.money : Number(data.money) || 0;
 
+        const challengeWins = Number(data.challengeWins) || 0;
+
         topUserList.push({
             id:            docSnap.id,
             name,
@@ -1491,12 +1493,17 @@ export async function getTopUsers(): Promise<LeaderboardEntry[]> {
             profileBackgroundUrl: resolveProfileBackgroundUrl(docSnap.id, name, data),
             netWorth:      Math.round(money),
             winRate,
+            challengeWins,
             rank:          1,
             isCurrentUser: false,
         });
     }
 
-    topUserList.sort((a, b) => b.netWorth - a.netWorth);
+    topUserList.sort((a, b) => {
+      const w = b.netWorth - a.netWorth;
+      if (w !== 0) return w;
+      return (b.challengeWins ?? 0) - (a.challengeWins ?? 0);
+    });
     topUserList.forEach((user, i) => { user.rank = i + 1; });
 
     return topUserList;
@@ -2014,6 +2021,100 @@ export async function sendFriendRequest(username : string, senderUid : string | 
         receiver: recipientUid,
     });
     return { success: true };
+}
+
+const PEER_CHALLENGES_COLLECTION = "peerChallenges";
+
+export interface SendPeerChallengeResult {
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * Persists a social challenge from `challengerUid` to `targetUid`.
+ * Counter-bets on a specific slip still use {@link proposeHeadToHead}; this
+ * records the gesture so flows can surface it later without tying it to a bet.
+ */
+export async function sendPeerChallenge(
+    challengerUid: string,
+    targetUid: string,
+): Promise<SendPeerChallengeResult> {
+    if (!challengerUid?.trim() || !targetUid?.trim()) {
+        return { success: false, error: "Missing user" };
+    }
+    if (challengerUid === targetUid) {
+        return { success: false, error: "You can't challenge yourself" };
+    }
+    try {
+        const [targetSnap, challengerSnap] = await Promise.all([
+            getDoc(doc(db, "userInfo", targetUid)),
+            getDoc(doc(db, "userInfo", challengerUid)),
+        ]);
+        if (!targetSnap.exists()) {
+            return { success: false, error: "Player not found" };
+        }
+        if (!challengerSnap.exists()) {
+            return { success: false, error: "Sign in again" };
+        }
+        const challengerData = challengerSnap.data();
+        const challengerName =
+            typeof challengerData?.["name"] === "string" ? (challengerData["name"] as string) : "";
+        const docId = `${challengerUid}_${targetUid}`;
+        await setDoc(
+            doc(db, PEER_CHALLENGES_COLLECTION, docId),
+            {
+                challengerUid,
+                targetUid,
+                challengerName,
+                createdAt: Timestamp.now(),
+                status: "sent",
+            },
+            { merge: true },
+        );
+        return { success: true };
+    } catch (e) {
+        console.error("sendPeerChallenge failed", e);
+        return { success: false, error: "Could not send challenge" };
+    }
+}
+
+export interface CancelPeerChallengeResult {
+    success: boolean;
+    error?: string;
+}
+
+/** Marks a {@link sendPeerChallenge} doc as cancelled (challenger only). */
+export async function cancelPeerChallenge(
+    challengerUid: string,
+    targetUid: string,
+): Promise<CancelPeerChallengeResult> {
+    if (!challengerUid?.trim() || !targetUid?.trim()) {
+        return { success: false, error: "Missing user" };
+    }
+    const docId = `${challengerUid}_${targetUid}`;
+    const ref = doc(db, PEER_CHALLENGES_COLLECTION, docId);
+    try {
+        const snap = await getDoc(ref);
+        if (!snap.exists()) {
+            return { success: false, error: "Nothing to cancel" };
+        }
+        const data = snap.data();
+        if (String(data["challengerUid"] ?? "") !== challengerUid) {
+            return { success: false, error: "Wrong user" };
+        }
+        if (String(data["status"] ?? "") === "cancelled") {
+            return { success: true };
+        }
+        await setDoc(
+            ref,
+            { status: "cancelled", cancelledAt: Timestamp.now() },
+            { merge: true },
+        );
+        return { success: true };
+    } catch (e) {
+        console.error("cancelPeerChallenge failed", e);
+        return { success: false, error: "Could not cancel" };
+    }
 }
 
 /**

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -2448,6 +2448,61 @@ export async function sendDirectMessage(input: SendDirectMessageInput): Promise<
     }
 }
 
+const COUNTER_BET_DM_PREFIX = "COUNTER_BET:";
+
+export function makeDmThreadId(uidA: string, uidB: string): string {
+    const [a, b] = [uidA, uidB].sort((x, y) => x.localeCompare(y));
+    return `dm:${a}:${b}`;
+}
+
+export function isCounterBetInviteMessageText(text: string): boolean {
+    return text.trimStart().startsWith(COUNTER_BET_DM_PREFIX);
+}
+
+export function parseCounterBetInviteIdFromMessage(text: string): string | null {
+    const t = text.trim();
+    if (!t.startsWith(COUNTER_BET_DM_PREFIX)) return null;
+    const id = t.slice(COUNTER_BET_DM_PREFIX.length).trim();
+    return id.length > 0 ? id : null;
+}
+
+/**
+ * Posts an optional personal note then a machine-readable counter-bet invite in the DM thread.
+ */
+export async function notifyHeadToHeadProposalDm(input: {
+    challengerUid: string;
+    opponentUid: string;
+    h2hId: string;
+    optionalNote?: string;
+}): Promise<void> {
+    const { challengerUid, opponentUid, h2hId, optionalNote } = input;
+    if (!challengerUid || !opponentUid || !h2hId) return;
+    const threadId = makeDmThreadId(challengerUid, opponentUid);
+    const base = Date.now();
+    let seq = 0;
+    const note = (optionalNote ?? "").trim();
+    if (note.length > 0) {
+        const r = await sendDirectMessage({
+            threadId,
+            messageId: `h2h_note_${h2hId}_${base}_${seq++}`,
+            fromUserId: challengerUid,
+            toUserId: opponentUid,
+            text: note,
+            createdAtMs: base,
+        });
+        if (!r.success) console.warn("notifyHeadToHeadProposalDm note failed", r);
+    }
+    const inv = await sendDirectMessage({
+        threadId,
+        messageId: `h2h_inv_${h2hId}_${base}_${seq++}`,
+        fromUserId: challengerUid,
+        toUserId: opponentUid,
+        text: `${COUNTER_BET_DM_PREFIX}${h2hId}`,
+        createdAtMs: base + 1,
+    });
+    if (!inv.success) console.warn("notifyHeadToHeadProposalDm invite failed", inv);
+}
+
 /**
  * Deletes a message only if the acting user is the sender.
  * NOTE: Client-side guard only; Firestore security rules should enforce too.
@@ -2664,9 +2719,11 @@ export async function proposeHeadToHead(
             // Hard lock: no fades after kickoff. Bets written before this field
             // existed (legacy data) won't have eventStartsAt — those skip the
             // lock and rely on the cron's existing settlement gating instead.
+            const slipMarketId = String(betData.marketId ?? "");
+            const mockSlip = slipMarketId.startsWith("mock-");
             const eventStartsTs = betData.eventStartsAt as Timestamp | undefined;
             const eventStartsDate = eventStartsTs?.toDate?.();
-            if (eventStartsDate && eventStartsDate.getTime() <= Date.now()) {
+            if (!mockSlip && eventStartsDate && eventStartsDate.getTime() <= Date.now()) {
                 throw new Error("EVENT_STARTED");
             }
 
@@ -2754,10 +2811,12 @@ export async function acceptHeadToHead(
             if (String(data.originalUserId) !== actingUserId) throw new Error("WRONG_USER");
 
             // Re-check the kickoff lock at accept time (the game may have started
-            // between proposal and acceptance).
+            // between proposal and acceptance). Mock NFL slips skip this (synthetic times).
+            const h2hMarketId = String(data.marketId ?? "");
+            const mockH2h = h2hMarketId.startsWith("mock-");
             const eventStartsTs = data.eventStartsAt as Timestamp | undefined;
             const eventStartsDate = eventStartsTs?.toDate?.();
-            if (eventStartsDate && eventStartsDate.getTime() <= Date.now()) {
+            if (!mockH2h && eventStartsDate && eventStartsDate.getTime() <= Date.now()) {
                 throw new Error("EVENT_STARTED");
             }
 

--- a/services/dbOps.ts
+++ b/services/dbOps.ts
@@ -1956,6 +1956,8 @@ async function buildCommunityActivity(
             action:    isParlay ? "placed a parlay on" : "placed a bet on",
             target:    String(data["marketTitle"] ?? ""),
             timestamp: formatActivityTimestamp(placedAtDate),
+            sortKey:   placedAtDate.getTime(),
+            activityKind: "bet",
         });
     }
 

--- a/services/gameChallenges.ts
+++ b/services/gameChallenges.ts
@@ -23,7 +23,7 @@ import { gradeOddsApiSelection } from '@/services/apiOddsGrading';
 import { fetchOddsApiScores } from '@/services/oddsApiScores';
 import type { OddsApiScoreEvent } from '@/services/oddsApiScores';
 import { gradeMockNflPickAfterFinal } from '@/lib/mockNflChallengeGrade';
-import { makeDmThreadId, sendDirectMessage, getUserMockNflGames } from '@/services/dbOps';
+import { getGlobalMockNflGames, makeDmThreadId, sendDirectMessage } from '@/services/dbOps';
 
 const COL = 'gameChallenges';
 const DM_PREFIX = 'GAME_CHALLENGE:';
@@ -198,7 +198,7 @@ export async function reconcileMockGameChallengeIfNeeded(challengeId: string): P
     if (gc.sportKey !== 'football_nfl_mock' || !gc.eventId.startsWith('mock-')) return;
     if (gc.status !== 'PENDING_ACCEPT' && gc.status !== 'ACTIVE') return;
 
-    const games = await getUserMockNflGames(gc.challengerUid);
+    const games = await getGlobalMockNflGames();
     const gameId = gc.eventId.startsWith('mock-') ? gc.eventId.slice('mock-'.length) : '';
     const game = games.find((g) => g.id === gameId);
 
@@ -256,24 +256,22 @@ export async function reconcileMockGameChallengeIfNeeded(challengeId: string): P
   }
 }
 
-/** After a challenger's mock NFL game goes FINAL, settle any challenges tied to that event. */
-export async function reconcileMockGameChallengesAfterUserGameFinal(
-  challengerUid: string,
-  game: { id: string; status: string },
-): Promise<void> {
-  if (!challengerUid || game.status !== 'FINAL') return;
+/** After the global mock NFL game goes FINAL, settle any challenges on that event. */
+export async function reconcileMockGameChallengesAfterGlobalMockFinal(game: {
+  id: string;
+  status: string;
+}): Promise<void> {
+  if (game.status !== 'FINAL') return;
   const eventId = `mock-${game.id}`;
   try {
-    const q = query(collection(db, COL), where('challengerUid', '==', challengerUid), limit(60));
+    const q = query(collection(db, COL), where('eventId', '==', eventId), limit(40));
     const snap = await getDocs(q);
     for (const d of snap.docs) {
-      const ddata = d.data();
-      if (String(ddata.eventId ?? '') !== eventId) continue;
-      if (String(ddata.sportKey ?? '') !== 'football_nfl_mock') continue;
+      if (String(d.data().sportKey ?? '') !== 'football_nfl_mock') continue;
       await reconcileMockGameChallengeIfNeeded(d.id);
     }
   } catch (e) {
-    console.error('reconcileMockGameChallengesAfterUserGameFinal', e);
+    console.error('reconcileMockGameChallengesAfterGlobalMockFinal', e);
   }
 }
 

--- a/services/gameChallenges.ts
+++ b/services/gameChallenges.ts
@@ -1,0 +1,320 @@
+/**
+ * Peer "game challenges": both users pick opposite sides on an upcoming h2h market.
+ * Created from profile → DM thread; opponent accepts; settled from Odds API scores.
+ * Winners get `challengeWins` on userInfo (leaderboard column).
+ */
+
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  increment,
+  limit,
+  query,
+  runTransaction,
+  Timestamp,
+  where,
+} from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import type { Market, MarketOption } from '@/models';
+import { gradeOddsApiSelection } from '@/services/apiOddsGrading';
+import { fetchOddsApiScores } from '@/services/oddsApiScores';
+import type { OddsApiScoreEvent } from '@/services/oddsApiScores';
+import { sendDirectMessage } from '@/services/dbOps';
+
+const COL = 'gameChallenges';
+const DM_PREFIX = 'GAME_CHALLENGE:';
+
+export type GameChallengeStatus =
+  | 'PENDING_ACCEPT'
+  | 'ACTIVE'
+  | 'DECLINED'
+  | 'CANCELLED'
+  | 'COMPLETED_CHALLENGER'
+  | 'COMPLETED_OPPONENT'
+  | 'PUSH';
+
+export interface GameChallengeDoc {
+  id: string;
+  challengerUid: string;
+  opponentUid: string;
+  challengerName: string;
+  opponentName: string;
+  sportKey: string;
+  eventId: string;
+  marketTitle: string;
+  challengerPickLabel: string;
+  challengerPickMarketKey: MarketOption['marketKey'];
+  opponentPickLabel: string;
+  opponentPickMarketKey: MarketOption['marketKey'];
+  status: GameChallengeStatus;
+  createdAt: Timestamp;
+  acceptedAt?: Timestamp;
+  settledAt?: Timestamp;
+}
+
+function dmThreadId(a: string, b: string): string {
+  const [x, y] = [a, b].sort((u, v) => u.localeCompare(v));
+  return `dm:${x}:${y}`;
+}
+
+function pickH2hPair(market: Market): { a: MarketOption; b: MarketOption } | null {
+  const h2h = market.options.filter((o) => (o.marketKey ?? 'h2h') === 'h2h');
+  if (h2h.length !== 2) return null;
+  return { a: h2h[0], b: h2h[1] };
+}
+
+export function isGameChallengeMessageText(text: string): boolean {
+  return text.trimStart().startsWith(DM_PREFIX);
+}
+
+export function parseGameChallengeIdFromMessage(text: string): string | null {
+  const t = text.trim();
+  if (!t.startsWith(DM_PREFIX)) return null;
+  const id = t.slice(DM_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
+export async function getGameChallenge(id: string): Promise<GameChallengeDoc | null> {
+  const snap = await getDoc(doc(db, COL, id));
+  if (!snap.exists()) return null;
+  const d = snap.data();
+  return {
+    id: snap.id,
+    challengerUid: String(d.challengerUid ?? ''),
+    opponentUid: String(d.opponentUid ?? ''),
+    challengerName: String(d.challengerName ?? ''),
+    opponentName: String(d.opponentName ?? ''),
+    sportKey: String(d.sportKey ?? ''),
+    eventId: String(d.eventId ?? ''),
+    marketTitle: String(d.marketTitle ?? ''),
+    challengerPickLabel: String(d.challengerPickLabel ?? ''),
+    challengerPickMarketKey: (d.challengerPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
+    opponentPickLabel: String(d.opponentPickLabel ?? ''),
+    opponentPickMarketKey: (d.opponentPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
+    status: (d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT',
+    createdAt: (d.createdAt as Timestamp) ?? Timestamp.now(),
+    acceptedAt: d.acceptedAt as Timestamp | undefined,
+    settledAt: d.settledAt as Timestamp | undefined,
+  };
+}
+
+export type CreateGameChallengeResult =
+  | { success: true; challengeId: string }
+  | { success: false; error: string };
+
+/**
+ * Creates a pending game challenge and posts a machine-readable line into the DM thread.
+ * Only two-option h2h moneylines are supported.
+ */
+export async function createGameChallengeAndNotify(input: {
+  challengerUid: string;
+  opponentUid: string;
+  challengerName: string;
+  opponentName: string;
+  market: Market;
+  chosenOption: MarketOption;
+}): Promise<CreateGameChallengeResult> {
+  const { challengerUid, opponentUid, challengerName, opponentName, market, chosenOption } = input;
+  if (!challengerUid || !opponentUid || challengerUid === opponentUid) {
+    return { success: false, error: 'Invalid users' };
+  }
+  const pair = pickH2hPair(market);
+  if (!pair) {
+    return { success: false, error: 'Pick a two-team moneyline (h2h) market only.' };
+  }
+  const { a, b } = pair;
+  const other = a.id === chosenOption.id ? b : b.id === chosenOption.id ? a : null;
+  if (!other) {
+    return { success: false, error: 'Pick one side of that matchup.' };
+  }
+  if (market.status === 'CLOSED') {
+    return { success: false, error: 'That market is closed.' };
+  }
+
+  try {
+    const ref = await addDoc(collection(db, COL), {
+      challengerUid,
+      opponentUid,
+      challengerName,
+      opponentName,
+      sportKey: market.sport_key,
+      eventId: market.id,
+      marketTitle: market.title,
+      challengerPickLabel: chosenOption.label,
+      challengerPickMarketKey: chosenOption.marketKey ?? 'h2h',
+      opponentPickLabel: other.label,
+      opponentPickMarketKey: other.marketKey ?? 'h2h',
+      status: 'PENDING_ACCEPT' as GameChallengeStatus,
+      createdAt: Timestamp.now(),
+    });
+
+    const threadId = dmThreadId(challengerUid, opponentUid);
+    const messageId = `gc_${ref.id}_${Date.now()}`;
+    const dm = await sendDirectMessage({
+      threadId,
+      messageId,
+      fromUserId: challengerUid,
+      toUserId: opponentUid,
+      text: `${DM_PREFIX}${ref.id}`,
+      createdAtMs: Date.now(),
+    });
+    if (!dm.success) {
+      return { success: false, error: 'Could not send DM' };
+    }
+    return { success: true, challengeId: ref.id };
+  } catch (e) {
+    console.error('createGameChallengeAndNotify', e);
+    return { success: false, error: 'Could not create challenge' };
+  }
+}
+
+export type MutateGameChallengeResult = { success: true } | { success: false; error: string };
+
+export async function acceptGameChallenge(
+  challengeId: string,
+  actingUid: string,
+): Promise<MutateGameChallengeResult> {
+  try {
+    await runTransaction(db, async (tx) => {
+      const r = doc(db, COL, challengeId);
+      const snap = await tx.get(r);
+      if (!snap.exists()) throw new Error('NOT_FOUND');
+      const d = snap.data();
+      if (String(d.opponentUid) !== actingUid) throw new Error('WRONG_USER');
+      if (d.status !== 'PENDING_ACCEPT') throw new Error('BAD_STATUS');
+      tx.update(r, { status: 'ACTIVE', acceptedAt: Timestamp.now() });
+    });
+    return { success: true };
+  } catch (e) {
+    const m = e instanceof Error ? e.message : '';
+    if (m === 'NOT_FOUND') return { success: false, error: 'Challenge not found' };
+    if (m === 'WRONG_USER') return { success: false, error: 'Only they can accept' };
+    if (m === 'BAD_STATUS') return { success: false, error: 'Already handled' };
+    return { success: false, error: 'Accept failed' };
+  }
+}
+
+export async function declineGameChallenge(
+  challengeId: string,
+  actingUid: string,
+): Promise<MutateGameChallengeResult> {
+  try {
+    await runTransaction(db, async (tx) => {
+      const r = doc(db, COL, challengeId);
+      const snap = await tx.get(r);
+      if (!snap.exists()) throw new Error('NOT_FOUND');
+      const d = snap.data();
+      if (String(d.opponentUid) !== actingUid) throw new Error('WRONG_USER');
+      if (d.status !== 'PENDING_ACCEPT') throw new Error('BAD_STATUS');
+      tx.update(r, { status: 'DECLINED' });
+    });
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Decline failed' };
+  }
+}
+
+export async function cancelGameChallenge(
+  challengeId: string,
+  actingUid: string,
+): Promise<MutateGameChallengeResult> {
+  try {
+    await runTransaction(db, async (tx) => {
+      const r = doc(db, COL, challengeId);
+      const snap = await tx.get(r);
+      if (!snap.exists()) throw new Error('NOT_FOUND');
+      const d = snap.data();
+      if (String(d.challengerUid) !== actingUid) throw new Error('WRONG_USER');
+      if (d.status !== 'PENDING_ACCEPT') throw new Error('BAD_STATUS');
+      tx.update(r, { status: 'CANCELLED' });
+    });
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Cancel failed' };
+  }
+}
+
+/** Poll-friendly: settle all ACTIVE challenges when scores are final (idempotent). */
+export async function settleActiveGameChallengesGlobal(): Promise<void> {
+  try {
+    const q = query(collection(db, COL), where('status', '==', 'ACTIVE'), limit(80));
+    const snap = await getDocs(q);
+    if (snap.empty) return;
+
+    const sportKeys = new Set<string>();
+    const rows: GameChallengeDoc[] = [];
+    for (const d of snap.docs) {
+      const gc = await getGameChallenge(d.id);
+      if (gc?.status === 'ACTIVE') {
+        rows.push(gc);
+        sportKeys.add(gc.sportKey);
+      }
+    }
+    if (rows.length === 0) return;
+
+    const scoresByEventId = new Map<string, OddsApiScoreEvent>();
+    for (const sk of sportKeys) {
+      try {
+        const events = await fetchOddsApiScores(sk, 3);
+        for (const e of events) {
+          if (e.completed && Array.isArray(e.scores) && e.scores.length >= 2) {
+            scoresByEventId.set(e.id, e);
+          }
+        }
+      } catch {
+        /* quota */
+      }
+    }
+    if (scoresByEventId.size === 0) return;
+
+    for (const gc of rows) {
+      const event = scoresByEventId.get(gc.eventId);
+      if (!event) continue;
+
+      const gCh = gradeOddsApiSelection(
+        { label: gc.challengerPickLabel, marketKey: gc.challengerPickMarketKey },
+        event,
+      );
+      const gOp = gradeOddsApiSelection(
+        { label: gc.opponentPickLabel, marketKey: gc.opponentPickMarketKey },
+        event,
+      );
+      if (gCh === null || gOp === null) continue;
+
+      let next: GameChallengeStatus = 'PUSH';
+      let winnerUid: string | null = null;
+      if (gCh === 'WON' && gOp === 'LOST') {
+        next = 'COMPLETED_CHALLENGER';
+        winnerUid = gc.challengerUid;
+      } else if (gCh === 'LOST' && gOp === 'WON') {
+        next = 'COMPLETED_OPPONENT';
+        winnerUid = gc.opponentUid;
+      } else if (gCh === 'PUSH' || gOp === 'PUSH') {
+        next = 'PUSH';
+      } else {
+        continue;
+      }
+
+      try {
+        await runTransaction(db, async (tx) => {
+          const r = doc(db, COL, gc.id);
+          const s = await tx.get(r);
+          if (!s.exists()) return;
+          if (s.data().status !== 'ACTIVE') return;
+          tx.update(r, { status: next, settledAt: Timestamp.now() });
+          if (winnerUid) {
+            const uref = doc(db, 'userInfo', winnerUid);
+            tx.update(uref, { challengeWins: increment(1) });
+          }
+        });
+      } catch {
+        /* concurrent settle */
+      }
+    }
+  } catch (e) {
+    console.error('settleActiveGameChallengesGlobal', e);
+  }
+}

--- a/services/gameChallenges.ts
+++ b/services/gameChallenges.ts
@@ -27,6 +27,37 @@ import { getGlobalMockNflGames, makeDmThreadId, sendDirectMessage } from '@/serv
 
 const COL = 'gameChallenges';
 const DM_PREFIX = 'GAME_CHALLENGE:';
+/** Rich settlement card in DM threads (parsed by ChatPane). */
+const GC_SETTLE_DM_PREFIX = 'GC_SETTLE:';
+
+export function isGcSettleMessageText(text: string): boolean {
+  return text.trimStart().startsWith(GC_SETTLE_DM_PREFIX);
+}
+
+export function parseGcSettleChallengeIdFromMessage(text: string): string | null {
+  const t = text.trim();
+  if (!t.startsWith(GC_SETTLE_DM_PREFIX)) return null;
+  const id = t.slice(GC_SETTLE_DM_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
+async function sendGameChallengeSettleDm(gc: GameChallengeDoc): Promise<void> {
+  try {
+    const threadId = makeDmThreadId(gc.challengerUid, gc.opponentUid);
+    const text = `${GC_SETTLE_DM_PREFIX}${gc.id}`;
+    const res = await sendDirectMessage({
+      threadId,
+      messageId: `gc_settle_${gc.id}`,
+      fromUserId: gc.challengerUid,
+      toUserId: gc.opponentUid,
+      text,
+      createdAtMs: Date.now(),
+    });
+    if (!res.success) console.warn('sendGameChallengeSettleDm failed', res);
+  } catch (e) {
+    console.warn('sendGameChallengeSettleDm', e);
+  }
+}
 
 export type GameChallengeStatus =
   | 'PENDING_ACCEPT'
@@ -197,6 +228,7 @@ export async function reconcileMockGameChallengeIfNeeded(challengeId: string): P
     if (!gc) return;
     if (gc.sportKey !== 'football_nfl_mock' || !gc.eventId.startsWith('mock-')) return;
     if (gc.status !== 'PENDING_ACCEPT' && gc.status !== 'ACTIVE') return;
+    const statusBeforeTxn = gc.status;
 
     const games = await getGlobalMockNflGames();
     const gameId = gc.eventId.startsWith('mock-') ? gc.eventId.slice('mock-'.length) : '';
@@ -251,6 +283,18 @@ export async function reconcileMockGameChallengeIfNeeded(challengeId: string): P
         tx.update(uref, { challengeWins: increment(1) });
       }
     });
+
+    if (statusBeforeTxn === 'ACTIVE') {
+      const post = await getGameChallenge(challengeId);
+      if (
+        post &&
+        (post.status === 'COMPLETED_CHALLENGER' ||
+          post.status === 'COMPLETED_OPPONENT' ||
+          post.status === 'PUSH')
+      ) {
+        await sendGameChallengeSettleDm(post);
+      }
+    }
   } catch (e) {
     console.error('reconcileMockGameChallengeIfNeeded', e);
   }
@@ -417,6 +461,15 @@ export async function settleActiveGameChallengesGlobal(): Promise<void> {
             tx.update(uref, { challengeWins: increment(1) });
           }
         });
+        const post = await getGameChallenge(gc.id);
+        if (
+          post &&
+          (post.status === 'COMPLETED_CHALLENGER' ||
+            post.status === 'COMPLETED_OPPONENT' ||
+            post.status === 'PUSH')
+        ) {
+          void sendGameChallengeSettleDm(post);
+        }
       } catch {
         /* concurrent settle */
       }

--- a/services/gameChallenges.ts
+++ b/services/gameChallenges.ts
@@ -22,7 +22,8 @@ import type { Market, MarketOption } from '@/models';
 import { gradeOddsApiSelection } from '@/services/apiOddsGrading';
 import { fetchOddsApiScores } from '@/services/oddsApiScores';
 import type { OddsApiScoreEvent } from '@/services/oddsApiScores';
-import { sendDirectMessage } from '@/services/dbOps';
+import { gradeMockNflPickAfterFinal } from '@/lib/mockNflChallengeGrade';
+import { makeDmThreadId, sendDirectMessage, getUserMockNflGames } from '@/services/dbOps';
 
 const COL = 'gameChallenges';
 const DM_PREFIX = 'GAME_CHALLENGE:';
@@ -32,6 +33,7 @@ export type GameChallengeStatus =
   | 'ACTIVE'
   | 'DECLINED'
   | 'CANCELLED'
+  | 'EXPIRED'
   | 'COMPLETED_CHALLENGER'
   | 'COMPLETED_OPPONENT'
   | 'PUSH';
@@ -55,15 +57,12 @@ export interface GameChallengeDoc {
   settledAt?: Timestamp;
 }
 
-function dmThreadId(a: string, b: string): string {
-  const [x, y] = [a, b].sort((u, v) => u.localeCompare(v));
-  return `dm:${x}:${y}`;
-}
-
-function pickH2hPair(market: Market): { a: MarketOption; b: MarketOption } | null {
-  const h2h = market.options.filter((o) => (o.marketKey ?? 'h2h') === 'h2h');
-  if (h2h.length !== 2) return null;
-  return { a: h2h[0], b: h2h[1] };
+/** Opposite side for spreads / totals / ML when exactly two options share the same marketKey. */
+export function opposingOptionForMarket(market: Market, chosen: MarketOption): MarketOption | null {
+  const key = chosen.marketKey ?? 'h2h';
+  const siblings = market.options.filter((o) => (o.marketKey ?? 'h2h') === key);
+  if (siblings.length !== 2) return null;
+  return siblings.find((o) => o.id !== chosen.id) ?? null;
 }
 
 export function isGameChallengeMessageText(text: string): boolean {
@@ -106,8 +105,8 @@ export type CreateGameChallengeResult =
   | { success: false; error: string };
 
 /**
- * Creates a pending game challenge and posts a machine-readable line into the DM thread.
- * Only two-option h2h moneylines are supported.
+ * Creates a pending game challenge and posts into the DM thread (optional note + invite line).
+ * Supports any market line type with exactly two options on the same marketKey (ML, spread, total).
  */
 export async function createGameChallengeAndNotify(input: {
   challengerUid: string;
@@ -116,22 +115,22 @@ export async function createGameChallengeAndNotify(input: {
   opponentName: string;
   market: Market;
   chosenOption: MarketOption;
+  /** Optional message sent first in the thread (same as counter-bet flow). */
+  optionalDmNote?: string;
 }): Promise<CreateGameChallengeResult> {
-  const { challengerUid, opponentUid, challengerName, opponentName, market, chosenOption } = input;
+  const { challengerUid, opponentUid, challengerName, opponentName, market, chosenOption, optionalDmNote } = input;
   if (!challengerUid || !opponentUid || challengerUid === opponentUid) {
     return { success: false, error: 'Invalid users' };
   }
-  const pair = pickH2hPair(market);
-  if (!pair) {
-    return { success: false, error: 'Pick a two-team moneyline (h2h) market only.' };
-  }
-  const { a, b } = pair;
-  const other = a.id === chosenOption.id ? b : b.id === chosenOption.id ? a : null;
+  const other = opposingOptionForMarket(market, chosenOption);
   if (!other) {
-    return { success: false, error: 'Pick one side of that matchup.' };
+    return { success: false, error: 'Pick a line that has exactly two sides (moneyline, spread, or total).' };
   }
   if (market.status === 'CLOSED') {
     return { success: false, error: 'That market is closed.' };
+  }
+  if (market.sport_key !== 'football_nfl_mock') {
+    return { success: false, error: 'Challenges use your NFL sim board only (the three rotating games).' };
   }
 
   try {
@@ -151,15 +150,30 @@ export async function createGameChallengeAndNotify(input: {
       createdAt: Timestamp.now(),
     });
 
-    const threadId = dmThreadId(challengerUid, opponentUid);
-    const messageId = `gc_${ref.id}_${Date.now()}`;
+    const threadId = makeDmThreadId(challengerUid, opponentUid);
+    const base = Date.now();
+    let seq = 0;
+    const note = (optionalDmNote ?? '').trim();
+    if (note.length > 0) {
+      const noteRes = await sendDirectMessage({
+        threadId,
+        messageId: `gc_note_${ref.id}_${base}_${seq++}`,
+        fromUserId: challengerUid,
+        toUserId: opponentUid,
+        text: note,
+        createdAtMs: base,
+      });
+      if (!noteRes.success) {
+        return { success: false, error: 'Could not send message' };
+      }
+    }
     const dm = await sendDirectMessage({
       threadId,
-      messageId,
+      messageId: `gc_${ref.id}_${base}_${seq++}`,
       fromUserId: challengerUid,
       toUserId: opponentUid,
       text: `${DM_PREFIX}${ref.id}`,
-      createdAtMs: Date.now(),
+      createdAtMs: base + 1,
     });
     if (!dm.success) {
       return { success: false, error: 'Could not send DM' };
@@ -173,11 +187,106 @@ export async function createGameChallengeAndNotify(input: {
 
 export type MutateGameChallengeResult = { success: true } | { success: false; error: string };
 
+/**
+ * When the challenger's mock NFL game is FINAL: pending invites become EXPIRED;
+ * active challenges settle to COMPLETED_* / PUSH (same grading as mock bet settlement).
+ */
+export async function reconcileMockGameChallengeIfNeeded(challengeId: string): Promise<void> {
+  try {
+    const gc = await getGameChallenge(challengeId);
+    if (!gc) return;
+    if (gc.sportKey !== 'football_nfl_mock' || !gc.eventId.startsWith('mock-')) return;
+    if (gc.status !== 'PENDING_ACCEPT' && gc.status !== 'ACTIVE') return;
+
+    const games = await getUserMockNflGames(gc.challengerUid);
+    const gameId = gc.eventId.startsWith('mock-') ? gc.eventId.slice('mock-'.length) : '';
+    const game = games.find((g) => g.id === gameId);
+
+    if (!game) {
+      if (gc.status === 'PENDING_ACCEPT' || gc.status === 'ACTIVE') {
+        await runTransaction(db, async (tx) => {
+          const r = doc(db, COL, challengeId);
+          const s = await tx.get(r);
+          if (!s.exists()) return;
+          const st = String(s.data().status);
+          if (st !== 'PENDING_ACCEPT' && st !== 'ACTIVE') return;
+          tx.update(r, { status: 'EXPIRED' });
+        });
+      }
+      return;
+    }
+
+    if (game.status !== 'FINAL' || game.awayScore == null || game.homeScore == null) return;
+
+    const gCh = gradeMockNflPickAfterFinal(game, gc.challengerPickLabel);
+    const gOp = gradeMockNflPickAfterFinal(game, gc.opponentPickLabel);
+    if (gCh === null || gOp === null || gCh === 'VOID' || gOp === 'VOID') return;
+
+    await runTransaction(db, async (tx) => {
+      const r = doc(db, COL, challengeId);
+      const s = await tx.get(r);
+      if (!s.exists()) return;
+      const st = String(s.data().status) as GameChallengeStatus;
+      if (st === 'PENDING_ACCEPT') {
+        tx.update(r, { status: 'EXPIRED' });
+        return;
+      }
+      if (st !== 'ACTIVE') return;
+
+      let next: GameChallengeStatus = 'PUSH';
+      let winnerUid: string | null = null;
+      if (gCh === 'WON' && gOp === 'LOST') {
+        next = 'COMPLETED_CHALLENGER';
+        winnerUid = gc.challengerUid;
+      } else if (gCh === 'LOST' && gOp === 'WON') {
+        next = 'COMPLETED_OPPONENT';
+        winnerUid = gc.opponentUid;
+      } else {
+        next = 'PUSH';
+      }
+
+      tx.update(r, { status: next, settledAt: Timestamp.now() });
+      if (winnerUid) {
+        const uref = doc(db, 'userInfo', winnerUid);
+        tx.update(uref, { challengeWins: increment(1) });
+      }
+    });
+  } catch (e) {
+    console.error('reconcileMockGameChallengeIfNeeded', e);
+  }
+}
+
+/** After a challenger's mock NFL game goes FINAL, settle any challenges tied to that event. */
+export async function reconcileMockGameChallengesAfterUserGameFinal(
+  challengerUid: string,
+  game: { id: string; status: string },
+): Promise<void> {
+  if (!challengerUid || game.status !== 'FINAL') return;
+  const eventId = `mock-${game.id}`;
+  try {
+    const q = query(collection(db, COL), where('challengerUid', '==', challengerUid), limit(60));
+    const snap = await getDocs(q);
+    for (const d of snap.docs) {
+      const ddata = d.data();
+      if (String(ddata.eventId ?? '') !== eventId) continue;
+      if (String(ddata.sportKey ?? '') !== 'football_nfl_mock') continue;
+      await reconcileMockGameChallengeIfNeeded(d.id);
+    }
+  } catch (e) {
+    console.error('reconcileMockGameChallengesAfterUserGameFinal', e);
+  }
+}
+
 export async function acceptGameChallenge(
   challengeId: string,
   actingUid: string,
 ): Promise<MutateGameChallengeResult> {
   try {
+    await reconcileMockGameChallengeIfNeeded(challengeId);
+    const fresh = await getGameChallenge(challengeId);
+    if (fresh?.status === 'EXPIRED') {
+      return { success: false, error: 'This invite expired — the sim game already ended.' };
+    }
     await runTransaction(db, async (tx) => {
       const r = doc(db, COL, challengeId);
       const snap = await tx.get(r);

--- a/services/gameChallenges.ts
+++ b/services/gameChallenges.ts
@@ -16,6 +16,7 @@ import {
   runTransaction,
   Timestamp,
   where,
+  type DocumentData,
 } from 'firebase/firestore';
 import { db } from '@/models/constants.ts';
 import type { Market, MarketOption } from '@/models';
@@ -88,6 +89,28 @@ export interface GameChallengeDoc {
   settledAt?: Timestamp;
 }
 
+/** Map a Firestore `gameChallenges` document (used by inbox listeners). */
+export function mapGameChallengeDoc(id: string, d: DocumentData): GameChallengeDoc {
+  return {
+    id,
+    challengerUid: String(d.challengerUid ?? ''),
+    opponentUid: String(d.opponentUid ?? ''),
+    challengerName: String(d.challengerName ?? ''),
+    opponentName: String(d.opponentName ?? ''),
+    sportKey: String(d.sportKey ?? ''),
+    eventId: String(d.eventId ?? ''),
+    marketTitle: String(d.marketTitle ?? ''),
+    challengerPickLabel: String(d.challengerPickLabel ?? ''),
+    challengerPickMarketKey: (d.challengerPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
+    opponentPickLabel: String(d.opponentPickLabel ?? ''),
+    opponentPickMarketKey: (d.opponentPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
+    status: (d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT',
+    createdAt: (d.createdAt as Timestamp) ?? Timestamp.now(),
+    acceptedAt: d.acceptedAt as Timestamp | undefined,
+    settledAt: d.settledAt as Timestamp | undefined,
+  };
+}
+
 /** Opposite side for spreads / totals / ML when exactly two options share the same marketKey. */
 export function opposingOptionForMarket(market: Market, chosen: MarketOption): MarketOption | null {
   const key = chosen.marketKey ?? 'h2h';
@@ -110,25 +133,7 @@ export function parseGameChallengeIdFromMessage(text: string): string | null {
 export async function getGameChallenge(id: string): Promise<GameChallengeDoc | null> {
   const snap = await getDoc(doc(db, COL, id));
   if (!snap.exists()) return null;
-  const d = snap.data();
-  return {
-    id: snap.id,
-    challengerUid: String(d.challengerUid ?? ''),
-    opponentUid: String(d.opponentUid ?? ''),
-    challengerName: String(d.challengerName ?? ''),
-    opponentName: String(d.opponentName ?? ''),
-    sportKey: String(d.sportKey ?? ''),
-    eventId: String(d.eventId ?? ''),
-    marketTitle: String(d.marketTitle ?? ''),
-    challengerPickLabel: String(d.challengerPickLabel ?? ''),
-    challengerPickMarketKey: (d.challengerPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
-    opponentPickLabel: String(d.opponentPickLabel ?? ''),
-    opponentPickMarketKey: (d.opponentPickMarketKey as MarketOption['marketKey']) ?? 'h2h',
-    status: (d.status as GameChallengeStatus) ?? 'PENDING_ACCEPT',
-    createdAt: (d.createdAt as Timestamp) ?? Timestamp.now(),
-    acceptedAt: d.acceptedAt as Timestamp | undefined,
-    settledAt: d.settledAt as Timestamp | undefined,
-  };
+  return mapGameChallengeDoc(snap.id, snap.data());
 }
 
 export type CreateGameChallengeResult =

--- a/services/oddsApiScores.ts
+++ b/services/oddsApiScores.ts
@@ -1,0 +1,31 @@
+/**
+ * Fetches completed/live scores from The Odds API via the same /api proxy as odds.
+ * Event `id` matches the event id used on markets and parlay legs (`marketId`).
+ */
+
+const API_BASE = '/api';
+
+export type OddsApiScoreRow = { name: string; score: string };
+
+export type OddsApiScoreEvent = {
+  id: string;
+  sport_key: string;
+  completed: boolean;
+  home_team?: string;
+  away_team?: string;
+  scores: OddsApiScoreRow[] | null;
+};
+
+export async function fetchOddsApiScores(
+  sportKey: string,
+  daysFrom: 1 | 2 | 3 = 3,
+): Promise<OddsApiScoreEvent[]> {
+  const q = new URLSearchParams({ daysFrom: String(daysFrom) });
+  const res = await fetch(`${API_BASE}/scores/${encodeURIComponent(sportKey)}?${q}`);
+  if (!res.ok) {
+    throw new Error(`scores ${sportKey}: ${res.status}`);
+  }
+  const data = (await res.json()) as unknown;
+  if (!Array.isArray(data)) return [];
+  return data as OddsApiScoreEvent[];
+}

--- a/services/parlayRollup.ts
+++ b/services/parlayRollup.ts
@@ -27,7 +27,7 @@ export function computeParlayRollup(
     stake: number,
 ): ParlayRollup {
     const normalized = legs.map((l) => {
-        const raw = (l.result ?? 'PENDING') as string;
+        const raw = String(l.result ?? 'PENDING').trim().toUpperCase();
         const result = (raw === 'WON' || raw === 'LOST' || raw === 'PUSH' || raw === 'VOID')
             ? raw
             : 'PENDING';

--- a/services/peerActivityFeed.ts
+++ b/services/peerActivityFeed.ts
@@ -1,0 +1,279 @@
+/**
+ * Realtime head-to-head + game-challenge rows merged into SocialActivity for the community feed.
+ */
+
+import {
+  collection,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  type QuerySnapshot,
+} from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
+import type { Friend } from '@/models';
+import type { SocialActivity, SocialActivityKind } from '@/models';
+import { getUserProfileSummary } from '@/services/dbOps';
+
+const H2H = 'headToHead';
+const GC = 'gameChallenges';
+const PEER_FEED_LIMIT = 28;
+
+function formatActivityTimestamp(d: Date): string {
+  const ms = Date.now() - d.getTime();
+  if (!Number.isFinite(ms) || ms < 60_000) return 'JUST NOW';
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}M AGO`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}H AGO`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}D AGO`;
+  return d.toLocaleDateString();
+}
+
+function tsMs(data: Record<string, unknown>, key: string): number {
+  const t = data[key] as { toMillis?: () => number } | undefined;
+  return typeof t?.toMillis === 'function' ? t.toMillis() : 0;
+}
+
+function labelTime(data: Record<string, unknown>): string {
+  const settled = data.settledAt as { toDate?: () => Date } | undefined;
+  const accepted = data.acceptedAt as { toDate?: () => Date } | undefined;
+  const created = data.createdAt as { toDate?: () => Date } | undefined;
+  const d =
+    typeof settled?.toDate === 'function'
+      ? settled.toDate()
+      : typeof accepted?.toDate === 'function'
+        ? accepted.toDate()
+        : typeof created?.toDate === 'function'
+          ? created.toDate()
+          : new Date(0);
+  return formatActivityTimestamp(d);
+}
+
+async function friendFor(uid: string, cache: Map<string, Friend | null>): Promise<Friend | null> {
+  if (cache.has(uid)) return cache.get(uid)!;
+  const f = await getUserProfileSummary(uid);
+  cache.set(uid, f);
+  return f;
+}
+
+async function buildPeerRowsFromSnapshots(
+  h2hSnap: QuerySnapshot,
+  gcSnap: QuerySnapshot,
+): Promise<SocialActivity[]> {
+  const fCache = new Map<string, Friend | null>();
+  const out: SocialActivity[] = [];
+
+  for (const docSnap of h2hSnap.docs) {
+    const d = docSnap.data() as Record<string, unknown>;
+    const st = String(d.status ?? '');
+    if (st === 'DECLINED' || st === 'CANCELLED') continue;
+
+    const challengerUid = String(d.challengerUserId ?? '');
+    const originalUid = String(d.originalUserId ?? '');
+    if (!challengerUid || !originalUid) continue;
+
+    const chF = await friendFor(challengerUid, fCache);
+    const orF = await friendFor(originalUid, fCache);
+    const chName = chF?.name ?? 'Player';
+    const orName = orF?.name ?? 'Player';
+
+    const mt = String(d.marketTitle ?? 'Matchup');
+    const sortKey =
+      Math.max(tsMs(d, 'createdAt'), tsMs(d, 'acceptedAt'), tsMs(d, 'settledAt')) || Date.now();
+
+    let action = 'counter-bet update ·';
+    let target = mt;
+    let primaryUid = challengerUid;
+    let primaryName = chName;
+    let primaryF = chF;
+    let peerUid = originalUid;
+    let peerName = orName;
+    let peerF = orF;
+
+    if (st === 'PENDING_ACCEPT') {
+      action = 'challenged';
+      target = `${orName}'s pick · ${mt}`;
+    } else if (st === 'ACCEPTED') {
+      action = 'counter-bet live vs';
+      target = `${orName} · ${mt}`;
+    } else if (st === 'WON_BY_ORIGINAL') {
+      action = 'counter settled · pick held vs';
+      target = `${chName} · ${mt}`;
+      primaryUid = originalUid;
+      primaryName = orName;
+      primaryF = orF;
+      peerUid = challengerUid;
+      peerName = chName;
+      peerF = chF;
+    } else if (st === 'WON_BY_CHALLENGER') {
+      action = 'counter settled · fader won vs';
+      target = `${orName} · ${mt}`;
+      primaryUid = challengerUid;
+      primaryName = chName;
+      primaryF = chF;
+      peerUid = originalUid;
+      peerName = orName;
+      peerF = orF;
+    } else if (st === 'PUSH') {
+      action = 'counter-bet pushed ·';
+      target = `${chName} vs ${orName} · ${mt}`;
+    }
+
+    out.push({
+      id: `peer-h2h-${docSnap.id}`,
+      userId: primaryUid,
+      userName: primaryName,
+      userAvatar: primaryName.slice(0, 2).toUpperCase(),
+      userAvatarUrl: primaryF?.avatarUrl,
+      userProfileBackgroundUrl: primaryF?.profileBackgroundUrl,
+      action,
+      target,
+      timestamp: labelTime(d),
+      sortKey,
+      activityKind: 'peer_counter' as SocialActivityKind,
+      peerUserId: peerUid,
+      peerUserName: peerName,
+      peerUserAvatar: peerName.slice(0, 2).toUpperCase(),
+      peerUserAvatarUrl: peerF?.avatarUrl,
+      peerH2hId: docSnap.id,
+    });
+  }
+
+  for (const docSnap of gcSnap.docs) {
+    const d = docSnap.data() as Record<string, unknown>;
+    const st = String(d.status ?? '');
+    if (st === 'DECLINED' || st === 'CANCELLED' || st === 'EXPIRED') continue;
+
+    const challengerUid = String(d.challengerUid ?? '');
+    const opponentUid = String(d.opponentUid ?? '');
+    if (!challengerUid || !opponentUid) continue;
+
+    const chF = await friendFor(challengerUid, fCache);
+    const opF = await friendFor(opponentUid, fCache);
+    const chName = chF?.name ?? 'Player';
+    const opName = opF?.name ?? 'Player';
+
+    const mt = String(d.marketTitle ?? 'Game');
+    const sortKey =
+      Math.max(tsMs(d, 'createdAt'), tsMs(d, 'acceptedAt'), tsMs(d, 'settledAt')) || Date.now();
+
+    let action = 'game challenge ·';
+    let target = mt;
+    let primaryUid = challengerUid;
+    let primaryName = chName;
+    let primaryF = chF;
+    let peerUid = opponentUid;
+    let peerName = opName;
+    let peerF = opF;
+
+    if (st === 'PENDING_ACCEPT') {
+      action = 'sent a game challenge to';
+      target = `${opName} · ${mt}`;
+    } else if (st === 'ACTIVE') {
+      action = 'game challenge live vs';
+      target = `${opName} · ${mt}`;
+    } else if (st === 'COMPLETED_CHALLENGER') {
+      action = 'won a game challenge vs';
+      target = `${opName} · ${mt}`;
+      primaryUid = challengerUid;
+      primaryName = chName;
+      primaryF = chF;
+      peerUid = opponentUid;
+      peerName = opName;
+      peerF = opF;
+    } else if (st === 'COMPLETED_OPPONENT') {
+      action = 'won a game challenge vs';
+      target = `${chName} · ${mt}`;
+      primaryUid = opponentUid;
+      primaryName = opName;
+      primaryF = opF;
+      peerUid = challengerUid;
+      peerName = chName;
+      peerF = chF;
+    } else if (st === 'PUSH') {
+      action = 'game challenge pushed ·';
+      target = `${chName} vs ${opName} · ${mt}`;
+    }
+
+    out.push({
+      id: `peer-gc-${docSnap.id}`,
+      userId: primaryUid,
+      userName: primaryName,
+      userAvatar: primaryName.slice(0, 2).toUpperCase(),
+      userAvatarUrl: primaryF?.avatarUrl,
+      userProfileBackgroundUrl: primaryF?.profileBackgroundUrl,
+      action,
+      target,
+      timestamp: labelTime(d),
+      sortKey,
+      activityKind: 'peer_challenge' as SocialActivityKind,
+      peerUserId: peerUid,
+      peerUserName: peerName,
+      peerUserAvatar: peerName.slice(0, 2).toUpperCase(),
+      peerUserAvatarUrl: peerF?.avatarUrl,
+      peerChallengeId: docSnap.id,
+    });
+  }
+
+  out.sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0));
+  return out;
+}
+
+/**
+ * Streams recent counter-bets and game challenges into SocialActivity-shaped rows.
+ */
+export function subscribeToPeerActivityFeed(
+  onUpdate: (rows: SocialActivity[]) => void,
+  onError?: (err: Error) => void,
+): () => void {
+  let cancelled = false;
+  let h2hSnap: QuerySnapshot | null = null;
+  let gcSnap: QuerySnapshot | null = null;
+
+  const emit = () => {
+    if (cancelled || !h2hSnap || !gcSnap) return;
+    void buildPeerRowsFromSnapshots(h2hSnap, gcSnap)
+      .then((rows) => {
+        if (!cancelled) onUpdate(rows);
+      })
+      .catch((err) => {
+        if (!cancelled && onError) onError(err as Error);
+        else if (!cancelled) console.error('buildPeerRowsFromSnapshots', err);
+      });
+  };
+
+  const qh = query(collection(db, H2H), orderBy('createdAt', 'desc'), limit(PEER_FEED_LIMIT));
+  const qg = query(collection(db, GC), orderBy('createdAt', 'desc'), limit(PEER_FEED_LIMIT));
+
+  const uh = onSnapshot(
+    qh,
+    (snap) => {
+      h2hSnap = snap;
+      emit();
+    },
+    (err) => {
+      if (!cancelled && onError) onError(err);
+      else console.error('peerActivityFeed h2h', err);
+    },
+  );
+
+  const ug = onSnapshot(
+    qg,
+    (snap) => {
+      gcSnap = snap;
+      emit();
+    },
+    (err) => {
+      if (!cancelled && onError) onError(err);
+      else console.error('peerActivityFeed gc', err);
+    },
+  );
+
+  return () => {
+    cancelled = true;
+    uh();
+    ug();
+  };
+}

--- a/services/settleApiOddsBets.ts
+++ b/services/settleApiOddsBets.ts
@@ -1,0 +1,94 @@
+/**
+ * Client-driven settlement for Odds API singles and parlays using the /scores endpoint.
+ * Mock NFL markets (`mock-*`) are excluded; they use `settleUserMockNflGameBets`.
+ */
+
+import { gradeOddsApiSelection } from './apiOddsGrading';
+import { fetchOddsApiScores } from './oddsApiScores';
+import { getBets, recordParlayLegResult, settleBet } from './dbOps';
+import type { Bet } from '@/models';
+
+function isMockMarketId(id: string): boolean {
+  return id.startsWith('mock-');
+}
+
+function collectSportKeysFromPending(pending: Bet[]): Set<string> {
+  const sportKeys = new Set<string>();
+  for (const bet of pending) {
+    if (bet.betType === 'parlay') {
+      for (const leg of bet.parlayLegs ?? []) {
+        if (!leg.sportKey || isMockMarketId(leg.marketId)) continue;
+        sportKeys.add(leg.sportKey);
+      }
+    } else {
+      if (!bet.sportKey || isMockMarketId(bet.marketId)) continue;
+      sportKeys.add(bet.sportKey);
+    }
+  }
+  return sportKeys;
+}
+
+/**
+ * Fetches recent final scores per involved sport and settles any pending API bets.
+ * Safe to call on an interval; leg + bet updates are idempotent server-side.
+ */
+export async function settlePendingApiOddsBetsForUser(uid: string): Promise<void> {
+  if (!uid) return;
+
+  const bets = await getBets(uid);
+  const pending = bets.filter((b) => (b.status ?? 'PENDING') === 'PENDING');
+  if (pending.length === 0) return;
+
+  const sportKeys = collectSportKeysFromPending(pending);
+  if (sportKeys.size === 0) return;
+
+  const scoresByEventId = new Map<string, import('./oddsApiScores').OddsApiScoreEvent>();
+  for (const sk of sportKeys) {
+    try {
+      const events = await fetchOddsApiScores(sk, 3);
+      for (const e of events) {
+        if (e.completed && Array.isArray(e.scores) && e.scores.length >= 2) {
+          scoresByEventId.set(e.id, e);
+        }
+      }
+    } catch {
+      /* quota / network */
+    }
+  }
+  if (scoresByEventId.size === 0) return;
+
+  for (const bet of pending) {
+    try {
+      if (bet.betType === 'parlay') {
+        const legs = bet.parlayLegs ?? [];
+        for (let idx = 0; idx < legs.length; idx++) {
+          const leg = legs[idx];
+          if (!leg.sportKey || isMockMarketId(leg.marketId)) continue;
+          if (leg.result && leg.result !== 'PENDING') continue;
+          const event = scoresByEventId.get(leg.marketId);
+          if (!event) continue;
+          const result = gradeOddsApiSelection(
+            { label: leg.optionLabel, marketKey: leg.marketKey },
+            event,
+          );
+          if (result !== null) {
+            await recordParlayLegResult(bet.id, idx, result);
+          }
+        }
+      } else {
+        if (!bet.sportKey || isMockMarketId(bet.marketId)) continue;
+        const event = scoresByEventId.get(bet.marketId);
+        if (!event) continue;
+        const result = gradeOddsApiSelection(
+          { label: bet.optionLabel, marketKey: bet.pickedMarketKey },
+          event,
+        );
+        if (result !== null) {
+          await settleBet(bet, result);
+        }
+      }
+    } catch {
+      /* continue */
+    }
+  }
+}

--- a/viewModels/useBettingViewModel.ts
+++ b/viewModels/useBettingViewModel.ts
@@ -9,6 +9,7 @@ import {
   listenForChange,
   subscribeToUserBets,
 } from '@/services/dbOps';
+import { settlePendingApiOddsBetsForUser } from '@/services/settleApiOddsBets';
 import { BoostType } from '@/services/dbOps';
 import { validateParlayAdd } from '@/services/parlayRules';
 
@@ -97,6 +98,19 @@ export function useBettingViewModel() {
     };
   }, [localStorage.getItem("userEmail")]);
 
+  // Odds API singles + parlays: poll /scores via proxy and settle completed events.
+  useEffect(() => {
+    const uid = localStorage.getItem('uid');
+    if (!uid) return;
+
+    void settlePendingApiOddsBetsForUser(uid);
+    const id = window.setInterval(() => {
+      const u = localStorage.getItem('uid');
+      if (u) void settlePendingApiOddsBetsForUser(u);
+    }, 90_000);
+    return () => window.clearInterval(id);
+  }, [localStorage.getItem('userEmail')]);
+
   /**
    * Places a bet, optionally with a weekly boost applied.
    * The boost is saved onto the bet doc and marked used atomically in Firestore.
@@ -184,6 +198,7 @@ export function useBettingViewModel() {
       parlayLegs,
       eventId:         singleEventId,
       sportKey:        singleSportKey,
+      pickedMarketKey: isParlayBet ? undefined : betSelection.option.marketKey ?? 'h2h',
       eventStartsAt:   singleEventStartsAt,
     };
 
@@ -289,6 +304,13 @@ export function useBettingViewModel() {
     });
   }, [flashParlayError]);
 
+  const focusQueuedSelection = useCallback((market: Market, option: MarketOption) => {
+    const key = `${market.id}:${option.id}`;
+    const exists = parlaySelections.some((sel) => `${sel.market.id}:${sel.option.id}` === key);
+    if (!exists) return;
+    setBetSelection({ market, option });
+  }, [parlaySelections]);
+
   return {
     balance,
     activeBets,
@@ -301,5 +323,6 @@ export function useBettingViewModel() {
     handleDailyBonus,
     clearBetSelection,
     selectBet,
+    focusQueuedSelection,
   };
 }

--- a/viewModels/useBettingViewModel.ts
+++ b/viewModels/useBettingViewModel.ts
@@ -10,6 +10,7 @@ import {
   subscribeToUserBets,
 } from '@/services/dbOps';
 import { settlePendingApiOddsBetsForUser } from '@/services/settleApiOddsBets';
+import { settleActiveGameChallengesGlobal } from '@/services/gameChallenges';
 import { BoostType } from '@/services/dbOps';
 import { validateParlayAdd } from '@/services/parlayRules';
 
@@ -104,9 +105,11 @@ export function useBettingViewModel() {
     if (!uid) return;
 
     void settlePendingApiOddsBetsForUser(uid);
+    void settleActiveGameChallengesGlobal();
     const id = window.setInterval(() => {
       const u = localStorage.getItem('uid');
       if (u) void settlePendingApiOddsBetsForUser(u);
+      void settleActiveGameChallengesGlobal();
     }, 90_000);
     return () => window.clearInterval(id);
   }, [localStorage.getItem('userEmail')]);

--- a/viewModels/useBettingViewModel.ts
+++ b/viewModels/useBettingViewModel.ts
@@ -121,24 +121,36 @@ export function useBettingViewModel() {
       betType: 'single' | 'parlay' = 'single',
       activeBoost: BoostType | null = null,
       onBoostUsed?: () => void,
+      /** When set, place this queued pick as a single (removes it from the slip on success). */
+      singleTarget?: BetSelection | null,
   ) => {
     console.log('handlePlaceBet called, activeBoost:', activeBoost);
-    if (!betSelection || isPlacingBet) return;
+    if (isPlacingBet) return;
+
+    const isParlayBet = betType === 'parlay';
+    const singlePick = !isParlayBet ? (singleTarget ?? betSelection) : null;
+    if (!isParlayBet && !singlePick) return;
+    if (isParlayBet && !betSelection) return;
 
     // Defensive lock: mock markets are bettable only while UPCOMING.
     // If a mock game finalized after selection but before checkout, remove it.
     const isClosedMock = (m: Market) => m.sport_key === 'football_nfl_mock' && m.status === 'CLOSED';
-    if (isClosedMock(betSelection.market)) {
+    const mockAnchor = isParlayBet ? betSelection! : singlePick!;
+    if (isClosedMock(mockAnchor.market)) {
       setParlaySelections((prev) =>
-        prev.filter((sel) => `${sel.market.id}:${sel.option.id}` !== `${betSelection.market.id}:${betSelection.option.id}`)
+        prev.filter((sel) => `${sel.market.id}:${sel.option.id}` !== `${mockAnchor.market.id}:${mockAnchor.option.id}`)
       );
-      setBetSelection(null);
+      setBetSelection((cur) => {
+        if (!cur) return null;
+        if (`${cur.market.id}:${cur.option.id}` === `${mockAnchor.market.id}:${mockAnchor.option.id}`) return null;
+        return cur;
+      });
       return;
     }
     const staleParlayMockLegs = parlaySelections.filter((sel) => isClosedMock(sel.market));
     if (staleParlayMockLegs.length > 0) {
       setParlaySelections((prev) => prev.filter((sel) => !isClosedMock(sel.market)));
-      if (isClosedMock(betSelection.market)) setBetSelection(null);
+      if (betSelection && isClosedMock(betSelection.market)) setBetSelection(null);
       return;
     }
 
@@ -146,19 +158,18 @@ export function useBettingViewModel() {
     if (!uid) return;
     if (!Number.isFinite(stake) || stake <= 0 || stake > balance) return;
 
-    const isParlayBet = betType === 'parlay';
     const parlayCount = parlaySelections.length;
     if (isParlayBet && parlayCount < 2) return;
 
     const parlayOdds = parlaySelections.reduce((acc, s) => acc * s.option.odds, 1);
-    const resolvedOdds = isParlayBet ? parlayOdds : betSelection.option.odds;
+    const resolvedOdds = isParlayBet ? parlayOdds : singlePick!.option.odds;
     const resolvedMarketId = isParlayBet
         ? `parlay:${parlaySelections.map((s) => s.market.id).join('|')}`
-        : betSelection.market.id;
+        : singlePick!.market.id;
     const resolvedMarketTitle = isParlayBet
         ? parlaySelections.map((s) => s.market.title).join(' | ')
-        : betSelection.market.title;
-    const resolvedOptionLabel = isParlayBet ? `${parlayCount}-Leg Parlay` : betSelection.option.label;
+        : singlePick!.market.title;
+    const resolvedOptionLabel = isParlayBet ? `${parlayCount}-Leg Parlay` : singlePick!.option.label;
     const parlayLegs = isParlayBet
         ? parlaySelections.map((s) => ({
           marketId:    s.market.id,
@@ -174,12 +185,12 @@ export function useBettingViewModel() {
     // For singles, capture the underlying event so head-to-head proposals can
     // enforce a "no fades after kickoff" lock. Parlays don't expose a single
     // event, so leave these fields unset (H2H disallows parlays in v1).
-    const singleEventId       = isParlayBet ? undefined : betSelection.market.id;
-    const singleSportKey      = isParlayBet ? undefined : betSelection.market.sport_key;
+    const singleEventId       = isParlayBet ? undefined : singlePick!.market.id;
+    const singleSportKey      = isParlayBet ? undefined : singlePick!.market.sport_key;
     const singleEventStartsAt = isParlayBet
         ? undefined
         : (() => {
-            const raw = betSelection.market.startTime;
+            const raw = singlePick!.market.startTime;
             if (!raw) return undefined;
             const parsed = new Date(raw);
             return Number.isNaN(parsed.getTime()) ? undefined : parsed;
@@ -198,7 +209,7 @@ export function useBettingViewModel() {
       parlayLegs,
       eventId:         singleEventId,
       sportKey:        singleSportKey,
-      pickedMarketKey: isParlayBet ? undefined : betSelection.option.marketKey ?? 'h2h',
+      pickedMarketKey: isParlayBet ? undefined : singlePick!.option.marketKey ?? 'h2h',
       eventStartsAt:   singleEventStartsAt,
     };
 
@@ -216,14 +227,21 @@ export function useBettingViewModel() {
         // off `parlaySelections.length >= 2`; without this, the same parlay
         // legs sit in the slip post-placement and a second click would place
         // a duplicate bet.
-        setBetSelection(null);
         if (isParlayBet) {
+          setBetSelection(null);
           setParlaySelections([]);
           setParlayRuleError(null);
           if (parlayErrorTimerRef.current) {
             clearTimeout(parlayErrorTimerRef.current);
             parlayErrorTimerRef.current = null;
           }
+        } else {
+          const placedKey = `${singlePick!.market.id}:${singlePick!.option.id}`;
+          setParlaySelections((prev) => {
+            const next = prev.filter((s) => `${s.market.id}:${s.option.id}` !== placedKey);
+            setBetSelection(next[next.length - 1] ?? null);
+            return next;
+          });
         }
         // Clear the boost after successful placement
         onBoostUsed?.();

--- a/viewModels/useDashboardViewModel.ts
+++ b/viewModels/useDashboardViewModel.ts
@@ -12,7 +12,7 @@ import {
   type UserThemeMode,
   subscribeToCommunityActivity,
   subscribeToFriendRequests,
-  subscribeToFriends
+  subscribeToFriends,
 } from '../services/dbOps';
 
 /**
@@ -117,10 +117,6 @@ export function useDashboardViewModel(auth: AuthViewModel) {
     };
   }, [auth.userEmail]);
 
-  const handleChallenge = useCallback((friend: Friend) => {
-    alert(`Challenge request sent to ${friend.name}! Head-to-head competition initiated.`);
-  }, []);
-
   const updateThemeMode = useCallback(async (nextThemeMode: UserThemeMode) => {
     if (themeMode === nextThemeMode) return;
     const uid = typeof localStorage !== 'undefined' ? localStorage.getItem('uid') : null;
@@ -148,7 +144,6 @@ export function useDashboardViewModel(auth: AuthViewModel) {
     markets,
     view,
     setView,
-    handleChallenge,
     leaderboardEntries,
     friends: friends,
     activity: activities,

--- a/viewModels/useDashboardViewModel.ts
+++ b/viewModels/useDashboardViewModel.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import type {Bet, Friend, LeaderboardEntry, SocialActivity} from '../models';
 import { useBettingViewModel } from './useBettingViewModel';
 import { useMarketsViewModel } from './useMarketsViewModel';
@@ -14,6 +14,8 @@ import {
   subscribeToFriendRequests,
   subscribeToFriends,
 } from '../services/dbOps';
+import { subscribeToPeerActivityFeed } from '@/services/peerActivityFeed';
+import { mergeActivityFeeds } from '@/lib/mergeActivityFeeds';
 
 /**
  * Composes betting + markets + auth for DashboardView.
@@ -33,7 +35,8 @@ export function useDashboardViewModel(auth: AuthViewModel) {
 
   const [friends, setFriends] = useState<Friend[]>([]);
   const [betList, setBetList] = useState<Bet[]>([]);
-  const [activities, setActivities] = useState<SocialActivity[]>([])
+  const [betActivities, setBetActivities] = useState<SocialActivity[]>([]);
+  const [peerActivities, setPeerActivities] = useState<SocialActivity[]>([]);
   const [view, setView] = useState<DashboardView>('MARKETS');
   const [leaderboardEntries, setLeaderboardEntries] = useState<LeaderboardEntry[]>([]);
   const [friendRequests, setFriendRequests] = useState<FriendRequest[]>([]);
@@ -46,7 +49,7 @@ export function useDashboardViewModel(auth: AuthViewModel) {
   useEffect(() => {
     const unsubActivity = subscribeToCommunityActivity(
       ({ activities, bets }) => {
-        setActivities(activities);
+        setBetActivities(activities);
         setBetList(bets);
       },
       (err) => {
@@ -57,6 +60,19 @@ export function useDashboardViewModel(auth: AuthViewModel) {
       unsubActivity();
     };
   }, []);
+
+  useEffect(() => {
+    const unsubPeer = subscribeToPeerActivityFeed(
+      (rows) => setPeerActivities(rows),
+      (err) => console.error('Peer activity feed failed', err),
+    );
+    return () => unsubPeer();
+  }, []);
+
+  const activities = useMemo(
+    () => mergeActivityFeeds(betActivities, peerActivities, 60),
+    [betActivities, peerActivities],
+  );
 
   // Everything below depends on the *current* user (friend requests inbox,
   // profile fields, friends list, theme, leaderboard "isCurrentUser" flag).
@@ -74,6 +90,8 @@ export function useDashboardViewModel(auth: AuthViewModel) {
       setUserName(undefined);
       setUserPrivacy(false);
       setLeaderboardEntries([]);
+      setPeerActivities([]);
+      setBetActivities([]);
       return;
     }
 

--- a/viewModels/useGameChallengesInboxViewModel.ts
+++ b/viewModels/useGameChallengesInboxViewModel.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { collection, onSnapshot, query, where, type DocumentData, type QueryDocumentSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants';
+import {
+  acceptGameChallenge,
+  cancelGameChallenge,
+  declineGameChallenge,
+  mapGameChallengeDoc,
+  type GameChallengeDoc,
+  type GameChallengeStatus,
+} from '@/services/gameChallenges';
+
+const GC_COL = 'gameChallenges';
+
+/**
+ * Realtime game-challenge rows for the Head-to-Head inbox (same buckets as counter-bets).
+ */
+export function useGameChallengesInboxViewModel(currentUserId: string | null) {
+  const [items, setItems] = useState<GameChallengeDoc[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const challDocsRef = useRef<QueryDocumentSnapshot<DocumentData>[]>([]);
+  const oppDocsRef = useRef<QueryDocumentSnapshot<DocumentData>[]>([]);
+
+  const flush = useCallback(() => {
+    const merged = new Map<string, GameChallengeDoc>();
+    for (const d of challDocsRef.current) {
+      merged.set(d.id, mapGameChallengeDoc(d.id, d.data()));
+    }
+    for (const d of oppDocsRef.current) {
+      merged.set(d.id, mapGameChallengeDoc(d.id, d.data()));
+    }
+    const all = [...merged.values()].sort(
+      (a, b) => b.createdAt.toMillis() - a.createdAt.toMillis(),
+    );
+    setItems(all);
+    setLoading(false);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!currentUserId) {
+      challDocsRef.current = [];
+      oppDocsRef.current = [];
+      setItems([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+
+    const qChall = query(collection(db, GC_COL), where('challengerUid', '==', currentUserId));
+    const qOpp = query(collection(db, GC_COL), where('opponentUid', '==', currentUserId));
+
+    const unsubChall = onSnapshot(
+      qChall,
+      (snap) => {
+        challDocsRef.current = snap.docs;
+        flush();
+      },
+      (e) => {
+        console.error('gameChallenges challenger listener', e);
+        setError(e.message);
+        setLoading(false);
+      },
+    );
+
+    const unsubOpp = onSnapshot(
+      qOpp,
+      (snap) => {
+        oppDocsRef.current = snap.docs;
+        flush();
+      },
+      (e) => {
+        console.error('gameChallenges opponent listener', e);
+        setError(e.message);
+        setLoading(false);
+      },
+    );
+
+    return () => {
+      unsubChall();
+      unsubOpp();
+    };
+  }, [currentUserId, flush]);
+
+  const buckets = useMemo(() => {
+    const incoming: GameChallengeDoc[] = [];
+    const outgoing: GameChallengeDoc[] = [];
+    const active: GameChallengeDoc[] = [];
+    const history: GameChallengeDoc[] = [];
+    const uid = currentUserId;
+
+    items.forEach((gc) => {
+      const st: GameChallengeStatus = gc.status;
+      if (st === 'PENDING_ACCEPT') {
+        if (gc.opponentUid === uid) incoming.push(gc);
+        if (gc.challengerUid === uid) outgoing.push(gc);
+      } else if (st === 'ACTIVE') {
+        active.push(gc);
+      } else {
+        history.push(gc);
+      }
+    });
+    return { incoming, outgoing, active, history };
+  }, [items, currentUserId]);
+
+  const opponentLabel = useCallback(
+    (gc: GameChallengeDoc): string => {
+      if (!currentUserId) return 'Peer';
+      if (gc.challengerUid === currentUserId) {
+        return gc.opponentName?.trim() || gc.opponentUid.slice(0, 8);
+      }
+      return gc.challengerName?.trim() || gc.challengerUid.slice(0, 8);
+    },
+    [currentUserId],
+  );
+
+  const accept = useCallback(
+    async (challengeId: string) => {
+      if (!currentUserId) return { success: false as const, error: 'USER_NOT_FOUND' };
+      return acceptGameChallenge(challengeId, currentUserId);
+    },
+    [currentUserId],
+  );
+
+  const decline = useCallback(
+    async (challengeId: string) => {
+      if (!currentUserId) return { success: false as const, error: 'USER_NOT_FOUND' };
+      return declineGameChallenge(challengeId, currentUserId);
+    },
+    [currentUserId],
+  );
+
+  const cancel = useCallback(
+    async (challengeId: string) => {
+      if (!currentUserId) return { success: false as const, error: 'USER_NOT_FOUND' };
+      return cancelGameChallenge(challengeId, currentUserId);
+    },
+    [currentUserId],
+  );
+
+  return {
+    loading,
+    error,
+    buckets,
+    items,
+    opponentLabel,
+    accept,
+    decline,
+    cancel,
+  };
+}

--- a/viewModels/useHeadToHeadViewModel.ts
+++ b/viewModels/useHeadToHeadViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HeadToHead, HeadToHeadStatus } from '../models';
 import {
   acceptHeadToHead,
@@ -7,11 +7,16 @@ import {
   getIncomingHeadToHead,
   getOutgoingHeadToHead,
   getUserName,
+  mapHeadToHead,
   proposeHeadToHead,
   type AcceptHeadToHeadResult,
   type DeclineOrCancelResult,
   type ProposeHeadToHeadResult,
 } from '../services/dbOps';
+import { collection, onSnapshot, query, where, type DocumentData, type QueryDocumentSnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants';
+
+const H2H_COLLECTION = 'headToHead';
 
 /**
  * Manages the current user's Head-to-Head challenges.
@@ -34,6 +39,117 @@ export function useHeadToHeadViewModel(currentUserId: string | null) {
   const [nameByUid, setNameByUid] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const origDocsRef = useRef<QueryDocumentSnapshot<DocumentData>[]>([]);
+  const challDocsRef = useRef<QueryDocumentSnapshot<DocumentData>[]>([]);
+
+  const mergeAndSetItems = useCallback(() => {
+    const merged = new Map<string, HeadToHead>();
+    for (const d of origDocsRef.current) {
+      merged.set(d.id, mapHeadToHead(d.id, d.data()));
+    }
+    for (const d of challDocsRef.current) {
+      merged.set(d.id, mapHeadToHead(d.id, d.data()));
+    }
+    const all = [...merged.values()].sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    );
+    setItems(all);
+    setLoading(false);
+    setError(null);
+
+    if (!currentUserId || all.length === 0) return;
+
+    const opponentUids = new Set<string>();
+    all.forEach((h2h) => {
+      if (h2h.challengerUserId !== currentUserId) opponentUids.add(h2h.challengerUserId);
+      if (h2h.originalUserId !== currentUserId) opponentUids.add(h2h.originalUserId);
+    });
+
+    setNameByUid((prev) => {
+      const missing = [...opponentUids].filter((uid) => !prev[uid]);
+      if (missing.length === 0) return prev;
+      void Promise.all(
+        missing.map(async (uid) => [uid, await getUserName(uid).catch(() => uid)] as const),
+      ).then((fetched) => {
+        setNameByUid((p) => {
+          const next = { ...p };
+          fetched.forEach(([uid, name]) => {
+            next[uid] = name;
+          });
+          return next;
+        });
+      });
+      return prev;
+    });
+  }, [currentUserId]);
+
+  useEffect(() => {
+    if (!currentUserId) {
+      origDocsRef.current = [];
+      challDocsRef.current = [];
+      setItems([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+
+    const qOrig = query(collection(db, H2H_COLLECTION), where('originalUserId', '==', currentUserId));
+    const qChall = query(collection(db, H2H_COLLECTION), where('challengerUserId', '==', currentUserId));
+
+    const unsubOrig = onSnapshot(
+      qOrig,
+      (snap) => {
+        origDocsRef.current = snap.docs;
+        mergeAndSetItems();
+      },
+      (e) => {
+        console.error('headToHead originalUserId listener', e);
+        setError(e.message);
+        setLoading(false);
+      },
+    );
+
+    const unsubChall = onSnapshot(
+      qChall,
+      (snap) => {
+        challDocsRef.current = snap.docs;
+        mergeAndSetItems();
+      },
+      (e) => {
+        console.error('headToHead challengerUserId listener', e);
+        setError(e.message);
+        setLoading(false);
+      },
+    );
+
+    return () => {
+      unsubOrig();
+      unsubChall();
+    };
+  }, [currentUserId, mergeAndSetItems]);
+
+  // ── Bucketing ──────────────────────────────────────────────────
+  const buckets = useMemo(() => {
+    const incoming: HeadToHead[] = [];
+    const outgoing: HeadToHead[] = [];
+    const active: HeadToHead[] = [];
+    const history: HeadToHead[] = [];
+    items.forEach((h2h) => {
+      const isOriginal = h2h.originalUserId === currentUserId;
+      const isChallenger = h2h.challengerUserId === currentUserId;
+      const status: HeadToHeadStatus = h2h.status;
+
+      if (status === 'PENDING_ACCEPT') {
+        if (isOriginal) incoming.push(h2h);
+        if (isChallenger) outgoing.push(h2h);
+      } else if (status === 'ACCEPTED') {
+        active.push(h2h);
+      } else {
+        history.push(h2h);
+      }
+    });
+    return { incoming, outgoing, active, history };
+  }, [items, currentUserId]);
 
   const refresh = useCallback(async () => {
     if (!currentUserId) {
@@ -47,8 +163,6 @@ export function useHeadToHeadViewModel(currentUserId: string | null) {
         getIncomingHeadToHead(currentUserId),
         getOutgoingHeadToHead(currentUserId),
       ]);
-      // Merge and dedupe (a user could in theory appear on both sides if the
-      // collection ever has weird data — stay defensive).
       const merged = new Map<string, HeadToHead>();
       [...incoming, ...outgoing].forEach((h2h) => merged.set(h2h.id, h2h));
       const all = [...merged.values()].sort(
@@ -56,63 +170,35 @@ export function useHeadToHeadViewModel(currentUserId: string | null) {
       );
       setItems(all);
 
-      // Resolve opponent display names. The "opponent" depends on perspective:
-      // for incoming, it's the challenger; for outgoing, it's the original.
       const opponentUids = new Set<string>();
       all.forEach((h2h) => {
         if (h2h.challengerUserId !== currentUserId) opponentUids.add(h2h.challengerUserId);
-        if (h2h.originalUserId   !== currentUserId) opponentUids.add(h2h.originalUserId);
+        if (h2h.originalUserId !== currentUserId) opponentUids.add(h2h.originalUserId);
       });
-      const missing = [...opponentUids].filter((uid) => !nameByUid[uid]);
-      if (missing.length > 0) {
-        const fetched = await Promise.all(
+      setNameByUid((prev) => {
+        const missing = [...opponentUids].filter((uid) => !prev[uid]);
+        if (missing.length === 0) return prev;
+        void Promise.all(
           missing.map(async (uid) => [uid, await getUserName(uid).catch(() => uid)] as const),
-        );
-        setNameByUid((prev) => {
-          const next = { ...prev };
-          fetched.forEach(([uid, name]) => { next[uid] = name; });
-          return next;
+        ).then((fetched) => {
+          setNameByUid((p) => {
+            const next = { ...p };
+            fetched.forEach(([uid, name]) => {
+              next[uid] = name;
+            });
+            return next;
+          });
         });
-      }
+        return prev;
+      });
     } catch (e) {
       console.error('Failed to load head-to-head challenges', e);
       setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setLoading(false);
     }
-  }, [currentUserId, nameByUid]);
-
-  useEffect(() => {
-    void refresh();
-    // We intentionally only depend on currentUserId — refresh's identity
-    // changes when nameByUid mutates, which would cause an infinite loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUserId]);
 
-  // ── Bucketing ──────────────────────────────────────────────────
-  const buckets = useMemo(() => {
-    const incoming: HeadToHead[] = [];
-    const outgoing: HeadToHead[] = [];
-    const active:   HeadToHead[] = [];
-    const history:  HeadToHead[] = [];
-    items.forEach((h2h) => {
-      const isOriginal   = h2h.originalUserId   === currentUserId;
-      const isChallenger = h2h.challengerUserId === currentUserId;
-      const status: HeadToHeadStatus = h2h.status;
-
-      if (status === 'PENDING_ACCEPT') {
-        if (isOriginal)   incoming.push(h2h);
-        if (isChallenger) outgoing.push(h2h);
-      } else if (status === 'ACCEPTED') {
-        active.push(h2h);
-      } else {
-        history.push(h2h);
-      }
-    });
-    return { incoming, outgoing, active, history };
-  }, [items, currentUserId]);
-
-  // ── Action wrappers ────────────────────────────────────────────
   const propose = useCallback(
     async (originalBetId: string): Promise<ProposeHeadToHeadResult> => {
       if (!currentUserId) {

--- a/viewModels/useMarketsViewModel.ts
+++ b/viewModels/useMarketsViewModel.ts
@@ -2,28 +2,10 @@ import { useState, useCallback, useRef, useEffect, useReducer, useMemo } from 'r
 import type { Market } from '../models';
 import { fetchMarketsForSportTab } from '../services/oddsApiService';
 import { SPORT_TABS } from '../models/constants';
+import { marketSearchHaystack, queryMatchesHaystack } from '@/lib/marketSearch';
 
 /** Cap deduped events kept for instant search (memory + stale data tradeoff). */
 const MAX_MARKET_SEARCH_CACHE = 1200;
-
-/** Text used for substring search (teams often appear only on spread/h2h option labels). */
-function marketSearchHaystack(m: Market): string {
-  const parts = [
-    m.title,
-    m.subtitle,
-    m.category,
-    m.sport_key ?? '',
-    ...m.options.map((o) => o.label),
-  ];
-  return parts.join(' ').toLowerCase().replace(/@/g, ' ');
-}
-
-function queryMatchesHaystack(haystack: string, rawQuery: string): boolean {
-  const q = rawQuery.trim().toLowerCase();
-  if (!q) return true;
-  const tokens = q.split(/\s+/).filter(Boolean);
-  return tokens.every((t) => haystack.includes(t));
-}
 
 function mergeIntoSearchCache(cache: Map<string, Market>, incoming: Market[]) {
   for (const m of incoming) {
@@ -149,8 +131,14 @@ export function useMarketsViewModel() {
     return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
   });
 
+  const allCachedMarkets = useMemo(
+    () => Array.from(marketSearchCacheRef.current.values()),
+    [searchCacheTick, markets],
+  );
+
   return {
     markets: displayMarkets,
+    allCachedMarkets,
     sportFilteredMarkets,
     hasSelectedSport: Boolean(sportFilter),
     loading,

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -117,7 +117,13 @@ interface DashboardViewProps {
   leaderboardEntries: LeaderboardEntry[];
   friends: Friend[];
   activity: SocialActivity[];
-  onPlaceBet: (stake: number, betType?: 'single' | 'parlay', boost?: BoostType | null, onBoostUsed?: () => void) => void;
+  onPlaceBet: (
+    stake: number,
+    betType?: 'single' | 'parlay',
+    boost?: BoostType | null,
+    onBoostUsed?: () => void,
+    singleTarget?: { market: Market; option: MarketOption } | null,
+  ) => void;
   onClearBet: () => void;
   onSelectBet: (market: Market, option: MarketOption) => void;
   onFocusQueuedSelection: (market: Market, option: MarketOption) => void;
@@ -424,9 +430,13 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     historyMaxStake !== null ||
     historySort !== 'recent';
 
-  const handlePlaceBetWithBoost = (stake: number, betType?: 'single' | 'parlay') => {
+  const handlePlaceBetWithBoost = (
+    stake: number,
+    betType?: 'single' | 'parlay',
+    singleTarget?: { market: Market; option: MarketOption } | null,
+  ) => {
     console.log('handlePlaceBetWithBoost called, activeBoost:', activeBoost);
-    onPlaceBet(stake, betType, activeBoost, () => setActiveBoost(null));
+    onPlaceBet(stake, betType, activeBoost, () => setActiveBoost(null), singleTarget);
   };
 
   useEffect(() => {
@@ -1014,7 +1024,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                             title={tab}
                             className={`market-top-pill rounded-lg border p-2 flex items-center justify-center text-[10px] font-black transition-all ${
                                 sportPrimarySelected
-                                    ? 'border-blue-500 bg-blue-600/20 text-blue-200'
+                                    ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 text-[#7dd3fc]'
                                     : sportMutedSelected
                                       ? 'border-slate-600 bg-slate-800/70 text-slate-300 ring-1 ring-slate-700/80'
                                       : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
@@ -1031,7 +1041,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         aria-pressed={sportFilter === 'ALL'}
                         className={`market-top-pill rounded-lg border p-2 flex items-center justify-center transition-all ${
                             sportFilter === 'ALL'
-                                ? 'border-blue-500 bg-blue-600/20 text-blue-200'
+                                ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 text-[#7dd3fc]'
                                 : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
                         }`}
                     >
@@ -1129,7 +1139,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                           value={searchQuery}
                           onChange={(e) => onSearchChange(e.target.value)}
                           disabled={!hasSelectedSport}
-                          className="w-full bg-slate-900 border border-slate-800 rounded-xl py-2.5 pl-10 pr-3 outline-none focus:border-blue-500 transition-all text-sm disabled:opacity-60 disabled:cursor-not-allowed"
+                          className="w-full bg-slate-900 border border-slate-800 rounded-xl py-2.5 pl-10 pr-3 outline-none focus:border-[#3FA9F5] transition-all text-sm disabled:opacity-60 disabled:cursor-not-allowed"
                       />
                     </div>
                   </div>
@@ -1156,7 +1166,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                       }}
                                       className={`shrink-0 inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-bold transition-all ${
                                           sportFilter === tab
-                                              ? 'border-violet-400/80 bg-violet-500/20 text-violet-200'
+                                              ? 'border-[#3FA9F5]/80 bg-[#3FA9F5]/15 text-[#7dd3fc]'
                                               : 'border-slate-800 bg-slate-900 text-slate-400 hover:text-slate-200'
                                       }`}
                                   >
@@ -1170,7 +1180,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         {markets.length >= VIEW_ALL_GAMES_VISIBLE_THRESHOLD && (
                           <button
                             type="button"
-                            className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-slate-300 hover:text-blue-300 transition-colors"
+                            className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-slate-300 hover:text-[#7dd3fc] transition-colors"
                           >
                             View All Games <ChevronRight size={14} />
                           </button>
@@ -1200,7 +1210,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         <button
                             onClick={onRetryMarkets}
                             disabled={!hasSelectedSport}
-                            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-xl font-bold transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                            className="inline-flex items-center gap-2 px-4 py-2 bg-[#3FA9F5] hover:bg-[#2e9ae8] text-slate-950 rounded-xl font-bold transition-all disabled:opacity-60 disabled:cursor-not-allowed"
                         >
                           <RefreshCw size={18} /> Retry
                         </button>
@@ -1347,12 +1357,12 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         onClick={() => onSelectBet(mockMarket, opt)}
                                         className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
                                           isMockOptionSelected(game.id, opt.id)
-                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
-                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                            ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 shadow-[0_0_0_1px_rgba(63,169,245,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-[#3FA9F5]/75 hover:bg-[#3FA9F5]/12'
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
+                                        <p className="text-lg leading-none font-semibold text-[#3FA9F5]">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1367,12 +1377,12 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         onClick={() => onSelectBet(mockMarket, opt)}
                                         className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
                                           isMockOptionSelected(game.id, opt.id)
-                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
-                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                            ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 shadow-[0_0_0_1px_rgba(63,169,245,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-[#3FA9F5]/75 hover:bg-[#3FA9F5]/12'
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
+                                        <p className="text-lg leading-none font-semibold text-[#3FA9F5]">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1387,12 +1397,12 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         onClick={() => onSelectBet(mockMarket, opt)}
                                         className={`market-odds-btn rounded-md border px-2.5 py-1.5 text-left transition-all ${
                                           isMockOptionSelected(game.id, opt.id)
-                                            ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
-                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                            ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 shadow-[0_0_0_1px_rgba(63,169,245,0.45)]'
+                                            : 'border-slate-700/90 bg-slate-900/95 hover:border-[#3FA9F5]/75 hover:bg-[#3FA9F5]/12'
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
+                                        <p className="text-lg leading-none font-semibold text-[#3FA9F5]">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1467,12 +1477,12 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                                       onClick={() => onSelectBet(market, opt)}
                                                       className={`market-odds-btn w-full rounded-md border px-2.5 py-1.5 text-left transition-all ${
                                                           isOptionSelected(market, opt)
-                                                              ? 'border-violet-400 bg-violet-600/20 shadow-[0_0_0_1px_rgba(167,139,250,0.45)]'
-                                                              : 'border-slate-700/90 bg-slate-900/95 hover:border-blue-500/80 hover:bg-blue-600/15'
+                                                              ? 'border-[#3FA9F5] bg-[#3FA9F5]/15 shadow-[0_0_0_1px_rgba(63,169,245,0.45)]'
+                                                              : 'border-slate-700/90 bg-slate-900/95 hover:border-[#3FA9F5]/75 hover:bg-[#3FA9F5]/12'
                                                       }`}
                                                   >
                                                     <p className="text-[10px] text-slate-400 truncate">{opt.label}</p>
-                                                    <p className={`text-sm font-semibold ${isOptionSelected(market, opt) ? 'text-violet-200' : 'text-blue-300'}`}>
+                                                    <p className={`text-sm font-semibold ${isOptionSelected(market, opt) ? 'text-[#7dd3fc]' : 'text-[#3FA9F5]'}`}>
                                                       {formatAmericanOddsLine(opt.odds)}
                                                     </p>
                                                   </button>
@@ -1627,14 +1637,18 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                 activeBoost={activeBoost}
                 limitError={null}
                 parlayRuleError={parlayRuleError}
-                onViewAllHistory={() => navigate('/history')}
+                isLightMode={isLightMode}
+                onGoToHistory={() => {
+                  setIsBetSlipCollapsed(true);
+                  navigate('/history');
+                }}
             />
         )}
         {view === 'MARKETS' && isBetSlipCollapsed && (
           <button
             type="button"
             onClick={() => setIsBetSlipCollapsed(false)}
-            className="fixed top-4 right-4 z-50 inline-flex h-11 w-11 items-center justify-center rounded-full border border-violet-400/50 bg-[#171427] text-violet-200 shadow-lg transition-colors hover:bg-[#221b3d]"
+            className="fixed top-4 right-4 z-50 inline-flex h-11 w-11 items-center justify-center rounded-full border border-[#3FA9F5]/50 bg-[#171427] text-[#7dd3fc] shadow-lg transition-colors hover:bg-[#221b3d]"
             title="Open bet slip"
             aria-label="Open bet slip"
           >

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -44,6 +44,14 @@ import type { MockNflGameState } from "@/services/dbOps.ts";
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
 import { computeParlayRollup } from '@/services/parlayRollup';
+import { formatAmericanOddsLine } from '@/lib/oddsAmericanFormat';
+import {
+  mlDecimalsForFavorite,
+  randomSpreadMagnitudeHalf,
+  randomTotalLineHalf,
+  spreadSideDecimals,
+  totalSideDecimals,
+} from '@/lib/mockNflGameGenerator';
 import { WinCelebrationModal } from '../components/WinCelebrationModal';
 
 type DashboardViewType = 'HOME' | 'MARKETS' | 'HISTORY' | 'LEADERBOARD' | 'SOCIAL' | 'PROFILE' | 'HEAD_TO_HEAD' | 'SETTINGS' | 'STORE';
@@ -112,6 +120,7 @@ interface DashboardViewProps {
   onPlaceBet: (stake: number, betType?: 'single' | 'parlay', boost?: BoostType | null, onBoostUsed?: () => void) => void;
   onClearBet: () => void;
   onSelectBet: (market: Market, option: MarketOption) => void;
+  onFocusQueuedSelection: (market: Market, option: MarketOption) => void;
   onDailyBonus: () => void;
   onLogout: () => void;
   onSetView: (view: string) => void;
@@ -156,6 +165,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     onPlaceBet,
     onClearBet,
     onSelectBet,
+    onFocusQueuedSelection,
     onDailyBonus,
     onLogout,
     onSetView,
@@ -193,7 +203,6 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const normalizeSpreadLine = (line: number) => (line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1));
   const pickRandom = <T,>(items: readonly T[]) => items[Math.floor(Math.random() * items.length)];
   const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
-  const decimalOdds = () => Number(randomBetween(1.72, 2.25).toFixed(2));
   const randomWeek = () => Math.floor(randomBetween(1, 19));
 
   const makeMockGame = (idPrefix: string, previous?: MockNflGameState): MockNflGameState => {
@@ -207,20 +216,25 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       guard += 1;
     }
 
-    const spreadMag = Number(randomBetween(1.5, 7.5).toFixed(1));
+    const spreadMag = randomSpreadMagnitudeHalf();
     const awayFavored = Math.random() < 0.5;
     const spreadLine = awayFavored ? -spreadMag : spreadMag;
+    const ml = mlDecimalsForFavorite(awayFavored);
+    const sp = spreadSideDecimals();
+    const tot = totalSideDecimals();
     return {
       id: `${idPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       week: randomWeek(),
       awayTeam,
       homeTeam,
-      awayOdds: decimalOdds(),
-      homeOdds: decimalOdds(),
-      totalOverOdds: decimalOdds(),
-      totalUnderOdds: decimalOdds(),
+      awayOdds: ml.away,
+      homeOdds: ml.home,
+      spreadAwayOdds: sp.away,
+      spreadHomeOdds: sp.home,
+      totalOverOdds: tot.over,
+      totalUnderOdds: tot.under,
       spreadLine,
-      totalLine: Number(randomBetween(39.5, 53.5).toFixed(1)),
+      totalLine: randomTotalLineHalf(),
       status: 'UPCOMING',
       awayScore: null,
       homeScore: null,
@@ -507,8 +521,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     startTime: new Date(game.updatedAtMs).toISOString(),
     status: game.status === 'FINAL' ? 'CLOSED' : 'UPCOMING',
     options: [
-      { id: `${game.id}-spread-away`, label: `${game.awayTeam} ${normalizeSpreadLine(game.spreadLine)}`, odds: game.awayOdds, marketKey: 'spreads' },
-      { id: `${game.id}-spread-home`, label: `${game.homeTeam} ${normalizeSpreadLine(-game.spreadLine)}`, odds: game.homeOdds, marketKey: 'spreads' },
+      { id: `${game.id}-spread-away`, label: `${game.awayTeam} ${normalizeSpreadLine(game.spreadLine)}`, odds: game.spreadAwayOdds ?? game.awayOdds, marketKey: 'spreads' },
+      { id: `${game.id}-spread-home`, label: `${game.homeTeam} ${normalizeSpreadLine(-game.spreadLine)}`, odds: game.spreadHomeOdds ?? game.homeOdds, marketKey: 'spreads' },
       { id: `${game.id}-total-over`, label: `Over ${game.totalLine.toFixed(1)}`, odds: game.totalOverOdds, marketKey: 'totals' },
       { id: `${game.id}-total-under`, label: `Under ${game.totalLine.toFixed(1)}`, odds: game.totalUnderOdds, marketKey: 'totals' },
       { id: `${game.id}-ml-away`, label: game.awayTeam, odds: game.awayOdds, marketKey: 'h2h' },
@@ -1267,7 +1281,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                       )}
                                     </div>
                                     <p className="mt-2 text-[11px] text-slate-400">
-                                      Odds {game.awayOdds.toFixed(2)} / {game.homeOdds.toFixed(2)}
+                                      ML {formatAmericanOddsLine(game.awayOdds)} / {formatAmericanOddsLine(game.homeOdds)}
                                     </p>
                                     <div className="mt-2 space-y-1">
                                       {game.status === 'FINAL' ? (
@@ -1338,7 +1352,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1358,7 +1372,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1378,7 +1392,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                         } ${!bettable ? 'cursor-not-allowed opacity-65' : ''}`}
                                       >
                                         <p className="text-[11px] text-slate-300 truncate">{opt.label}</p>
-                                        <p className="text-lg leading-none font-semibold text-blue-300">{opt.odds.toFixed(2)}</p>
+                                        <p className="text-lg leading-none font-semibold text-blue-300">{formatAmericanOddsLine(opt.odds)}</p>
                                       </button>
                                     ))}
                                   </div>
@@ -1459,7 +1473,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                                   >
                                                     <p className="text-[10px] text-slate-400 truncate">{opt.label}</p>
                                                     <p className={`text-sm font-semibold ${isOptionSelected(market, opt) ? 'text-violet-200' : 'text-blue-300'}`}>
-                                                      {opt.odds.toFixed(2)}
+                                                      {formatAmericanOddsLine(opt.odds)}
                                                     </p>
                                                   </button>
                                               ) : (
@@ -1608,6 +1622,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                 onPlaceBet={handlePlaceBetWithBoost}
                 onClose={() => setIsBetSlipCollapsed(true)}
                 onSelectBet={onSelectBet}
+                onFocusSelection={onFocusQueuedSelection}
                 balance={balance}
                 activeBoost={activeBoost}
                 limitError={null}

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -40,23 +40,33 @@ import { profileBackgroundForUid } from '@/models/profileBackgrounds';
 import { Swords, ShoppingBag } from 'lucide-react';
 import type { LeaderboardEntry, Friend, SocialActivity } from '../models';
 import { BoostType } from '@/services/dbOps.ts';
-import { DAILY_BONUS_AMOUNT, MOCK_NFL_TEAM_POOL, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
-import { FriendRequest, getBets, getUserMoney, getUserMockNflGames, listenForChange, saveUserMockNflGames, settleUserMockNflGameBets } from "@/services/dbOps.ts";
-import type { MockNflGameState } from "@/services/dbOps.ts";
+import { DAILY_BONUS_AMOUNT, VIEW_ALL_GAMES_VISIBLE_THRESHOLD } from '../models/constants';
+import {
+  FriendRequest,
+  ensureGlobalMockNflBoardSeeded,
+  getBets,
+  getUserMoney,
+  listenForChange,
+  makeDmThreadId,
+  saveGlobalMockNflGames,
+  sendDirectMessage,
+  settleAllUsersForMockNflGame,
+  subscribeToGlobalMockNflGames,
+} from "@/services/dbOps.ts";
+import type { MockNflGameState } from '@/models';
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
 import { buildMockNflMarketFromGameState } from '@/lib/mockNflMarketFromState';
-import { reconcileMockGameChallengesAfterUserGameFinal } from '@/services/gameChallenges';
+import { reconcileMockGameChallengesAfterGlobalMockFinal } from '@/services/gameChallenges';
 import { computeParlayRollup } from '@/services/parlayRollup';
 import { formatAmericanOddsLine } from '@/lib/oddsAmericanFormat';
+import { createRandomMockNflGameState } from '@/lib/globalMockNflBoard';
 import {
-  mlDecimalsForFavorite,
-  randomSpreadMagnitudeHalf,
-  randomTotalLineHalf,
-  spreadSideDecimals,
-  totalSideDecimals,
-} from '@/lib/mockNflGameGenerator';
-import { WinCelebrationModal } from '../components/WinCelebrationModal';
+  WinCelebrationModal,
+  type WinCelebrationPayload,
+} from '../components/WinCelebrationModal';
+import { collection, onSnapshot, query, where, type QuerySnapshot } from 'firebase/firestore';
+import { db } from '@/models/constants.ts';
 
 type DashboardViewType = 'HOME' | 'MARKETS' | 'HISTORY' | 'LEADERBOARD' | 'SOCIAL' | 'PROFILE' | 'HEAD_TO_HEAD' | 'SETTINGS' | 'STORE';
 
@@ -144,6 +154,80 @@ interface DashboardViewProps {
   onThemeModeChange: (mode: UserThemeMode) => void;
 }
 
+const H2H_COL = 'headToHead';
+const GC_COL = 'gameChallenges';
+
+type QueuedCelebration = { key: string; payload: WinCelebrationPayload };
+
+function readStringSetFromLs(storageKey: string): Set<string> {
+  if (typeof localStorage === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(storageKey);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeStringSetToLs(storageKey: string, ids: Set<string>) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(storageKey, JSON.stringify(Array.from(ids)));
+}
+
+function userWonH2h(
+  data: { status?: unknown; originalUserId?: unknown; challengerUserId?: unknown },
+  uid: string,
+): boolean {
+  const status = String(data.status ?? '');
+  const orig = String(data.originalUserId ?? '');
+  const chall = String(data.challengerUserId ?? '');
+  return (status === 'WON_BY_ORIGINAL' && uid === orig) || (status === 'WON_BY_CHALLENGER' && uid === chall);
+}
+
+function h2hDocToWinPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const orig = String(data.originalUserId ?? '');
+  const chall = String(data.challengerUserId ?? '');
+  const opponent = uid === orig ? chall : orig;
+  return {
+    kind: 'h2h_win',
+    opponentUid: opponent,
+    marketTitle: String(data.marketTitle ?? ''),
+    pickLabel: String(data.originalSide ?? ''),
+    totalEscrow: (Number(data.originalStake) || 0) + (Number(data.challengerStake) || 0),
+    originalBetId: String(data.originalBetId ?? ''),
+  };
+}
+
+function userWonGc(
+  data: { status?: unknown; challengerUid?: unknown; opponentUid?: unknown },
+  uid: string,
+): boolean {
+  const status = String(data.status ?? '');
+  const chall = String(data.challengerUid ?? '');
+  const opp = String(data.opponentUid ?? '');
+  return (status === 'COMPLETED_CHALLENGER' && uid === chall) || (status === 'COMPLETED_OPPONENT' && uid === opp);
+}
+
+function gcDocToWinPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const chall = String(data.challengerUid ?? '');
+  const opp = String(data.opponentUid ?? '');
+  if (String(data.status ?? '') === 'COMPLETED_CHALLENGER' && uid === chall) {
+    return {
+      kind: 'gc_win',
+      opponentUid: opp,
+      marketTitle: String(data.marketTitle ?? ''),
+      yourPick: String(data.challengerPickLabel ?? ''),
+    };
+  }
+  return {
+    kind: 'gc_win',
+    opponentUid: chall,
+    marketTitle: String(data.marketTitle ?? ''),
+    yourPick: String(data.opponentPickLabel ?? ''),
+  };
+}
+
 export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const {
     userName,
@@ -199,14 +283,24 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     [mockNflGames],
   );
   const [isBetSlipCollapsed, setIsBetSlipCollapsed] = useState(false);
-  const [pendingWinBets, setPendingWinBets] = useState<Bet[]>([]);
-  const [activeWinBet, setActiveWinBet] = useState<Bet | null>(null);
+  const [celebrationQueue, setCelebrationQueue] = useState<QueuedCelebration[]>([]);
+  const [activeCelebration, setActiveCelebration] = useState<QueuedCelebration | null>(null);
   const [challengeFriendTarget, setChallengeFriendTarget] = useState<Friend | null>(null);
   const seenWinningBetIds = useRef<Set<string>>(new Set());
   const hasInitializedWinTracking = useRef(false);
+  const seenH2hWinCelebrationIds = useRef<Set<string>>(new Set());
+  const h2hBootstrapDone = useRef(false);
+  const lastH2hOrigSnap = useRef<QuerySnapshot | null>(null);
+  const lastH2hChallSnap = useRef<QuerySnapshot | null>(null);
+  const seenGcWinCelebrationIds = useRef<Set<string>>(new Set());
+  const gcBootstrapDone = useRef(false);
+  const lastGcChallSnap = useRef<QuerySnapshot | null>(null);
+  const lastGcOppSnap = useRef<QuerySnapshot | null>(null);
 
   const userUid = typeof localStorage !== 'undefined' ? localStorage.getItem('uid') ?? '' : '';
   const seenWinningBetsStorageKey = userUid ? `bethub_seen_winning_bets:${userUid}` : '';
+  const seenH2hWinCelebrationStorageKey = userUid ? `bethub_seen_h2h_win_celebration:${userUid}` : '';
+  const seenGcWinCelebrationStorageKey = userUid ? `bethub_seen_gc_win_celebration:${userUid}` : '';
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -214,78 +308,16 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   }, [isLightMode]);
 
   const normalizeSpreadLine = (line: number) => (line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1));
-  const pickRandom = <T,>(items: readonly T[]) => items[Math.floor(Math.random() * items.length)];
   const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
-  const randomWeek = () => Math.floor(randomBetween(1, 19));
-
-  const makeMockGame = (idPrefix: string, previous?: MockNflGameState): MockNflGameState => {
-    const teamPool = MOCK_NFL_TEAM_POOL;
-    const shouldFlip = Boolean(previous) && Math.random() < 0.5;
-    const awayTeam = shouldFlip && previous ? previous.homeTeam : pickRandom(teamPool);
-    let homeTeam = shouldFlip && previous ? previous.awayTeam : pickRandom(teamPool);
-    let guard = 0;
-    while (homeTeam === awayTeam && guard < 10) {
-      homeTeam = pickRandom(teamPool);
-      guard += 1;
-    }
-
-    const spreadMag = randomSpreadMagnitudeHalf();
-    const awayFavored = Math.random() < 0.5;
-    const spreadLine = awayFavored ? -spreadMag : spreadMag;
-    const ml = mlDecimalsForFavorite(awayFavored);
-    const sp = spreadSideDecimals();
-    const tot = totalSideDecimals();
-    return {
-      id: `${idPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      week: randomWeek(),
-      awayTeam,
-      homeTeam,
-      awayOdds: ml.away,
-      homeOdds: ml.home,
-      spreadAwayOdds: sp.away,
-      spreadHomeOdds: sp.home,
-      totalOverOdds: tot.over,
-      totalUnderOdds: tot.under,
-      spreadLine,
-      totalLine: randomTotalLineHalf(),
-      status: 'UPCOMING',
-      awayScore: null,
-      homeScore: null,
-      winner: null,
-      updatedAtMs: Date.now(),
-    };
-  };
-
-  const ensureMockBoard = (existing: MockNflGameState[]): MockNflGameState[] => {
-    const upcoming = existing.filter((g) => g.status !== 'FINAL');
-    const seeded = [...upcoming];
-    while (seeded.length < 3) {
-      seeded.push(makeMockGame('mock-nfl', seeded[seeded.length - 1]));
-    }
-    return seeded.slice(0, 3);
-  };
 
   useEffect(() => {
-    if (!userUid) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const stored = await getUserMockNflGames(userUid);
-        if (cancelled) return;
-        const board = ensureMockBoard(stored);
-        setMockNflGames(board);
-        await saveUserMockNflGames(userUid, board);
-      } catch (err) {
-        console.error('Failed to load mock NFL games', err);
-        if (cancelled) return;
-        const board = ensureMockBoard([]);
-        setMockNflGames(board);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [userUid]);
+    const unsub = subscribeToGlobalMockNflGames(
+      (games) => setMockNflGames(games),
+      (err) => console.error('Global mock NFL subscription failed', err),
+    );
+    void ensureGlobalMockNflBoardSeeded().catch((e) => console.error('ensureGlobalMockNflBoardSeeded', e));
+    return () => unsub();
+  }, []);
 
   const simulateMockGame = async (gameId: string, mode: 'RANDOM' | 'AWAY' | 'HOME') => {
     let finalizedGame: MockNflGameState | null = null;
@@ -315,24 +347,20 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       return finalized;
     });
     setMockNflGames(next);
-    if (userUid) {
-      await saveUserMockNflGames(userUid, next);
-      if (finalizedGame) {
-        await settleUserMockNflGameBets(userUid, finalizedGame);
-        await reconcileMockGameChallengesAfterUserGameFinal(userUid, finalizedGame);
-      }
+    await saveGlobalMockNflGames(next);
+    if (finalizedGame) {
+      await settleAllUsersForMockNflGame(finalizedGame);
+      await reconcileMockGameChallengesAfterGlobalMockFinal(finalizedGame);
     }
   };
 
   const createNewMockGame = async (gameId: string) => {
     const next = mockNflGames.map((g) => {
       if (g.id !== gameId) return g;
-      return makeMockGame('mock-nfl', g);
+      return createRandomMockNflGameState('mock-nfl', g);
     });
     setMockNflGames(next);
-    if (userUid) {
-      await saveUserMockNflGames(userUid, next);
-    }
+    await saveGlobalMockNflGames(next);
   };
 
   useEffect(() => {
@@ -456,9 +484,21 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   useEffect(() => {
     seenWinningBetIds.current = new Set();
     hasInitializedWinTracking.current = false;
-    setPendingWinBets([]);
-    setActiveWinBet(null);
-  }, [userUid]);
+    seenH2hWinCelebrationIds.current = seenH2hWinCelebrationStorageKey
+      ? readStringSetFromLs(seenH2hWinCelebrationStorageKey)
+      : new Set();
+    seenGcWinCelebrationIds.current = seenGcWinCelebrationStorageKey
+      ? readStringSetFromLs(seenGcWinCelebrationStorageKey)
+      : new Set();
+    h2hBootstrapDone.current = false;
+    gcBootstrapDone.current = false;
+    lastH2hOrigSnap.current = null;
+    lastH2hChallSnap.current = null;
+    lastGcChallSnap.current = null;
+    lastGcOppSnap.current = null;
+    setCelebrationQueue([]);
+    setActiveCelebration(null);
+  }, [userUid, seenH2hWinCelebrationStorageKey, seenGcWinCelebrationStorageKey]);
 
   useEffect(() => {
     if (!userUid) return;
@@ -495,15 +535,166 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
 
     unseen.forEach((bet) => seenWinningBetIds.current.add(bet.id));
     writeStoredSeenIds(seenWinningBetIds.current);
-    setPendingWinBets((prev) => [...prev, ...unseen]);
+    setCelebrationQueue((prev) => {
+      const keys = new Set(prev.map((q) => q.key));
+      const additions: QueuedCelebration[] = unseen
+        .filter((bet) => !keys.has(`bet:${bet.id}`))
+        .map((bet) => ({ key: `bet:${bet.id}`, payload: { kind: 'bet', bet } as const }));
+      return [...prev, ...additions];
+    });
   }, [props.activeBets, seenWinningBetsStorageKey, userUid]);
 
   useEffect(() => {
-    if (activeWinBet || pendingWinBets.length === 0) return;
-    const [next, ...rest] = pendingWinBets;
-    setActiveWinBet(next);
-    setPendingWinBets(rest);
-  }, [activeWinBet, pendingWinBets]);
+    if (activeCelebration || celebrationQueue.length === 0) return;
+    const [next, ...rest] = celebrationQueue;
+    setActiveCelebration(next);
+    setCelebrationQueue(rest);
+  }, [activeCelebration, celebrationQueue]);
+
+  useEffect(() => {
+    if (!userUid || !seenH2hWinCelebrationStorageKey) return;
+
+    const persistH2hSeen = () => writeStringSetToLs(seenH2hWinCelebrationStorageKey, seenH2hWinCelebrationIds.current);
+
+    const tryBootstrapH2h = () => {
+      if (h2hBootstrapDone.current) return;
+      if (!lastH2hOrigSnap.current || !lastH2hChallSnap.current) return;
+      h2hBootstrapDone.current = true;
+      const merged = new Map([...lastH2hOrigSnap.current.docs, ...lastH2hChallSnap.current.docs].map((d) => [d.id, d]));
+      merged.forEach((d) => {
+        const data = d.data() as Record<string, unknown>;
+        if (userWonH2h(data, userUid)) seenH2hWinCelebrationIds.current.add(`h2h_win:${d.id}`);
+      });
+      persistH2hSeen();
+    };
+
+    const qOrig = query(collection(db, H2H_COL), where('originalUserId', '==', userUid));
+    const qChall = query(collection(db, H2H_COL), where('challengerUserId', '==', userUid));
+
+    const unsubOrig = onSnapshot(qOrig, (snap) => {
+      lastH2hOrigSnap.current = snap;
+      tryBootstrapH2h();
+      if (!h2hBootstrapDone.current) return;
+      snap.docChanges().forEach((ch) => {
+        if (ch.type === 'removed') return;
+        const data = ch.doc.data() as Record<string, unknown>;
+        if (!userWonH2h(data, userUid)) return;
+        const dedupe = `h2h_win:${ch.doc.id}`;
+        if (seenH2hWinCelebrationIds.current.has(dedupe)) return;
+        seenH2hWinCelebrationIds.current.add(dedupe);
+        persistH2hSeen();
+        const payload = h2hDocToWinPayload(data, userUid);
+        setCelebrationQueue((prev) =>
+          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
+        );
+      });
+    });
+
+    const unsubChall = onSnapshot(qChall, (snap) => {
+      lastH2hChallSnap.current = snap;
+      tryBootstrapH2h();
+      if (!h2hBootstrapDone.current) return;
+      snap.docChanges().forEach((ch) => {
+        if (ch.type === 'removed') return;
+        const data = ch.doc.data() as Record<string, unknown>;
+        if (!userWonH2h(data, userUid)) return;
+        const dedupe = `h2h_win:${ch.doc.id}`;
+        if (seenH2hWinCelebrationIds.current.has(dedupe)) return;
+        seenH2hWinCelebrationIds.current.add(dedupe);
+        persistH2hSeen();
+        const payload = h2hDocToWinPayload(data, userUid);
+        setCelebrationQueue((prev) =>
+          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
+        );
+      });
+    });
+
+    return () => {
+      unsubOrig();
+      unsubChall();
+    };
+  }, [userUid, seenH2hWinCelebrationStorageKey]);
+
+  useEffect(() => {
+    if (!userUid || !seenGcWinCelebrationStorageKey) return;
+
+    const persistGcSeen = () => writeStringSetToLs(seenGcWinCelebrationStorageKey, seenGcWinCelebrationIds.current);
+
+    const tryBootstrapGc = () => {
+      if (gcBootstrapDone.current) return;
+      if (!lastGcChallSnap.current || !lastGcOppSnap.current) return;
+      gcBootstrapDone.current = true;
+      const merged = new Map([...lastGcChallSnap.current.docs, ...lastGcOppSnap.current.docs].map((d) => [d.id, d]));
+      merged.forEach((d) => {
+        const data = d.data() as Record<string, unknown>;
+        if (userWonGc(data, userUid)) seenGcWinCelebrationIds.current.add(`gc_win:${d.id}`);
+      });
+      persistGcSeen();
+    };
+
+    const qChall = query(collection(db, GC_COL), where('challengerUid', '==', userUid));
+    const qOpp = query(collection(db, GC_COL), where('opponentUid', '==', userUid));
+
+    const unsubChall = onSnapshot(qChall, (snap) => {
+      lastGcChallSnap.current = snap;
+      tryBootstrapGc();
+      if (!gcBootstrapDone.current) return;
+      snap.docChanges().forEach((ch) => {
+        if (ch.type === 'removed') return;
+        const data = ch.doc.data() as Record<string, unknown>;
+        if (!userWonGc(data, userUid)) return;
+        const dedupe = `gc_win:${ch.doc.id}`;
+        if (seenGcWinCelebrationIds.current.has(dedupe)) return;
+        seenGcWinCelebrationIds.current.add(dedupe);
+        persistGcSeen();
+        const payload = gcDocToWinPayload(data, userUid);
+        setCelebrationQueue((prev) =>
+          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
+        );
+      });
+    });
+
+    const unsubOpp = onSnapshot(qOpp, (snap) => {
+      lastGcOppSnap.current = snap;
+      tryBootstrapGc();
+      if (!gcBootstrapDone.current) return;
+      snap.docChanges().forEach((ch) => {
+        if (ch.type === 'removed') return;
+        const data = ch.doc.data() as Record<string, unknown>;
+        if (!userWonGc(data, userUid)) return;
+        const dedupe = `gc_win:${ch.doc.id}`;
+        if (seenGcWinCelebrationIds.current.has(dedupe)) return;
+        seenGcWinCelebrationIds.current.add(dedupe);
+        persistGcSeen();
+        const payload = gcDocToWinPayload(data, userUid);
+        setCelebrationQueue((prev) =>
+          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
+        );
+      });
+    });
+
+    return () => {
+      unsubChall();
+      unsubOpp();
+    };
+  }, [userUid, seenGcWinCelebrationStorageKey]);
+
+  const handleCloseCelebration = async (opts?: { banter?: string }) => {
+    const cur = activeCelebration;
+    setActiveCelebration(null);
+    const banter = opts?.banter?.trim();
+    if (!cur || !banter || !userUid) return;
+    if (cur.payload.kind !== 'h2h_win' && cur.payload.kind !== 'gc_win') return;
+    const threadId = makeDmThreadId(userUid, cur.payload.opponentUid);
+    await sendDirectMessage({
+      threadId,
+      messageId: `celebration_banter_${Date.now()}`,
+      fromUserId: userUid,
+      toUserId: cur.payload.opponentUid,
+      text: banter,
+      createdAtMs: Date.now(),
+    });
+  };
 
 
   // ── Grab uid once for sidebar cards ────────────────────────────
@@ -1216,7 +1407,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                 <span className="inline-flex rounded-full border border-amber-400/50 bg-amber-500/20 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-amber-200">
                                   Mock NFL
                                 </span>
-                                <span className="text-xs text-slate-300">Simulate outcomes and place test bets</span>
+                                <span className="text-xs text-slate-300">Simulated NFL games.</span>
                               </div>
                             </div>
                             {footballApiLeagues.length > 0 && (
@@ -1663,9 +1854,9 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
           />
         )}
         <WinCelebrationModal
-          bet={activeWinBet}
-          open={Boolean(activeWinBet)}
-          onClose={() => setActiveWinBet(null)}
+          payload={activeCelebration?.payload ?? null}
+          open={Boolean(activeCelebration)}
+          onClose={handleCloseCelebration}
         />
       </div>
   );

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -35,6 +35,8 @@ import { SiteFooter } from '../components/SiteFooter';
 import { ProfileView } from './ProfileView';
 import { HeadToHeadView } from './HeadToHeadView';
 import { StoreView } from './StoreView';
+import { CounterOpponentModal } from '../components/CounterOpponentModal';
+import { profileBackgroundForUid } from '@/models/profileBackgrounds';
 import { Swords, ShoppingBag } from 'lucide-react';
 import type { LeaderboardEntry, Friend, SocialActivity } from '../models';
 import { BoostType } from '@/services/dbOps.ts';
@@ -135,7 +137,6 @@ interface DashboardViewProps {
   onLeagueFilter: (league: string) => void;
   onSearchChange: (query: string) => void;
   onRetryMarkets: () => void;
-  onChallenge: (friend: Friend) => void;
   themeMode: UserThemeMode;
   themeSaving: boolean;
   onThemeModeChange: (mode: UserThemeMode) => void;
@@ -180,7 +181,6 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     onLeagueFilter,
     onSearchChange,
     onRetryMarkets,
-    onChallenge,
     themeMode,
     themeSaving,
     onThemeModeChange,
@@ -195,6 +195,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const [isBetSlipCollapsed, setIsBetSlipCollapsed] = useState(false);
   const [pendingWinBets, setPendingWinBets] = useState<Bet[]>([]);
   const [activeWinBet, setActiveWinBet] = useState<Bet | null>(null);
+  const [challengeFriendTarget, setChallengeFriendTarget] = useState<Friend | null>(null);
   const seenWinningBetIds = useRef<Set<string>>(new Set());
   const hasInitializedWinTracking = useRef(false);
 
@@ -711,7 +712,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
           <SocialMessagingView
             friends={friends}
             activities={activity}
-            onChallenge={onChallenge}
+            onChallenge={(f) => setChallengeFriendTarget(f)}
             bets={betList}
             userPrivacy={userPrivacy}
             friendRequests={friendReqs}
@@ -727,6 +728,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
             balance={balance}
             activeBetsCount={props.activeBets.length}
             currentUserId={typeof localStorage !== 'undefined' ? localStorage.getItem('uid') : null}
+            currentUserDisplayName={userName}
+            markets={markets}
             themeMode={themeMode}
             themeSaving={themeSaving}
             onThemeModeChange={onThemeModeChange}
@@ -1654,6 +1657,21 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
           >
             <Ticket size={18} />
           </button>
+        )}
+        {challengeFriendTarget && (
+          <CounterOpponentModal
+            isOpen
+            onClose={() => setChallengeFriendTarget(null)}
+            opponentUserId={challengeFriendTarget.id}
+            opponentDisplayName={challengeFriendTarget.name}
+            opponentAvatarUrl={challengeFriendTarget.avatarUrl}
+            backgroundImageUrl={
+              challengeFriendTarget.profileBackgroundUrl
+                ?? profileBackgroundForUid(challengeFriendTarget.id, challengeFriendTarget.name)
+            }
+            currentUserId={typeof localStorage !== 'undefined' ? localStorage.getItem('uid') : null}
+            balance={balance}
+          />
         )}
         <WinCelebrationModal
           bet={activeWinBet}

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, NavLink } from 'react-router-dom';
 import {
   Trophy,
@@ -46,6 +46,7 @@ import {
   ensureGlobalMockNflBoardSeeded,
   getBets,
   getUserMoney,
+  getUserProfileSummary,
   listenForChange,
   makeDmThreadId,
   saveGlobalMockNflGames,
@@ -67,6 +68,13 @@ import {
 } from '../components/WinCelebrationModal';
 import { collection, onSnapshot, query, where, type QuerySnapshot } from 'firebase/firestore';
 import { db } from '@/models/constants.ts';
+import { UserAvatar } from '../components/UserAvatar';
+import {
+  compileHistoryBetPeers,
+  type HeadToHeadDocRow,
+  type GameChallengeDocRow,
+  type HistoryBetPeerInfo,
+} from '@/lib/historyBetPeerMap';
 
 type DashboardViewType = 'HOME' | 'MARKETS' | 'HISTORY' | 'LEADERBOARD' | 'SOCIAL' | 'PROFILE' | 'HEAD_TO_HEAD' | 'SETTINGS' | 'STORE';
 
@@ -405,6 +413,15 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const [historyYear, setHistoryYear] = useState<number | 'all'>('all');
   const [historyMinStake, setHistoryMinStake] = useState<number>(0);
   const [historyMaxStake, setHistoryMaxStake] = useState<number | null>(null);
+  /** When true, history lists only tickets linked to a counter-bet or game challenge. */
+  const [historyPeersOnly, setHistoryPeersOnly] = useState(false);
+  const [historyBetPeers, setHistoryBetPeers] = useState<Record<string, HistoryBetPeerInfo>>({});
+  const [historyPeerProfiles, setHistoryPeerProfiles] = useState<Record<string, Friend>>({});
+  const h2hOrigRowsRef = useRef<HeadToHeadDocRow[]>([]);
+  const h2hChallRowsRef = useRef<HeadToHeadDocRow[]>([]);
+  const gcChallRowsRef = useRef<GameChallengeDocRow[]>([]);
+  const gcOppRowsRef = useRef<GameChallengeDocRow[]>([]);
+  const activeBetsForHistoryRef = useRef<Bet[]>(props.activeBets);
 
   // Distinct years the user has bet in. Always derived from the realtime
   // activeBets list so newly-placed bets in fresh years show up automatically.
@@ -429,6 +446,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
         const s = (b.status ?? 'PENDING').toLowerCase();
         if (!historyStatusSet.has(s)) return false;
       }
+      if (historyPeersOnly && !historyBetPeers[b.id]) return false;
       if (historyYear !== 'all' && b.placedAt.getFullYear() !== historyYear) return false;
       if (b.stake < historyMinStake) return false;
       if (historyMaxStake !== null && b.stake > historyMaxStake) return false;
@@ -441,7 +459,16 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       case 'recent':
       default:            return list.sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime());
     }
-  }, [props.activeBets, historyStatusSet, historyYear, historyMinStake, historyMaxStake, historySort]);
+  }, [
+    props.activeBets,
+    historyStatusSet,
+    historyYear,
+    historyMinStake,
+    historyMaxStake,
+    historySort,
+    historyPeersOnly,
+    historyBetPeers,
+  ]);
 
   const toggleHistoryStatus = (status: string) =>
     setHistoryStatusSet((prev) => {
@@ -457,6 +484,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     setHistoryYear('all');
     setHistoryMinStake(0);
     setHistoryMaxStake(null);
+    setHistoryPeersOnly(false);
   };
 
   const hasActiveHistoryFilters =
@@ -464,7 +492,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     historyYear !== 'all' ||
     historyMinStake > 0 ||
     historyMaxStake !== null ||
-    historySort !== 'recent';
+    historySort !== 'recent' ||
+    historyPeersOnly;
 
   const handlePlaceBetWithBoost = (
     stake: number,
@@ -695,6 +724,86 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       createdAtMs: Date.now(),
     });
   };
+
+  const rebuildHistoryBetPeers = useCallback(() => {
+    const uid = userUid;
+    if (!uid) return;
+    const dedupeH2h = new Map<string, HeadToHeadDocRow>();
+    [...h2hOrigRowsRef.current, ...h2hChallRowsRef.current].forEach((r) => dedupeH2h.set(r.id, r));
+    const dedupeGc = new Map<string, GameChallengeDocRow>();
+    [...gcChallRowsRef.current, ...gcOppRowsRef.current].forEach((r) => dedupeGc.set(r.id, r));
+    setHistoryBetPeers(
+      compileHistoryBetPeers(uid, [...dedupeH2h.values()], [...dedupeGc.values()], activeBetsForHistoryRef.current),
+    );
+  }, [userUid]);
+
+  useEffect(() => {
+    activeBetsForHistoryRef.current = props.activeBets;
+    rebuildHistoryBetPeers();
+  }, [props.activeBets, rebuildHistoryBetPeers]);
+
+  const historyPeerLoadedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    historyPeerLoadedRef.current = new Set();
+    setHistoryPeerProfiles({});
+    if (!userUid) {
+      h2hOrigRowsRef.current = [];
+      h2hChallRowsRef.current = [];
+      gcChallRowsRef.current = [];
+      gcOppRowsRef.current = [];
+      setHistoryBetPeers({});
+      return;
+    }
+
+    const mapSnap = (snap: QuerySnapshot) =>
+      snap.docs.map((d) => ({ id: d.id, data: d.data() as Record<string, unknown> }));
+
+    const qHOrig = query(collection(db, H2H_COL), where('originalUserId', '==', userUid));
+    const qHChall = query(collection(db, H2H_COL), where('challengerUserId', '==', userUid));
+    const qGcChall = query(collection(db, GC_COL), where('challengerUid', '==', userUid));
+    const qGcOpp = query(collection(db, GC_COL), where('opponentUid', '==', userUid));
+
+    const u1 = onSnapshot(qHOrig, (snap) => {
+      h2hOrigRowsRef.current = mapSnap(snap);
+      rebuildHistoryBetPeers();
+    });
+    const u2 = onSnapshot(qHChall, (snap) => {
+      h2hChallRowsRef.current = mapSnap(snap);
+      rebuildHistoryBetPeers();
+    });
+    const u3 = onSnapshot(qGcChall, (snap) => {
+      gcChallRowsRef.current = mapSnap(snap);
+      rebuildHistoryBetPeers();
+    });
+    const u4 = onSnapshot(qGcOpp, (snap) => {
+      gcOppRowsRef.current = mapSnap(snap);
+      rebuildHistoryBetPeers();
+    });
+
+    return () => {
+      u1();
+      u2();
+      u3();
+      u4();
+    };
+  }, [userUid, rebuildHistoryBetPeers]);
+
+  useEffect(() => {
+    let cancelled = false;
+    for (const p of Object.values(historyBetPeers)) {
+      const oid = p.opponentUid;
+      if (!oid || historyPeerLoadedRef.current.has(oid)) continue;
+      historyPeerLoadedRef.current.add(oid);
+      void getUserProfileSummary(oid).then((f) => {
+        if (cancelled || !f) return;
+        setHistoryPeerProfiles((prev) => ({ ...prev, [oid]: f }));
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [historyBetPeers]);
 
 
   // ── Grab uid once for sidebar cards ────────────────────────────
@@ -982,6 +1091,19 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                       <StatusChip value="void"      label="Void"      tone="bg-slate-500/20 text-slate-200 border-slate-500/40" />
                       <StatusChip value="cancelled" label="Cancelled" tone="bg-slate-500/20 text-slate-200 border-slate-500/40" />
                       <StatusChip value="pending"   label="Pending"   tone="bg-blue-500/15 text-blue-300 border-blue-500/40" />
+                      <button
+                        type="button"
+                        onClick={() => setHistoryPeersOnly((v) => !v)}
+                        className={`text-[11px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full border transition-colors inline-flex items-center gap-1.5 ${
+                          historyPeersOnly
+                            ? 'bg-violet-500/20 text-violet-200 border-violet-500/45'
+                            : 'border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500'
+                        }`}
+                        title="Show only tickets linked to a counter-bet or NFL sim game challenge"
+                      >
+                        <Swords size={12} className="opacity-90" aria-hidden />
+                        Counters & challenges
+                      </button>
                     </div>
 
                     <div className="hidden lg:block h-7 w-px bg-slate-700/70" aria-hidden />
@@ -1129,6 +1251,8 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                         s === 'push'                         ? { label: 'Refund',           value: `$${bet.stake.toLocaleString()}`,         color: 'text-amber-300' } :
                         (s === 'void' || s === 'cancelled')  ? { label: 'Refund',           value: `$${bet.stake.toLocaleString()}`,         color: 'text-slate-300' } :
                                                                { label: 'Potential Payout', value: `$${bet.potentialPayout.toLocaleString()}`, color: 'text-blue-400' };
+                      const peer = historyBetPeers[bet.id];
+                      const peerFriend = peer ? historyPeerProfiles[peer.opponentUid] : undefined;
                       return (
                         <div key={bet.id} className={`glass-card rounded-2xl p-6 border-slate-800 hover:border-slate-700 transition-all ${rowAccent}`}>
                           <div className="flex justify-between items-start mb-4">
@@ -1141,6 +1265,49 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               {pillLabel}
                             </span>
                           </div>
+                          {peer ? (
+                            <div className="mb-4">
+                              <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                                {peer.kind === 'counter' ? 'Counter-bet vs' : 'Game challenge vs'}
+                              </p>
+                              <button
+                                type="button"
+                                onClick={() => navigate(`/profile/${peer.opponentUid}`)}
+                                className="group relative w-full max-w-md overflow-hidden rounded-xl border border-slate-700/80 bg-slate-950/50 text-left transition-colors hover:border-violet-500/40"
+                              >
+                                {peerFriend?.profileBackgroundUrl ? (
+                                  <div
+                                    className="absolute inset-0 bg-cover bg-center opacity-50 transition-opacity group-hover:opacity-60"
+                                    style={{ backgroundImage: `url("${peerFriend.profileBackgroundUrl}")` }}
+                                    aria-hidden
+                                  />
+                                ) : null}
+                                <div className="absolute inset-0 bg-gradient-to-r from-slate-950/92 via-slate-950/80 to-slate-950/55" aria-hidden />
+                                <div className="relative flex items-center gap-3 px-3 py-2.5">
+                                  <UserAvatar
+                                    initials={peerFriend?.avatar ?? '??'}
+                                    imageUrl={peerFriend?.avatarUrl}
+                                    alt={`${peerFriend?.name ?? 'Opponent'} avatar`}
+                                    className="h-11 w-11 shrink-0 rounded-xl ring-2 ring-slate-700/80 group-hover:ring-violet-500/40"
+                                    textClassName="text-xs text-violet-200"
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <p className="truncate text-sm font-black text-slate-50 group-hover:text-white">
+                                      {peerFriend?.name ?? '…'}
+                                    </p>
+                                    <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 group-hover:text-slate-300">
+                                      Tap for profile
+                                    </p>
+                                  </div>
+                                  {peer.kind === 'counter' ? (
+                                    <Swords className="h-4 w-4 shrink-0 text-red-400/90 opacity-80 group-hover:opacity-100" aria-hidden />
+                                  ) : (
+                                    <Trophy className="h-4 w-4 shrink-0 text-amber-400/90 opacity-80 group-hover:opacity-100" aria-hidden />
+                                  )}
+                                </div>
+                              </button>
+                            </div>
+                          ) : null}
                           <div className="flex justify-between items-end border-t border-slate-800 pt-4">
                             <div className="grid grid-cols-2 gap-8">
                               <div>

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -193,6 +193,26 @@ function userWonH2h(
   return (status === 'WON_BY_ORIGINAL' && uid === orig) || (status === 'WON_BY_CHALLENGER' && uid === chall);
 }
 
+function userLostH2h(
+  data: { status?: unknown; originalUserId?: unknown; challengerUserId?: unknown },
+  uid: string,
+): boolean {
+  const status = String(data.status ?? '');
+  const orig = String(data.originalUserId ?? '');
+  const chall = String(data.challengerUserId ?? '');
+  return (status === 'WON_BY_ORIGINAL' && uid === chall) || (status === 'WON_BY_CHALLENGER' && uid === orig);
+}
+
+function userPushH2h(data: { status?: unknown }, _uid: string): boolean {
+  return String(data.status ?? '') === 'PUSH';
+}
+
+function h2hYourSideLabel(data: Record<string, unknown>, uid: string): string {
+  const orig = String(data.originalUserId ?? '');
+  if (uid === orig) return String(data.originalSide ?? 'Your pick');
+  return `Fade (${String(data.originalSide ?? '')})`;
+}
+
 function h2hDocToWinPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
   const orig = String(data.originalUserId ?? '');
   const chall = String(data.challengerUserId ?? '');
@@ -207,6 +227,29 @@ function h2hDocToWinPayload(data: Record<string, unknown>, uid: string): WinCele
   };
 }
 
+function h2hDocToLossPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const orig = String(data.originalUserId ?? '');
+  const chall = String(data.challengerUserId ?? '');
+  const opponent = uid === orig ? chall : orig;
+  return {
+    kind: 'h2h_loss',
+    opponentUid: opponent,
+    marketTitle: String(data.marketTitle ?? ''),
+    yourSideLabel: h2hYourSideLabel(data, uid),
+  };
+}
+
+function h2hDocToPushPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const orig = String(data.originalUserId ?? '');
+  const chall = String(data.challengerUserId ?? '');
+  const opponent = uid === orig ? chall : orig;
+  return {
+    kind: 'h2h_push',
+    opponentUid: opponent,
+    marketTitle: String(data.marketTitle ?? ''),
+  };
+}
+
 function userWonGc(
   data: { status?: unknown; challengerUid?: unknown; opponentUid?: unknown },
   uid: string,
@@ -215,6 +258,20 @@ function userWonGc(
   const chall = String(data.challengerUid ?? '');
   const opp = String(data.opponentUid ?? '');
   return (status === 'COMPLETED_CHALLENGER' && uid === chall) || (status === 'COMPLETED_OPPONENT' && uid === opp);
+}
+
+function userLostGc(
+  data: { status?: unknown; challengerUid?: unknown; opponentUid?: unknown },
+  uid: string,
+): boolean {
+  const status = String(data.status ?? '');
+  const chall = String(data.challengerUid ?? '');
+  const opp = String(data.opponentUid ?? '');
+  return (status === 'COMPLETED_CHALLENGER' && uid === opp) || (status === 'COMPLETED_OPPONENT' && uid === chall);
+}
+
+function userPushGc(data: { status?: unknown }, _uid: string): boolean {
+  return String(data.status ?? '') === 'PUSH';
 }
 
 function gcDocToWinPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
@@ -233,6 +290,31 @@ function gcDocToWinPayload(data: Record<string, unknown>, uid: string): WinCeleb
     opponentUid: chall,
     marketTitle: String(data.marketTitle ?? ''),
     yourPick: String(data.opponentPickLabel ?? ''),
+  };
+}
+
+function gcDocToLossPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const chall = String(data.challengerUid ?? '');
+  const opp = String(data.opponentUid ?? '');
+  const opponent = uid === chall ? opp : chall;
+  const yourPick =
+    uid === chall ? String(data.challengerPickLabel ?? '') : String(data.opponentPickLabel ?? '');
+  return {
+    kind: 'gc_loss',
+    opponentUid: opponent,
+    marketTitle: String(data.marketTitle ?? ''),
+    yourPick,
+  };
+}
+
+function gcDocToPushPayload(data: Record<string, unknown>, uid: string): WinCelebrationPayload {
+  const chall = String(data.challengerUid ?? '');
+  const opp = String(data.opponentUid ?? '');
+  const opponent = uid === chall ? opp : chall;
+  return {
+    kind: 'gc_push',
+    opponentUid: opponent,
+    marketTitle: String(data.marketTitle ?? ''),
   };
 }
 
@@ -294,26 +376,55 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const [celebrationQueue, setCelebrationQueue] = useState<QueuedCelebration[]>([]);
   const [activeCelebration, setActiveCelebration] = useState<QueuedCelebration | null>(null);
   const [challengeFriendTarget, setChallengeFriendTarget] = useState<Friend | null>(null);
+  const [h2hNavAttention, setH2hNavAttention] = useState(false);
+  const h2hPendingOrigRef = useRef(false);
+  const gcPendingOppRef = useRef(false);
   const seenWinningBetIds = useRef<Set<string>>(new Set());
   const hasInitializedWinTracking = useRef(false);
-  const seenH2hWinCelebrationIds = useRef<Set<string>>(new Set());
+  const seenPeerOutcomeModalIds = useRef<Set<string>>(new Set());
   const h2hBootstrapDone = useRef(false);
   const lastH2hOrigSnap = useRef<QuerySnapshot | null>(null);
   const lastH2hChallSnap = useRef<QuerySnapshot | null>(null);
-  const seenGcWinCelebrationIds = useRef<Set<string>>(new Set());
   const gcBootstrapDone = useRef(false);
   const lastGcChallSnap = useRef<QuerySnapshot | null>(null);
   const lastGcOppSnap = useRef<QuerySnapshot | null>(null);
 
   const userUid = typeof localStorage !== 'undefined' ? localStorage.getItem('uid') ?? '' : '';
   const seenWinningBetsStorageKey = userUid ? `bethub_seen_winning_bets:${userUid}` : '';
-  const seenH2hWinCelebrationStorageKey = userUid ? `bethub_seen_h2h_win_celebration:${userUid}` : '';
-  const seenGcWinCelebrationStorageKey = userUid ? `bethub_seen_gc_win_celebration:${userUid}` : '';
+  const peerOutcomeModalStorageKey = userUid ? `bethub_seen_peer_outcome_modal:${userUid}` : '';
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
     document.documentElement.dataset.theme = isLightMode ? 'light' : 'ocean';
   }, [isLightMode]);
+
+  useEffect(() => {
+    if (!userUid) {
+      h2hPendingOrigRef.current = false;
+      gcPendingOppRef.current = false;
+      setH2hNavAttention(false);
+      return;
+    }
+    const sync = () => setH2hNavAttention(h2hPendingOrigRef.current || gcPendingOppRef.current);
+    const qH = query(collection(db, H2H_COL), where('originalUserId', '==', userUid));
+    const qGc = query(collection(db, GC_COL), where('opponentUid', '==', userUid));
+    const u1 = onSnapshot(qH, (snap) => {
+      h2hPendingOrigRef.current = snap.docs.some(
+        (d) => String((d.data() as Record<string, unknown>).status ?? '') === 'PENDING_ACCEPT',
+      );
+      sync();
+    });
+    const u2 = onSnapshot(qGc, (snap) => {
+      gcPendingOppRef.current = snap.docs.some(
+        (d) => String((d.data() as Record<string, unknown>).status ?? '') === 'PENDING_ACCEPT',
+      );
+      sync();
+    });
+    return () => {
+      u1();
+      u2();
+    };
+  }, [userUid]);
 
   const normalizeSpreadLine = (line: number) => (line > 0 ? `+${line.toFixed(1)}` : line.toFixed(1));
   const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
@@ -513,12 +624,14 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   useEffect(() => {
     seenWinningBetIds.current = new Set();
     hasInitializedWinTracking.current = false;
-    seenH2hWinCelebrationIds.current = seenH2hWinCelebrationStorageKey
-      ? readStringSetFromLs(seenH2hWinCelebrationStorageKey)
-      : new Set();
-    seenGcWinCelebrationIds.current = seenGcWinCelebrationStorageKey
-      ? readStringSetFromLs(seenGcWinCelebrationStorageKey)
-      : new Set();
+    if (peerOutcomeModalStorageKey && userUid) {
+      const merged = readStringSetFromLs(peerOutcomeModalStorageKey);
+      readStringSetFromLs(`bethub_seen_h2h_win_celebration:${userUid}`).forEach((k) => merged.add(k));
+      readStringSetFromLs(`bethub_seen_gc_win_celebration:${userUid}`).forEach((k) => merged.add(k));
+      seenPeerOutcomeModalIds.current = merged;
+    } else {
+      seenPeerOutcomeModalIds.current = new Set();
+    }
     h2hBootstrapDone.current = false;
     gcBootstrapDone.current = false;
     lastH2hOrigSnap.current = null;
@@ -527,7 +640,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     lastGcOppSnap.current = null;
     setCelebrationQueue([]);
     setActiveCelebration(null);
-  }, [userUid, seenH2hWinCelebrationStorageKey, seenGcWinCelebrationStorageKey]);
+  }, [userUid, peerOutcomeModalStorageKey]);
 
   useEffect(() => {
     if (!userUid) return;
@@ -581,9 +694,10 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   }, [activeCelebration, celebrationQueue]);
 
   useEffect(() => {
-    if (!userUid || !seenH2hWinCelebrationStorageKey) return;
+    if (!userUid || !peerOutcomeModalStorageKey) return;
 
-    const persistH2hSeen = () => writeStringSetToLs(seenH2hWinCelebrationStorageKey, seenH2hWinCelebrationIds.current);
+    const persistPeerOutcomesSeen = () =>
+      writeStringSetToLs(peerOutcomeModalStorageKey, seenPeerOutcomeModalIds.current);
 
     const tryBootstrapH2h = () => {
       if (h2hBootstrapDone.current) return;
@@ -592,9 +706,25 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       const merged = new Map([...lastH2hOrigSnap.current.docs, ...lastH2hChallSnap.current.docs].map((d) => [d.id, d]));
       merged.forEach((d) => {
         const data = d.data() as Record<string, unknown>;
-        if (userWonH2h(data, userUid)) seenH2hWinCelebrationIds.current.add(`h2h_win:${d.id}`);
+        if (userWonH2h(data, userUid)) seenPeerOutcomeModalIds.current.add(`h2h_win:${d.id}`);
+        if (userLostH2h(data, userUid)) seenPeerOutcomeModalIds.current.add(`h2h_loss:${d.id}`);
+        if (userPushH2h(data, userUid)) seenPeerOutcomeModalIds.current.add(`h2h_push:${d.id}`);
       });
-      persistH2hSeen();
+      persistPeerOutcomesSeen();
+    };
+
+    const queueIfNew = (dedupe: string, payload: WinCelebrationPayload) => {
+      if (seenPeerOutcomeModalIds.current.has(dedupe)) return;
+      seenPeerOutcomeModalIds.current.add(dedupe);
+      persistPeerOutcomesSeen();
+      setCelebrationQueue((prev) => (prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }]));
+    };
+
+    const processH2hDoc = (docSnap: { id: string; data: () => Record<string, unknown> }) => {
+      const data = docSnap.data();
+      if (userWonH2h(data, userUid)) queueIfNew(`h2h_win:${docSnap.id}`, h2hDocToWinPayload(data, userUid));
+      if (userLostH2h(data, userUid)) queueIfNew(`h2h_loss:${docSnap.id}`, h2hDocToLossPayload(data, userUid));
+      if (userPushH2h(data, userUid)) queueIfNew(`h2h_push:${docSnap.id}`, h2hDocToPushPayload(data, userUid));
     };
 
     const qOrig = query(collection(db, H2H_COL), where('originalUserId', '==', userUid));
@@ -606,16 +736,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       if (!h2hBootstrapDone.current) return;
       snap.docChanges().forEach((ch) => {
         if (ch.type === 'removed') return;
-        const data = ch.doc.data() as Record<string, unknown>;
-        if (!userWonH2h(data, userUid)) return;
-        const dedupe = `h2h_win:${ch.doc.id}`;
-        if (seenH2hWinCelebrationIds.current.has(dedupe)) return;
-        seenH2hWinCelebrationIds.current.add(dedupe);
-        persistH2hSeen();
-        const payload = h2hDocToWinPayload(data, userUid);
-        setCelebrationQueue((prev) =>
-          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
-        );
+        processH2hDoc(ch.doc);
       });
     });
 
@@ -625,16 +746,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       if (!h2hBootstrapDone.current) return;
       snap.docChanges().forEach((ch) => {
         if (ch.type === 'removed') return;
-        const data = ch.doc.data() as Record<string, unknown>;
-        if (!userWonH2h(data, userUid)) return;
-        const dedupe = `h2h_win:${ch.doc.id}`;
-        if (seenH2hWinCelebrationIds.current.has(dedupe)) return;
-        seenH2hWinCelebrationIds.current.add(dedupe);
-        persistH2hSeen();
-        const payload = h2hDocToWinPayload(data, userUid);
-        setCelebrationQueue((prev) =>
-          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
-        );
+        processH2hDoc(ch.doc);
       });
     });
 
@@ -642,12 +754,13 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       unsubOrig();
       unsubChall();
     };
-  }, [userUid, seenH2hWinCelebrationStorageKey]);
+  }, [userUid, peerOutcomeModalStorageKey]);
 
   useEffect(() => {
-    if (!userUid || !seenGcWinCelebrationStorageKey) return;
+    if (!userUid || !peerOutcomeModalStorageKey) return;
 
-    const persistGcSeen = () => writeStringSetToLs(seenGcWinCelebrationStorageKey, seenGcWinCelebrationIds.current);
+    const persistPeerOutcomesSeen = () =>
+      writeStringSetToLs(peerOutcomeModalStorageKey, seenPeerOutcomeModalIds.current);
 
     const tryBootstrapGc = () => {
       if (gcBootstrapDone.current) return;
@@ -656,9 +769,25 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       const merged = new Map([...lastGcChallSnap.current.docs, ...lastGcOppSnap.current.docs].map((d) => [d.id, d]));
       merged.forEach((d) => {
         const data = d.data() as Record<string, unknown>;
-        if (userWonGc(data, userUid)) seenGcWinCelebrationIds.current.add(`gc_win:${d.id}`);
+        if (userWonGc(data, userUid)) seenPeerOutcomeModalIds.current.add(`gc_win:${d.id}`);
+        if (userLostGc(data, userUid)) seenPeerOutcomeModalIds.current.add(`gc_loss:${d.id}`);
+        if (userPushGc(data, userUid)) seenPeerOutcomeModalIds.current.add(`gc_push:${d.id}`);
       });
-      persistGcSeen();
+      persistPeerOutcomesSeen();
+    };
+
+    const queueIfNew = (dedupe: string, payload: WinCelebrationPayload) => {
+      if (seenPeerOutcomeModalIds.current.has(dedupe)) return;
+      seenPeerOutcomeModalIds.current.add(dedupe);
+      persistPeerOutcomesSeen();
+      setCelebrationQueue((prev) => (prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }]));
+    };
+
+    const processGcDoc = (docSnap: { id: string; data: () => Record<string, unknown> }) => {
+      const data = docSnap.data();
+      if (userWonGc(data, userUid)) queueIfNew(`gc_win:${docSnap.id}`, gcDocToWinPayload(data, userUid));
+      if (userLostGc(data, userUid)) queueIfNew(`gc_loss:${docSnap.id}`, gcDocToLossPayload(data, userUid));
+      if (userPushGc(data, userUid)) queueIfNew(`gc_push:${docSnap.id}`, gcDocToPushPayload(data, userUid));
     };
 
     const qChall = query(collection(db, GC_COL), where('challengerUid', '==', userUid));
@@ -670,16 +799,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       if (!gcBootstrapDone.current) return;
       snap.docChanges().forEach((ch) => {
         if (ch.type === 'removed') return;
-        const data = ch.doc.data() as Record<string, unknown>;
-        if (!userWonGc(data, userUid)) return;
-        const dedupe = `gc_win:${ch.doc.id}`;
-        if (seenGcWinCelebrationIds.current.has(dedupe)) return;
-        seenGcWinCelebrationIds.current.add(dedupe);
-        persistGcSeen();
-        const payload = gcDocToWinPayload(data, userUid);
-        setCelebrationQueue((prev) =>
-          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
-        );
+        processGcDoc(ch.doc);
       });
     });
 
@@ -689,16 +809,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       if (!gcBootstrapDone.current) return;
       snap.docChanges().forEach((ch) => {
         if (ch.type === 'removed') return;
-        const data = ch.doc.data() as Record<string, unknown>;
-        if (!userWonGc(data, userUid)) return;
-        const dedupe = `gc_win:${ch.doc.id}`;
-        if (seenGcWinCelebrationIds.current.has(dedupe)) return;
-        seenGcWinCelebrationIds.current.add(dedupe);
-        persistGcSeen();
-        const payload = gcDocToWinPayload(data, userUid);
-        setCelebrationQueue((prev) =>
-          prev.some((q) => q.key === dedupe) ? prev : [...prev, { key: dedupe, payload }],
-        );
+        processGcDoc(ch.doc);
       });
     });
 
@@ -706,7 +817,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       unsubChall();
       unsubOpp();
     };
-  }, [userUid, seenGcWinCelebrationStorageKey]);
+  }, [userUid, peerOutcomeModalStorageKey]);
 
   const handleCloseCelebration = async (opts?: { banter?: string }) => {
     const cur = activeCelebration;
@@ -1296,7 +1407,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                                       {peerFriend?.name ?? '…'}
                                     </p>
                                     <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 group-hover:text-slate-300">
-                                      Tap for profile
+                                      View profile
                                     </p>
                                   </div>
                                   {peer.kind === 'counter' ? (
@@ -1904,9 +2015,23 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
             <NavLink to="/history" title="History" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-blue-600/10 text-blue-400' : 'text-slate-500 hover:bg-slate-800'}`}>
               <Receipt size={24} />
             </NavLink>
-            <NavLink to="/head-to-head" title="Head-to-Head" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-red-500/10 text-red-400' : 'text-slate-500 hover:bg-slate-800'}`}>
-              <Swords size={24} />
-            </NavLink>
+            <span className="relative inline-flex">
+              <NavLink
+                to="/head-to-head"
+                title="Head-to-Head"
+                className={({ isActive }) =>
+                  `p-3 rounded-xl transition-all ${isActive ? 'bg-red-500/10 text-red-400' : 'text-slate-500 hover:bg-slate-800'}`
+                }
+              >
+                <Swords size={24} />
+              </NavLink>
+              {h2hNavAttention ? (
+                <span
+                  className="pointer-events-none absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-slate-900"
+                  aria-label="Pending head-to-head or challenge to review"
+                />
+              ) : null}
+            </span>
             <NavLink to="/store" title="Store" className={({ isActive }) => `p-3 rounded-xl transition-all ${isActive ? 'bg-violet-500/10 text-violet-400' : 'text-slate-500 hover:bg-slate-800'}`}>
               <ShoppingBag size={24} />
             </NavLink>

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -45,6 +45,8 @@ import { FriendRequest, getBets, getUserMoney, getUserMockNflGames, listenForCha
 import type { MockNflGameState } from "@/services/dbOps.ts";
 import {betList, friendsList} from "@/services/authService.ts";
 import type { UserThemeMode } from '@/services/dbOps';
+import { buildMockNflMarketFromGameState } from '@/lib/mockNflMarketFromState';
+import { reconcileMockGameChallengesAfterUserGameFinal } from '@/services/gameChallenges';
 import { computeParlayRollup } from '@/services/parlayRollup';
 import { formatAmericanOddsLine } from '@/lib/oddsAmericanFormat';
 import {
@@ -192,6 +194,10 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
   const isLightMode = themeMode === 'light';
   const [promotionsOpen, setPromotionsOpen] = useState(false);
   const [mockNflGames, setMockNflGames] = useState<MockNflGameState[]>([]);
+  const mockNflChallengeMarkets = useMemo(
+    () => mockNflGames.map((g) => buildMockNflMarketFromGameState(g)),
+    [mockNflGames],
+  );
   const [isBetSlipCollapsed, setIsBetSlipCollapsed] = useState(false);
   const [pendingWinBets, setPendingWinBets] = useState<Bet[]>([]);
   const [activeWinBet, setActiveWinBet] = useState<Bet | null>(null);
@@ -313,6 +319,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
       await saveUserMockNflGames(userUid, next);
       if (finalizedGame) {
         await settleUserMockNflGameBets(userUid, finalizedGame);
+        await reconcileMockGameChallengesAfterUserGameFinal(userUid, finalizedGame);
       }
     }
   };
@@ -522,25 +529,6 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
     return { label: time, tone: 'upcoming' as const };
   };
 
-  const mockMarketForGame = (game: MockNflGameState): Market => ({
-    id: `mock-${game.id}`,
-    sport_key: 'football_nfl_mock',
-    title: `${game.awayTeam} @ ${game.homeTeam}`,
-    subtitle: 'NFL',
-    category: 'Football',
-    type: MarketType.SPORTS,
-    startTime: new Date(game.updatedAtMs).toISOString(),
-    status: game.status === 'FINAL' ? 'CLOSED' : 'UPCOMING',
-    options: [
-      { id: `${game.id}-spread-away`, label: `${game.awayTeam} ${normalizeSpreadLine(game.spreadLine)}`, odds: game.spreadAwayOdds ?? game.awayOdds, marketKey: 'spreads' },
-      { id: `${game.id}-spread-home`, label: `${game.homeTeam} ${normalizeSpreadLine(-game.spreadLine)}`, odds: game.spreadHomeOdds ?? game.homeOdds, marketKey: 'spreads' },
-      { id: `${game.id}-total-over`, label: `Over ${game.totalLine.toFixed(1)}`, odds: game.totalOverOdds, marketKey: 'totals' },
-      { id: `${game.id}-total-under`, label: `Under ${game.totalLine.toFixed(1)}`, odds: game.totalUnderOdds, marketKey: 'totals' },
-      { id: `${game.id}-ml-away`, label: game.awayTeam, odds: game.awayOdds, marketKey: 'h2h' },
-      { id: `${game.id}-ml-home`, label: game.homeTeam, odds: game.homeOdds, marketKey: 'h2h' },
-    ],
-  });
-
   const isMockOptionSelected = (gameId: string, optionId: string) =>
     parlaySelections.some((sel) => sel.market.id === `mock-${gameId}` && sel.option.id === optionId);
 
@@ -730,6 +718,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
             currentUserId={typeof localStorage !== 'undefined' ? localStorage.getItem('uid') : null}
             currentUserDisplayName={userName}
             markets={markets}
+            nflMockChallengeMarkets={mockNflChallengeMarkets}
             themeMode={themeMode}
             themeSaving={themeSaving}
             onThemeModeChange={onThemeModeChange}
@@ -1251,7 +1240,7 @@ export const DashboardView: React.FC<DashboardViewProps> = (props) => {
                               {mockNflGames.map((game) => (
                                 <div key={game.id} className="grid grid-cols-[minmax(230px,1.2fr)_repeat(3,minmax(120px,0.62fr))] items-stretch gap-2 rounded-lg border border-amber-400/25 bg-slate-900/70 p-2.5">
                                   {(() => {
-                                    const mockMarket = mockMarketForGame(game);
+                                    const mockMarket = buildMockNflMarketFromGameState(game);
                                     const spreadAway = mockMarket.options[0];
                                     const spreadHome = mockMarket.options[1];
                                     const totalOver = mockMarket.options[2];

--- a/views/HeadToHeadView.tsx
+++ b/views/HeadToHeadView.tsx
@@ -1,66 +1,126 @@
 import React, { useMemo, useState } from 'react';
-import { Swords, Inbox, Send, Activity, History as HistoryIcon, Check, X as XIcon, RefreshCw, AlertCircle, Clock3 } from 'lucide-react';
+import { Swords, Check, X as XIcon, RefreshCw, AlertCircle, Clock3 } from 'lucide-react';
 import type { HeadToHead, HeadToHeadStatus } from '../models';
 import { useHeadToHeadViewModel, type HeadToHeadBucket } from '../viewModels/useHeadToHeadViewModel';
+import { useGameChallengesInboxViewModel } from '../viewModels/useGameChallengesInboxViewModel';
+import type { GameChallengeDoc, GameChallengeStatus } from '@/services/gameChallenges';
 
 interface HeadToHeadViewProps {
   currentUserId: string | null;
 }
 
+type InboxRow =
+  | { kind: 'h2h'; sortMs: number; h2h: HeadToHead }
+  | { kind: 'gc'; sortMs: number; gc: GameChallengeDoc };
+
+function mergeBucket(tab: HeadToHeadBucket, h2hList: HeadToHead[], gcList: GameChallengeDoc[]): InboxRow[] {
+  const rows: InboxRow[] = [
+    ...h2hList.map((h2h) => ({
+      kind: 'h2h' as const,
+      sortMs: h2h.createdAt.getTime(),
+      h2h,
+    })),
+    ...gcList.map((gc) => ({
+      kind: 'gc' as const,
+      sortMs: gc.createdAt.toMillis(),
+      gc,
+    })),
+  ];
+  rows.sort((a, b) => b.sortMs - a.sortMs);
+  return rows;
+}
+
 /**
  * "Head-to-Head" inbox + history page.
  *
- * Lays out the four buckets (incoming / outgoing / active / history) as tabs,
- * each rendering a list of HeadToHead cards. The current user can:
- *   - Accept/Decline an incoming proposal
- *   - Cancel an outgoing proposal (refunds them)
- *   - Just view active and historical H2Hs
- *
- * @author Cursor (head-to-head feature)
+ * Counter-bets (fade) and game challenges share the same four buckets.
+ * The current user can accept/decline/cancel pending items; lists stay in
+ * sync via Firestore listeners.
  */
 export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId }) => {
-  const {
-    loading,
-    error,
-    buckets,
-    refresh,
-    accept,
-    decline,
-    cancel,
-    opponentNameFor,
-  } = useHeadToHeadViewModel(currentUserId);
+  const h2h = useHeadToHeadViewModel(currentUserId);
+  const gc = useGameChallengesInboxViewModel(currentUserId);
 
   const [activeTab, setActiveTab] = useState<HeadToHeadBucket>('incoming');
-  const [actingId, setActingId] = useState<string | null>(null);
-  const [errorByH2H, setErrorByH2H] = useState<Record<string, string>>({});
+  const [actingKey, setActingKey] = useState<string | null>(null);
+  const [errorByKey, setErrorByKey] = useState<Record<string, string>>({});
 
   const tabs = useMemo(
-    () => ([
-      { id: 'incoming' as const, label: 'Incoming', icon: Inbox,        count: buckets.incoming.length, accent: 'text-amber-300'   },
-      { id: 'outgoing' as const, label: 'Outgoing', icon: Send,         count: buckets.outgoing.length, accent: 'text-blue-300'    },
-      { id: 'active'   as const, label: 'Active',   icon: Activity,     count: buckets.active.length,   accent: 'text-emerald-300' },
-      { id: 'history'  as const, label: 'History',  icon: HistoryIcon,  count: buckets.history.length,  accent: 'text-slate-400'   },
-    ]),
-    [buckets],
+    () => [
+      {
+        id: 'incoming' as const,
+        label: 'Your turn',
+        count: h2h.buckets.incoming.length + gc.buckets.incoming.length,
+      },
+      {
+        id: 'outgoing' as const,
+        label: 'Their turn',
+        count: h2h.buckets.outgoing.length + gc.buckets.outgoing.length,
+      },
+      {
+        id: 'active' as const,
+        label: 'Live',
+        count: h2h.buckets.active.length + gc.buckets.active.length,
+      },
+      {
+        id: 'history' as const,
+        label: 'Past',
+        count: h2h.buckets.history.length + gc.buckets.history.length,
+      },
+    ],
+    [h2h.buckets, gc.buckets],
   );
 
-  const list = buckets[activeTab];
+  const list = useMemo(
+    () => mergeBucket(activeTab, h2h.buckets[activeTab], gc.buckets[activeTab]),
+    [activeTab, h2h.buckets, gc.buckets],
+  );
 
-  const handleAction = async (
-    h2h: HeadToHead,
-    action: 'accept' | 'decline' | 'cancel',
-  ) => {
-    if (actingId) return;
-    setActingId(h2h.id);
-    setErrorByH2H((prev) => { const n = { ...prev }; delete n[h2h.id]; return n; });
+  const combinedError = [h2h.error, gc.error].filter(Boolean).join(' · ');
+  const loading = h2h.loading || gc.loading;
+
+  const clearRowError = (key: string) => {
+    setErrorByKey((prev) => {
+      const n = { ...prev };
+      delete n[key];
+      return n;
+    });
+  };
+
+  const handleH2hAction = async (h2hRow: HeadToHead, action: 'accept' | 'decline' | 'cancel') => {
+    const key = `h2h:${h2hRow.id}`;
+    if (actingKey) return;
+    setActingKey(key);
+    clearRowError(key);
     let result: { success: boolean; error?: string };
-    if      (action === 'accept')  result = await accept(h2h.id);
-    else if (action === 'decline') result = await decline(h2h.id);
-    else                           result = await cancel(h2h.id);
+    if (action === 'accept') result = await h2h.accept(h2hRow.id);
+    else if (action === 'decline') result = await h2h.decline(h2hRow.id);
+    else result = await h2h.cancel(h2hRow.id);
     if (!result.success) {
-      setErrorByH2H((prev) => ({ ...prev, [h2h.id]: friendlyError(result.error ?? 'UNKNOWN') }));
+      setErrorByKey((prev) => ({ ...prev, [key]: friendlyH2hError(result.error ?? 'UNKNOWN') }));
+    } else {
+      if (action === 'accept') setActiveTab('active');
+      if (action === 'decline' || action === 'cancel') setActiveTab('history');
     }
-    setActingId(null);
+    setActingKey(null);
+  };
+
+  const handleGcAction = async (gcRow: GameChallengeDoc, action: 'accept' | 'decline' | 'cancel') => {
+    const key = `gc:${gcRow.id}`;
+    if (actingKey) return;
+    setActingKey(key);
+    clearRowError(key);
+    let result: { success: boolean; error?: string };
+    if (action === 'accept') result = await gc.accept(gcRow.id);
+    else if (action === 'decline') result = await gc.decline(gcRow.id);
+    else result = await gc.cancel(gcRow.id);
+    if (!result.success) {
+      setErrorByKey((prev) => ({ ...prev, [key]: result.error ?? 'Something went wrong.' }));
+    } else {
+      if (action === 'accept') setActiveTab('active');
+      if (action === 'decline' || action === 'cancel') setActiveTab('history');
+    }
+    setActingKey(null);
   };
 
   return (
@@ -71,12 +131,12 @@ export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId })
             <Swords className="text-red-400" size={28} /> Head-to-Head
           </h2>
           <p className="text-slate-400 mt-1 text-sm">
-            Fade other users&apos; bets — odds-matched, peer-to-peer.
+            Fade other users&apos; bets — odds-matched, peer-to-peer. Game challenges land here too.
           </p>
         </div>
         <button
           type="button"
-          onClick={() => void refresh()}
+          onClick={() => void h2h.refresh()}
           disabled={loading}
           className="inline-flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-slate-300 hover:bg-slate-800 transition-colors disabled:opacity-50"
         >
@@ -84,10 +144,8 @@ export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId })
         </button>
       </header>
 
-      {/* Tabs */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-5">
         {tabs.map((tab) => {
-          const Icon = tab.icon;
           const isActive = activeTab === tab.id;
           return (
             <button
@@ -100,12 +158,13 @@ export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId })
                   : 'border-slate-800 bg-slate-900/50 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'
               }`}
             >
-              <Icon size={14} className={isActive ? tab.accent : ''} />
               {tab.label}
               {tab.count > 0 && (
-                <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${
-                  isActive ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'
-                }`}>
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] ${
+                    isActive ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'
+                  }`}
+                >
                   {tab.count}
                 </span>
               )}
@@ -114,10 +173,9 @@ export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId })
         })}
       </div>
 
-      {/* List */}
-      {error && (
+      {combinedError && (
         <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 mb-4 text-sm text-red-300 flex items-center gap-2">
-          <AlertCircle size={16} /> Failed to load: {error}
+          <AlertCircle size={16} /> Failed to load: {combinedError}
         </div>
       )}
 
@@ -129,33 +187,42 @@ export const HeadToHeadView: React.FC<HeadToHeadViewProps> = ({ currentUserId })
         </div>
       ) : (
         <div className="space-y-3">
-          {list.map((h2h) => (
-            <HeadToHeadCard
-              key={h2h.id}
-              h2h={h2h}
-              perspective={activeTab === 'outgoing' ? 'challenger' : activeTab === 'incoming' ? 'original' : 'auto'}
-              currentUserId={currentUserId}
-              opponentName={opponentNameFor(h2h)}
-              isActing={actingId === h2h.id}
-              errorMsg={errorByH2H[h2h.id]}
-              onAccept={activeTab === 'incoming'  ? () => handleAction(h2h, 'accept')  : undefined}
-              onDecline={activeTab === 'incoming' ? () => handleAction(h2h, 'decline') : undefined}
-              onCancel={activeTab === 'outgoing'  ? () => handleAction(h2h, 'cancel')  : undefined}
-            />
-          ))}
+          {list.map((row) =>
+            row.kind === 'h2h' ? (
+              <HeadToHeadCard
+                key={`h2h-${row.h2h.id}`}
+                h2h={row.h2h}
+                perspective={activeTab === 'outgoing' ? 'challenger' : activeTab === 'incoming' ? 'original' : 'auto'}
+                currentUserId={currentUserId}
+                opponentName={h2h.opponentNameFor(row.h2h)}
+                isActing={actingKey === `h2h:${row.h2h.id}`}
+                errorMsg={errorByKey[`h2h:${row.h2h.id}`]}
+                onAccept={activeTab === 'incoming' ? () => void handleH2hAction(row.h2h, 'accept') : undefined}
+                onDecline={activeTab === 'incoming' ? () => void handleH2hAction(row.h2h, 'decline') : undefined}
+                onCancel={activeTab === 'outgoing' ? () => void handleH2hAction(row.h2h, 'cancel') : undefined}
+              />
+            ) : (
+              <GameChallengeInboxCard
+                key={`gc-${row.gc.id}`}
+                gc={row.gc}
+                currentUserId={currentUserId}
+                opponentName={gc.opponentLabel(row.gc)}
+                isActing={actingKey === `gc:${row.gc.id}`}
+                errorMsg={errorByKey[`gc:${row.gc.id}`]}
+                onAccept={activeTab === 'incoming' ? () => void handleGcAction(row.gc, 'accept') : undefined}
+                onDecline={activeTab === 'incoming' ? () => void handleGcAction(row.gc, 'decline') : undefined}
+                onCancel={activeTab === 'outgoing' ? () => void handleGcAction(row.gc, 'cancel') : undefined}
+              />
+            ),
+          )}
         </div>
       )}
     </div>
   );
 };
 
-// ─────────────────────────────────────────────────────────────────
-//  Card
-// ─────────────────────────────────────────────────────────────────
-
 interface HeadToHeadCardProps {
   h2h: HeadToHead;
-  /** Which seat the current user is in. 'auto' lets the card decide for active/history. */
   perspective: 'original' | 'challenger' | 'auto';
   currentUserId: string | null;
   opponentName: string;
@@ -180,38 +247,37 @@ const HeadToHeadCard: React.FC<HeadToHeadCardProps> = ({
   const resolvedPerspective: 'original' | 'challenger' =
     perspective !== 'auto'
       ? perspective
-      : h2h.originalUserId === currentUserId ? 'original' : 'challenger';
+      : h2h.originalUserId === currentUserId
+        ? 'original'
+        : 'challenger';
 
   const totalEscrow = h2h.originalStake + h2h.challengerStake;
-
-  // What the current user stands to win (gross, not counting their own escrow).
-  const myStake   = resolvedPerspective === 'original' ? h2h.originalStake   : h2h.challengerStake;
-  const myProfit  = resolvedPerspective === 'original' ? h2h.challengerStake : h2h.originalStake;
-  const winsIf    = resolvedPerspective === 'original' ? 'pick wins' : 'pick loses';
+  const myStake = resolvedPerspective === 'original' ? h2h.originalStake : h2h.challengerStake;
+  const myProfit = resolvedPerspective === 'original' ? h2h.challengerStake : h2h.originalStake;
+  const winsIf = resolvedPerspective === 'original' ? 'pick wins' : 'pick loses';
 
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
-            vs. {opponentName} · {h2h.marketTitle}
+            Counter-bet · vs. {opponentName} · {h2h.marketTitle}
           </p>
           <p className="font-semibold text-slate-100 truncate">
-            <span className="text-blue-300">{h2h.originalSide}</span>
-            {' '}@ {h2h.originalOdds.toFixed(2)}
+            <span className="text-blue-300">{h2h.originalSide}</span> @ {h2h.originalOdds.toFixed(2)}
           </p>
           <p className="text-[11px] text-slate-500 mt-1 inline-flex items-center gap-1">
             <Clock3 size={10} />
             {h2h.createdAt.toLocaleString()}
           </p>
         </div>
-        <StatusBadge status={h2h.status} />
+        <H2hStatusBadge status={h2h.status} />
       </div>
 
       <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
-        <Stat label="Your stake"  value={`$${myStake.toFixed(2)}`}  tone="neutral" />
+        <Stat label="Your stake" value={`$${myStake.toFixed(2)}`} tone="neutral" />
         <Stat label={`Win if ${winsIf}`} value={`$${myProfit.toFixed(2)}`} tone="positive" />
-        <Stat label="Total pot"   value={`$${totalEscrow.toFixed(2)}`} tone="muted" />
+        <Stat label="Total pot" value={`$${totalEscrow.toFixed(2)}`} tone="muted" />
       </div>
 
       {errorMsg && (
@@ -239,7 +305,7 @@ const HeadToHeadCard: React.FC<HeadToHeadCardProps> = ({
               disabled={isActing}
               className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider text-slate-300 hover:bg-slate-800 transition-colors disabled:opacity-50"
             >
-              <XIcon size={12} /> Decline
+              <XIcon size={12} /> Deny
             </button>
           )}
           {onAccept && (
@@ -258,15 +324,130 @@ const HeadToHeadCard: React.FC<HeadToHeadCardProps> = ({
   );
 };
 
-const StatusBadge: React.FC<{ status: HeadToHeadStatus }> = ({ status }) => {
+const H2hStatusBadge: React.FC<{ status: HeadToHeadStatus }> = ({ status }) => {
   const map: Record<HeadToHeadStatus, { label: string; cls: string }> = {
-    PENDING_ACCEPT:    { label: 'Awaiting accept', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-300' },
-    ACCEPTED:          { label: 'Locked in',       cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' },
-    DECLINED:          { label: 'Declined',        cls: 'border-slate-700 bg-slate-800 text-slate-400' },
-    CANCELLED:         { label: 'Cancelled',       cls: 'border-slate-700 bg-slate-800 text-slate-400' },
-    WON_BY_ORIGINAL:   { label: 'Original won',    cls: 'border-blue-500/30 bg-blue-500/10 text-blue-300' },
-    WON_BY_CHALLENGER: { label: 'Challenger won',  cls: 'border-red-500/30 bg-red-500/10 text-red-300' },
-    PUSH:              { label: 'Push',             cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    PENDING_ACCEPT: { label: 'Awaiting accept', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-300' },
+    ACCEPTED: { label: 'Locked in', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' },
+    DECLINED: { label: 'Denied', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    CANCELLED: { label: 'Cancelled', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    WON_BY_ORIGINAL: { label: 'Original won', cls: 'border-blue-500/30 bg-blue-500/10 text-blue-300' },
+    WON_BY_CHALLENGER: { label: 'Challenger won', cls: 'border-red-500/30 bg-red-500/10 text-red-300' },
+    PUSH: { label: 'Push', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+  };
+  const { label, cls } = map[status];
+  return (
+    <span className={`shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${cls}`}>
+      {label}
+    </span>
+  );
+};
+
+interface GameChallengeInboxCardProps {
+  gc: GameChallengeDoc;
+  currentUserId: string | null;
+  opponentName: string;
+  isActing: boolean;
+  errorMsg?: string;
+  onAccept?: () => void;
+  onDecline?: () => void;
+  onCancel?: () => void;
+}
+
+const GameChallengeInboxCard: React.FC<GameChallengeInboxCardProps> = ({
+  gc,
+  currentUserId,
+  opponentName,
+  isActing,
+  errorMsg,
+  onAccept,
+  onDecline,
+  onCancel,
+}) => {
+  const youAreChallenger = currentUserId === gc.challengerUid;
+  const yourPick = youAreChallenger ? gc.challengerPickLabel : gc.opponentPickLabel;
+  const theirPick = youAreChallenger ? gc.opponentPickLabel : gc.challengerPickLabel;
+
+  return (
+    <div className="rounded-2xl border border-amber-900/40 bg-amber-950/20 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-amber-400/90">
+            Game challenge · vs. {opponentName}
+          </p>
+          <p className="font-semibold text-slate-100 line-clamp-2 mt-0.5">{gc.marketTitle}</p>
+          <p className="text-[11px] text-slate-400 mt-1">
+            You: <span className="text-emerald-300/95">{yourPick}</span>
+            {' · '}
+            Them: <span className="text-slate-300">{theirPick}</span>
+          </p>
+          <p className="text-[11px] text-slate-500 mt-1 inline-flex items-center gap-1">
+            <Clock3 size={10} />
+            {gc.createdAt.toDate().toLocaleString()}
+          </p>
+        </div>
+        <GcStatusBadge status={gc.status} />
+      </div>
+
+      {errorMsg && (
+        <div className="mt-3 flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-[11px] text-red-300">
+          <AlertCircle size={12} className="mt-0.5 shrink-0" /> {errorMsg}
+        </div>
+      )}
+
+      {(onAccept || onDecline || onCancel) && (
+        <div className="mt-3 flex items-center justify-end gap-2">
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isActing}
+              className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider text-slate-300 hover:bg-slate-800 transition-colors disabled:opacity-50"
+            >
+              <XIcon size={12} /> Cancel invite
+            </button>
+          )}
+          {onDecline && (
+            <button
+              type="button"
+              onClick={onDecline}
+              disabled={isActing}
+              className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider text-slate-300 hover:bg-slate-800 transition-colors disabled:opacity-50"
+            >
+              <XIcon size={12} /> Deny
+            </button>
+          )}
+          {onAccept && (
+            <button
+              type="button"
+              onClick={onAccept}
+              disabled={isActing}
+              className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/90 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider text-white hover:bg-emerald-500 transition-colors disabled:opacity-50"
+            >
+              <Check size={12} /> Accept
+            </button>
+          )}
+        </div>
+      )}
+
+      {gc.status === 'ACTIVE' && (
+        <p className="mt-3 text-[11px] text-slate-500">
+          Locks when the sim or scores grade — winner gets the tally on the leaderboard.
+        </p>
+      )}
+    </div>
+  );
+};
+
+const GcStatusBadge: React.FC<{ status: GameChallengeStatus }> = ({ status }) => {
+  const map: Record<GameChallengeStatus, { label: string; cls: string }> = {
+    PENDING_ACCEPT: { label: 'Awaiting accept', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-300' },
+    ACTIVE: { label: 'Live', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' },
+    DECLINED: { label: 'Denied', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    CANCELLED: { label: 'Cancelled', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    EXPIRED: { label: 'Expired', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
+    COMPLETED_CHALLENGER: { label: 'Challenger won', cls: 'border-blue-500/30 bg-blue-500/10 text-blue-300' },
+    COMPLETED_OPPONENT: { label: 'Opponent won', cls: 'border-red-500/30 bg-red-500/10 text-red-300' },
+    PUSH: { label: 'Push', cls: 'border-slate-700 bg-slate-800 text-slate-400' },
   };
   const { label, cls } = map[status];
   return (
@@ -278,9 +459,9 @@ const StatusBadge: React.FC<{ status: HeadToHeadStatus }> = ({ status }) => {
 
 const Stat: React.FC<{ label: string; value: string; tone: 'neutral' | 'positive' | 'muted' }> = ({ label, value, tone }) => {
   const valueClass = {
-    neutral:  'text-slate-100',
+    neutral: 'text-slate-100',
     positive: 'text-emerald-300',
-    muted:    'text-slate-400',
+    muted: 'text-slate-400',
   }[tone];
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-950/40 p-2">
@@ -290,35 +471,47 @@ const Stat: React.FC<{ label: string; value: string; tone: 'neutral' | 'positive
   );
 };
 
-// ─────────────────────────────────────────────────────────────────
-//  Empty-state copy
-// ─────────────────────────────────────────────────────────────────
-
 function emptyCopy(bucket: HeadToHeadBucket): string {
   switch (bucket) {
-    case 'incoming': return 'No one has challenged your bets yet.';
-    case 'outgoing': return 'No outgoing challenges.';
-    case 'active':   return 'No active head-to-heads.';
-    case 'history':  return 'No past head-to-heads.';
-  }
-}
-function emptyHint(bucket: HeadToHeadBucket): string {
-  switch (bucket) {
-    case 'incoming': return 'Place pending bets — others can fade them and they\'ll appear here.';
-    case 'outgoing': return "Use Counter on a profile or friend, or Counter-Bet on their slip, then cancel here if they haven't accepted yet.";
-    case 'active':   return 'Locked-in H2Hs settle automatically when the game ends.';
-    case 'history':  return 'Resolved, declined, and cancelled H2Hs land here.';
+    case 'incoming':
+      return 'Nothing needs your OK yet.';
+    case 'outgoing':
+      return 'No invites waiting on them.';
+    case 'active':
+      return 'No live counters or challenges.';
+    case 'history':
+      return 'No past peer matchups yet.';
   }
 }
 
-function friendlyError(code: string): string {
+function emptyHint(bucket: HeadToHeadBucket): string {
+  switch (bucket) {
+    case 'incoming':
+      return 'Send a counter or game challenge to someone.';
+    case 'outgoing':
+      return 'Wait for them to accept.';
+    case 'active':
+      return 'The game is in progress.';
+    case 'history':
+      return 'The game has ended.';
+  }
+}
+
+function friendlyH2hError(code: string): string {
   switch (code) {
-    case 'H2H_NOT_FOUND':      return 'This challenge no longer exists.';
-    case 'WRONG_USER':         return 'You can\'t take this action on this challenge.';
-    case 'WRONG_STATUS':       return 'This challenge has already been resolved.';
-    case 'EVENT_STARTED':      return 'The game already started — this challenge is locked.';
-    case 'INSUFFICIENT_FUNDS': return 'You don\'t have enough funds to accept.';
-    case 'USER_NOT_FOUND':     return 'Account not found. Try signing in again.';
-    default:                   return 'Something went wrong. Please try again.';
+    case 'H2H_NOT_FOUND':
+      return 'This challenge no longer exists.';
+    case 'WRONG_USER':
+      return "You can't take this action on this challenge.";
+    case 'WRONG_STATUS':
+      return 'This challenge has already been resolved.';
+    case 'EVENT_STARTED':
+      return 'The game already started — this challenge is locked.';
+    case 'INSUFFICIENT_FUNDS':
+      return "You don't have enough funds to accept.";
+    case 'USER_NOT_FOUND':
+      return 'Account not found. Try signing in again.';
+    default:
+      return 'Something went wrong. Please try again.';
   }
 }

--- a/views/HeadToHeadView.tsx
+++ b/views/HeadToHeadView.tsx
@@ -229,7 +229,7 @@ const HeadToHeadCard: React.FC<HeadToHeadCardProps> = ({
               disabled={isActing}
               className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider text-slate-300 hover:bg-slate-800 transition-colors disabled:opacity-50"
             >
-              <XIcon size={12} /> Withdraw
+              <XIcon size={12} /> Cancel challenge
             </button>
           )}
           {onDecline && (
@@ -305,7 +305,7 @@ function emptyCopy(bucket: HeadToHeadBucket): string {
 function emptyHint(bucket: HeadToHeadBucket): string {
   switch (bucket) {
     case 'incoming': return 'Place pending bets — others can fade them and they\'ll appear here.';
-    case 'outgoing': return 'Tap Counter-Bet on someone\'s profile to send a challenge.';
+    case 'outgoing': return "Use Counter on a profile or friend, or Counter-Bet on their slip, then cancel here if they haven't accepted yet.";
     case 'active':   return 'Locked-in H2Hs settle automatically when the game ends.';
     case 'history':  return 'Resolved, declined, and cancelled H2Hs land here.';
   }

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -9,8 +9,12 @@ import {
   Target,
   Clock3,
   Swords,
+  MessageSquare,
 } from 'lucide-react';
 import { CounterBetModal } from '../components/CounterBetModal';
+import { CounterOpponentModal } from '@/components/CounterOpponentModal';
+import { GameChallengeModal } from '@/components/GameChallengeModal';
+import { challengeBetEligibility } from '@/lib/challengeBetEligibility';
 import { proposeHeadToHead, sendFriendRequest } from '@/services/dbOps';
 import {
   getAccountProfile,
@@ -24,7 +28,7 @@ import {
   type AccountStatKey,
   type AchievementDefinition,
 } from '@/services/dbOps';
-import type { Bet } from '../models';
+import type { Bet, Market } from '../models';
 import { SettingsView } from './SettingsView';
 import { getUserStoreState } from '@/services/storeOps';
 import { findStoreAvatar } from '@/models/storeItems';
@@ -37,6 +41,10 @@ interface ProfileViewProps {
   balance: number;
   activeBetsCount: number;
   currentUserId?: string | null;
+  /** Display name for DM / game challenges (BetHub username). */
+  currentUserDisplayName?: string;
+  /** Markets list for picking a game to challenge someone on. */
+  markets?: Market[];
   themeMode: UserThemeMode;
   themeSaving: boolean;
   onThemeModeChange: (mode: UserThemeMode) => void;
@@ -48,6 +56,8 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   balance,
   activeBetsCount,
   currentUserId,
+  currentUserDisplayName,
+  markets = [],
   themeMode,
   themeSaving,
   onThemeModeChange,
@@ -96,6 +106,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   const [showSettings, setShowSettings] = useState(false);
   const [publicPreview, setPublicPreview] = useState(false);
   const [friendRequestState, setFriendRequestState] = useState<'idle' | 'sending' | 'sent'>('idle');
+  const [showCounterModal, setShowCounterModal] = useState(false);
+  const [showGameChallengeModal, setShowGameChallengeModal] = useState(false);
+  const [challengeBets, setChallengeBets] = useState<Bet[]>([]);
 
   // Counter-Bet (head-to-head) modal target.
   const [counterBetTarget, setCounterBetTarget] = useState<Bet | null>(null);
@@ -113,22 +126,16 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
     | { kind: 'enabled' };
   const fadeEligibility = (bet: Bet): FadeEligibility => {
     if (isOwnProfile) return { kind: 'hidden' };
-    const status = bet.status ?? 'PENDING';
-    if (status !== 'PENDING')      return { kind: 'disabled', reason: `This bet is already ${status.toLowerCase()}.` };
-    if (bet.betType === 'parlay')  return { kind: 'disabled', reason: 'Parlays can\'t be faded yet.' };
-    if (!bet.eventId || !bet.sportKey) {
-      return { kind: 'disabled', reason: 'This bet is missing event info — too old to auto-settle a fade.' };
-    }
-    if (bet.odds <= 1)             return { kind: 'disabled', reason: 'Invalid odds — can\'t compute a fair fade.' };
-    if (bet.eventStartsAt && bet.eventStartsAt.getTime() <= Date.now()) {
-      return { kind: 'disabled', reason: 'Game has already started — too late to fade.' };
-    }
-    return { kind: 'enabled' };
+    const r = challengeBetEligibility(bet);
+    if (r.kind === 'enabled') return { kind: 'enabled' };
+    return { kind: 'disabled', reason: r.reason };
   };
 
   useEffect(() => {
     let cancelled = false;
     setFriendRequestState('idle');
+    setShowCounterModal(false);
+    setShowGameChallengeModal(false);
 
     async function loadAccount() {
       if (!profileUserId) {
@@ -191,6 +198,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
           setUnlockedAchievementIds([]);
         }
 
+        setChallengeBets([...bets].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()));
         setRecentBets(
           [...bets]
             .sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime())
@@ -429,9 +437,29 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                           onClick={() => navigate('/friends', { state: { openChatWithUserId: profileUserId } })}
                           className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/10 px-3 py-1.5 text-xs font-semibold text-blue-200 hover:border-blue-400/60 hover:bg-blue-500/20 transition-colors"
                         >
-                          <Swords size={14} />
+                          <MessageSquare size={14} aria-hidden />
                           Message
                         </button>
+                        {currentUserId && currentUserId !== profileUserId && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => setShowCounterModal(true)}
+                              className="inline-flex items-center gap-2 rounded-lg border border-red-500/35 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-200 transition-colors hover:border-red-400/55 hover:bg-red-500/20"
+                            >
+                              <Swords size={14} aria-hidden />
+                              Counter
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setShowGameChallengeModal(true)}
+                              className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-100 transition-colors hover:border-amber-400/60 hover:bg-amber-500/20"
+                            >
+                              <Trophy size={14} aria-hidden />
+                              Challenge
+                            </button>
+                          </>
+                        )}
                         <button
                           type="button"
                           onClick={() => void handleSendFriendRequest()}
@@ -617,7 +645,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                 <section className={`${sectionShell} p-6 sm:p-8`}>
                   <div className="mb-5 flex items-center justify-between gap-3">
                     <h3 className={`${sectionLabel} flex items-center gap-2 text-slate-400`}>
-                      <Target size={14} className="text-violet-400/90" aria-hidden />
                       Featured Bets
                     </h3>
                     {showEditUi && (
@@ -722,6 +749,33 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                 </section>
               )}
         </div>
+      )}
+      {showCounterModal && profileUserId && currentUserId && currentUserId !== profileUserId && (
+        <CounterOpponentModal
+          isOpen
+          onClose={() => setShowCounterModal(false)}
+          opponentUserId={profileUserId}
+          opponentDisplayName={displayName}
+          opponentAvatarUrl={profileAvatarUrl}
+          backgroundImageUrl={coverImageUrl}
+          currentUserId={currentUserId}
+          balance={balance}
+          prefetchedBets={challengeBets}
+        />
+      )}
+      {showGameChallengeModal && profileUserId && currentUserId && currentUserId !== profileUserId && (
+        <GameChallengeModal
+          isOpen
+          onClose={() => setShowGameChallengeModal(false)}
+          markets={markets}
+          opponentUserId={profileUserId}
+          opponentDisplayName={displayName}
+          opponentAvatarUrl={profileAvatarUrl}
+          backgroundImageUrl={coverImageUrl}
+          currentUserId={currentUserId}
+          challengerDisplayName={currentUserDisplayName?.trim() || userEmail.split('@')[0] || 'Player'}
+          onSent={() => navigate('/friends', { state: { openChatWithUserId: profileUserId } })}
+        />
       )}
       {counterBetTarget && currentUserId && (
         <CounterBetModal

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Settings,
@@ -70,7 +70,10 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   // so useParams() returns an empty object. Parse the uid out of the pathname
   // ourselves so links like /profile/<uid> from the leaderboard, friends list,
   // and activity feed actually resolve to that user.
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { pathname } = location;
+  const openCounterFromNav = useRef(false);
+  const openGameChallengeFromNav = useRef(false);
   const routeUserId = (() => {
     const segments = pathname
       .replace(/^\/bethub\/?/, '')
@@ -112,6 +115,26 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   const [showCounterModal, setShowCounterModal] = useState(false);
   const [showGameChallengeModal, setShowGameChallengeModal] = useState(false);
   const [challengeBets, setChallengeBets] = useState<Bet[]>([]);
+
+  useEffect(() => {
+    const st = location.state as { openGameChallenge?: boolean; openCounter?: boolean } | null;
+    if (!st?.openGameChallenge && !st?.openCounter) return;
+    if (st.openGameChallenge) openGameChallengeFromNav.current = true;
+    if (st.openCounter) openCounterFromNav.current = true;
+    navigate(pathname, { replace: true, state: {} });
+  }, [location.state, navigate, pathname]);
+
+  useEffect(() => {
+    if (loading || isOwnProfile || !profileUserId) return;
+    if (openCounterFromNav.current) {
+      openCounterFromNav.current = false;
+      setShowCounterModal(true);
+    }
+    if (openGameChallengeFromNav.current) {
+      openGameChallengeFromNav.current = false;
+      setShowGameChallengeModal(true);
+    }
+  }, [loading, isOwnProfile, profileUserId]);
 
   // Counter-Bet (head-to-head) modal target.
   const [counterBetTarget, setCounterBetTarget] = useState<Bet | null>(null);

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -45,6 +45,8 @@ interface ProfileViewProps {
   currentUserDisplayName?: string;
   /** Markets list for picking a game to challenge someone on. */
   markets?: Market[];
+  /** Live NFL sim board (three games) for profile game challenges. */
+  nflMockChallengeMarkets?: Market[];
   themeMode: UserThemeMode;
   themeSaving: boolean;
   onThemeModeChange: (mode: UserThemeMode) => void;
@@ -58,6 +60,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   currentUserId,
   currentUserDisplayName,
   markets = [],
+  nflMockChallengeMarkets = [],
   themeMode,
   themeSaving,
   onThemeModeChange,
@@ -767,7 +770,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
         <GameChallengeModal
           isOpen
           onClose={() => setShowGameChallengeModal(false)}
-          markets={markets}
+          mockNflMarkets={nflMockChallengeMarkets}
           opponentUserId={profileUserId}
           opponentDisplayName={displayName}
           opponentAvatarUrl={profileAvatarUrl}
@@ -782,6 +785,11 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
           bet={counterBetTarget}
           ownerName={displayName}
           balance={balance}
+          counterDm={
+            profileUserId && currentUserId !== profileUserId
+              ? { messagingFromUserId: currentUserId, opponentUserId: profileUserId }
+              : undefined
+          }
           onConfirm={(originalBetId) => proposeHeadToHead(originalBetId, currentUserId)}
           onClose={() => setCounterBetTarget(null)}
         />

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -409,7 +409,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                   </div>
                   <div className="min-w-0 flex-1 text-left">
                     <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.28em] text-blue-200/80">
-                      {isOwnProfile ? 'BetHub Profile' : 'Player Profile'}
+                      {isOwnProfile ? 'BetHub Profile' : 'Profile'}
                     </p>
                     <h2 className="text-2xl font-black tracking-tight text-white drop-shadow sm:text-4xl">
                       {displayName}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,18 @@ export default defineConfig(() => {
               rewrite: (path) => path.replace(/^\/api\/sports/, '/v4/sports'),
               configure: addApiKeyProxy(oddsApiKey),
             },
+            '/api/scores': {
+              target: 'https://api.the-odds-api.com',
+              changeOrigin: true,
+              rewrite: (path) => {
+                const [pathname, query = ''] = path.split('?');
+                const m = pathname.match(/^\/api\/scores\/([^/]+)$/);
+                const sport = m?.[1] ?? '';
+                const q = query ? `?${query}` : '';
+                return `/v4/sports/${sport}/scores${q}`;
+              },
+              configure: addApiKeyProxy(oddsApiKey),
+            },
           },
     },
     plugins: [react()],


### PR DESCRIPTION
**Contributor:** aohallx  
**Base:** `main` ← **Compare:** `bugfix-parlayFix-challengeButtonFix`  

This PR bundles peer betting, mock NFL, bet slip, parlay settlement, social/DM, and leaderboard work. No secrets, credentials, or API keys are included in this description or the referenced code paths for the PR text.

---

### Summary

Large feature merge: head-to-head counters, game challenges, shared mock NFL board, redesigned slip (singles + parlays + history), profile/DM surfaces, settlement UX, and leaderboard challenge sorting—aligned with Firestore-backed flows.

---

### Highlights (expand each)

<details>
<summary><strong>1. Head-to-Head hub (counters + challenges in one place)</strong></summary>

- Renamed buckets: **Your turn**, **Their turn**, **Live**, **Past** (no silly tab icons).
- Counter-bets and game challenges merge into the same lists with realtime Firestore listeners.
- Accept / deny / cancel moves items between buckets; empty states and hints updated.

</details>

<details>
<summary><strong>2. Incoming counters & challenges actually show up</strong></summary>

- Pending items appear under **Your turn** / **Their turn** as soon as they exist in the DB.
- Manual **Refresh** still re-fetches counters for edge cases; challenges stay live via snapshot.

</details>

<details>
<summary><strong>3. Sidebar notification dot (needs user's OK)</strong></summary>

- Amber dot on the Head-to-Head nav icon when you have an unanswered **counter** (you own the original bet) or **game challenge** (you’re the invitee).
- Clears when the invite is accepted or declined—not merely by opening the page.

</details>

<details>
<summary><strong>4. Full-screen outcome modals (win, loss, push)</strong></summary>

- Win celebrations extended to **loss** and **push** for both counter-bets and game challenges (distinct visuals: gold vs rose vs slate).
- Deduped per user via localStorage so old settlements don’t spam on reload; migrates legacy “seen win” keys.

</details>

<details>
<summary><strong>5. Optional banter after a peer win</strong></summary>

- After H2H or game-challenge **wins**, optional victory-lap text can be sent into the DM thread on dismiss.
- Loss/push modals close without DM side-effects.

</details>

<details>
<summary><strong>6. DM settlement cards & threads</strong></summary>

- Rich cards in chat for counter and challenge settlements (win/loss/push styling, e.g. gold/red accents).
- Users can see outcome context and continue the social flow from the thread.

</details>

<details>
<summary><strong>7. Global mock NFL game board</strong></summary>

- Shared mock games drive lines for challenges; board seeding/listeners keep the sim state coherent across clients.
- Challenges scoped to the mock NFL experience where required by product rules.

</details>

<details>
<summary><strong>8. Pick a mock game → see spread, total, moneyline</strong></summary>

- Selecting one of the rotating mock games surfaces line detail (spread / total / ML) before committing to a challenge.
- Only actionable while games are still **upcoming** (not after kick-style locks in the flow).

</details>

<details>
<summary><strong>9. Counter-bet rules (whose bet, when)</strong></summary>

- Counter flow targets another user’s **active / eligible** slip so you can’t fade dead tickets incorrectly.
- Profile / opponent flows wired to propose head-to-head against the right underlying bet.

</details>

<details>
<summary><strong>10. Profile & history show peer context</strong></summary>

- Public-facing profile surfaces challenge/counter context where designed.
- History can filter or emphasize bets linked to counters/challenges and show opponent peer info when applicable.

</details>

<details>
<summary><strong>11. Bet slip redesign (singles + parlays)</strong></summary>

- Clearer layout for singles vs parlays, calmer hierarchy, and a simpler mental model for stacked legs.
- Per-leg affordances so each single can be bet independently where the product supports it.

</details>

<details>
<summary><strong>12. Bet slip → History shortcut</strong></summary>

- Path from the slip to **History** so users can review tickets without hunting the nav.

</details>

<details>
<summary><strong>13. Bet cell accent: blue instead of purple</strong></summary>

- Visual tweak for ticket/market cells so primary actions read more “sportsbook blue” than generic violet.

</details>

<details>
<summary><strong>14. Parlay math, mock grading, and DB sync</strong></summary>

- Parlay rollup and settlement paths aligned with mock NFL and stored bet docs so wins/losses/pushes persist correctly.
- Fixes around clearing parlay state and strict parlay rules where they touched the same surfaces.

</details>

<details>
<summary><strong>15. Social / DM: search preview for non-friends</strong></summary>

- When searching for someone to message before you’re friends, preview/search affordances show under the friends/messages UX so you can find the right person safely.

</details>

<details>
<summary><strong>16. Peer activity feed merge</strong></summary>

- Community and peer feeds composed for the dashboard/social experience so challenge/counter activity surfaces next to broader bet activity (within the limits of the implementation).

</details>

<details>
<summary><strong>17. Leaderboard: challenge-aware sorting</strong></summary>

- Leaderboard honors **challenge wins** (and related columns) so repeated game-challenge success can rank users fairly alongside other stats.

</details>

<details>
<summary><strong>18. Settlement detail modals</strong></summary>

- Peer settle detail views for drilling into counter/challenge resolution without leaving the app chrome.

</details>

<details>
<summary><strong>19. Game challenge creation & DM invites</strong></summary>

- Modal flow to pick sides on two-option markets, post structured invites into DM threads, accept/decline/cancel semantics, and expiry handling where the sim ends before accept.

</details>

<details>
<summary><strong>20. Head-to-head Firestore & service layer</strong></summary>

- `headToHead` and `gameChallenges` collections: propose, accept, decline, cancel, settle, and idempotent settlement hooks tied to underlying bet results where applicable.
- `mapHeadToHead` / `mapGameChallengeDoc` helpers for consistent client parsing—no private keys in repo; use env-based config only where already established.

</details>

<details>
<summary><strong>21. Misc polish & “and more”</strong></summary>

- Copy updates (e.g. Counter opponent help text), theme/header cohesion, and small UX guardrails discovered while wiring mock + peer flows end-to-end.

</details>

---

### Test / review checklist (manual)

- [ ] Place single + parlay on mock/API paths; confirm slip + history.
- [ ] Send counter + challenge; accept/decline/cancel; confirm H2H tabs + nav dot.
- [ ] Let a mock game finalize; confirm settlement DM + full-screen outcome once per result.
- [ ] Leaderboard challenge column / sort behaves as expected.

---

### Notes for maintainers

- Prefer **squash** or a clean merge strategy per repo conventions; commit history on the branch is incremental feature work.
- If anything in the checklist fails, narrow to the failing subsystem (slip vs H2H vs DM vs leaderboard) before reverting broad chunks.
<img width="1563" height="873" alt="Screenshot 2026-05-10 234605" src="https://github.com/user-attachments/assets/c64ab45b-5172-4c64-a339-c214cbececb9" />
<img width="1196" height="286" alt="Screenshot 2026-05-11 015221" src="https://github.com/user-attachments/assets/95f055a5-726a-449c-beb8-f5c245084e27" />
<img width="1919" height="877" alt="Screenshot 2026-05-11 015024" src="https://github.com/user-attachments/assets/30f9a72a-b8cf-4ff6-b5c4-efd70d9c6884" />
<img width="1919" height="891" alt="Screenshot 2026-05-11 015008" src="https://github.com/user-attachments/assets/67c75cd9-3cbe-45c7-86f5-4ca05d6c404d" />
<img width="1919" height="858" alt="Screenshot 2026-05-11 015002" src="https://github.com/user-attachments/assets/564faed4-06f1-4583-98cf-6fad665bd6ec" />
<img width="1919" height="888" alt="Screenshot 2026-05-11 014956" src="https://github.com/user-attachments/assets/94a32995-7959-4d23-ab0b-718f658ba2e1" />
<img width="1811" height="644" alt="Screenshot 2026-05-11 014950" src="https://github.com/user-attachments/assets/3b466210-2b70-4019-a7f1-d808da9cdbae" />
<img width="1239" height="865" alt="Screenshot 2026-05-11 014740" src="https://github.com/user-attachments/assets/f8000e87-e29b-42da-9dd4-2fb029bd6596" />
<img width="1919" height="943" alt="Screenshot 2026-05-11 014733" src="https://github.com/user-attachments/assets/7c4e27a8-3995-4ba7-924b-77c6ddb5f4b0" />
<img width="330" height="415" alt="Screenshot 2026-05-11 014714" src="https://github.com/user-attachments/assets/71b94328-c670-4b07-bfe4-332f9976df54" />
<img width="335" height="689" alt="Screenshot 2026-05-11 014637" src="https://github.com/user-attachments/assets/10973819-7086-4a8a-be5b-19b904c1eae0" />
<img width="342" height="533" alt="Screenshot 2026-05-11 014632" src="https://github.com/user-attachments/assets/b8fc7bc3-9c26-4532-9d8c-a1ddf82d23df" />
<img width="1238" height="560" alt="Screenshot 2026-05-11 014615" src="https://github.com/user-attachments/assets/009089db-1809-4380-ba27-ba95716ca8ec" />



